### PR TITLE
fix(signals): unregister all effects with 'cleanAll' method

### DIFF
--- a/src/utils/signals/index.test.ts
+++ b/src/utils/signals/index.test.ts
@@ -173,4 +173,26 @@ describe("signals", () => {
 
     expect(triple.value).toBe(6);
   });
+
+  it('should remove all effects with "cleanAll" method', () => {
+    const { state, effect, cleanAll } = signals();
+    const count = state<number>(0);
+    const mockEffect = mock<(count?: number) => void>(() => {});
+
+    effect(() => {
+      mockEffect(count.value);
+    });
+
+    expect(mockEffect).toHaveBeenCalledTimes(1);
+
+    count.value = 1;
+
+    expect(mockEffect).toHaveBeenCalledTimes(2);
+
+    cleanAll();
+
+    count.value = 2;
+
+    expect(mockEffect).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
Related to https://github.com/aralroca/brisa/issues/9

When the web-components were unmounted, the effects registered in the component were not being cleaned. Now with this change if it is done well.