### PR TITLE
feat: support ffi in same build

### DIFF
--- a/cli.cjs
+++ b/cli.cjs
@@ -1,13 +1,17 @@
 #!/usr/bin/env bun
 const { spawnSync } = require("child_process");
+const path = require("node:path");
+
+const BRISA_BUILD_FOLDER =
+  process.env.BRISA_BUILD_FOLDER || path.join(process.cwd(), "build");
 
 const prodOptions = {
   stdio: "inherit",
-  env: { ...process.env, NODE_ENV: "production" },
+  env: { ...process.env, NODE_ENV: "production", BRISA_BUILD_FOLDER },
 };
 const devOptions = {
   stdio: "inherit",
-  env: { ...process.env, NODE_ENV: "development" },
+  env: { ...process.env, NODE_ENV: "development", BRISA_BUILD_FOLDER },
 };
 
 let BUN_EXEC;

--- a/docs/02-building-your-application/06-configuring/02-environment-variables.md
+++ b/docs/02-building-your-application/06-configuring/02-environment-variables.md
@@ -195,6 +195,10 @@ BAR=hello\$FOO
 process.env.BAR; // => "hello$FOO"
 ```
 
+### Brisa environment variables
+
+- `BRISA_BUILD_FOLDER` - You can **define** it to change the **build folder** and/or **use** it in your code to load files compiled for another process, see an example [here](/docs/building-your-application/configuring/zig-rust-c-files).
+
 ### `dotenv`
 
 Generally speaking, you won't need `dotenv` or `dotenv-expand` anymore, because Bun reads `.env` files automatically.

--- a/docs/02-building-your-application/06-configuring/04-zig-rust-c-files.md
+++ b/docs/02-building-your-application/06-configuring/04-zig-rust-c-files.md
@@ -1,0 +1,120 @@
+---
+title: Use C ABI files (zig, rust, c/c++, c#, nim, kotlin...)
+description: Learn how to incorporate files from C ABI languages into your server files.
+---
+
+If you need to utilize files from different C ABI languages (Zig, Rust, C/C++, C#, Nim, Kotlin, etc.), you can achieve this as follows:
+
+## Create Your Zig, Rust, or Other File:
+
+Zig:
+
+```zig filename="src/utils/add.zig"
+// add.zig
+pub export fn add(a: i32, b: i32) i32 {
+  return a + b;
+}
+```
+
+or with Rust:
+
+```rs filename="src/utils/add.rs"
+// add.rs
+#[no_mangle]
+pub extern "C" fn add(a: isize, b: isize) -> isize {
+    a + b
+}
+```
+
+## Compile Your Files
+
+You need to compile it before using it in your Brisa app.
+
+Zig:
+
+```sh
+zig build-lib add.zig -dynamic -OReleaseFast
+```
+
+or with Rust:
+
+```sh
+rustc --crate-type cdylib add.rs
+```
+
+Then, we need to move the generated files inside the `build` folder.
+
+We recommend to use the `predev` and `prebuild` script to your `package.json` to compile and move them.
+
+Instead of:
+
+```json
+{
+  "scripts": {
+    "dev": "brisa dev",
+    "build": "brisa build",
+    "start": "brisa start"
+  }
+}
+```
+
+Add these scripts:
+
+```json
+{
+  "scripts": {
+    "predev": "bun run build-ffi",
+    "dev": "brisa dev",
+    "prebuild": "bun run build-ffi",
+    "build": "brisa build",
+    "start": "brisa start",
+    "build-ffi": "zig build-lib src/zig/add.zig -dynamic -OReleaseFast"
+  }
+}
+```
+
+> [!IMPORTANT]
+>
+> During the build process, Brisa automatically moves all generated files starting with `lib*` from the root to the build folder in both development (`predev`) and production (`prebuild`).
+
+## Create a JS/TS Bridge
+
+Develop a JavaScript/TypeScript file to bridge to the compiled file.
+
+```ts filename="src/utils/add.ts"
+// src/utils/add.ts
+import { dlopen, FFIType, suffix } from "bun:ffi";
+import path from "node:path";
+
+// `suffix` is either "dylib", "so", or "dll" depending on the platform
+// you don't have to use "suffix", it's just there for convenience
+const lib = dlopen(path.join(Bun.env.BRISA_BUILD_FOLDER, `libadd.${suffix}`), {
+  add: {
+    args: [FFIType.i32, FFIType.i32],
+    returns: FFIType.i32,
+  },
+});
+
+export default lib.symbols.add;
+```
+
+Ensure correct typing for the `args` and the `return`.
+
+Access the environment variable `BRISA_BUILD_FOLDER` via `process.env.BRISA_BUILD_FOLDER` or `Bun.env.BRISA_BUILD_FOLDER`. This represents the path to the build folder, where the `lib*` files are located.
+
+## Consume it in Your Server Code
+
+Now, you can use it in any server file: components, layout, middleware, API, response headers, etc.
+
+```tsx filename="src/pages/index.tsx"
+// src/pages/index.tsx
+import add from "@/utils/add";
+
+export default function HomePage() {
+  return <div>5+5 is {add(5, 5)}</div>;
+}
+```
+
+> [!NOTE]
+>
+> For more details, such as dealing with pointers, refer to [Bun's FFI documentation](https://bun.sh/docs/api/ffi).

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs";
+import path from "node:path";
 import compileAll from "@/utils/compile-all";
 import getConstants from "@/constants";
 
-const { IS_PRODUCTION, LOG_PREFIX, BUILD_DIR } = getConstants();
+const { IS_PRODUCTION, LOG_PREFIX, BUILD_DIR, ROOT_DIR } = getConstants();
 
 console.log(
   LOG_PREFIX.WAIT,
@@ -22,6 +23,18 @@ const end = Bun.nanoseconds();
 const ms = ((end - start) / 1e6).toFixed(2);
 
 if (!success) process.exit(1);
+
+// Move all lib* root files to build dir
+// useful for FFI: https://brisa.build/docs/building-your-application/configuring/zig-rust-c-files
+const rootFiles = fs.readdirSync(ROOT_DIR, { withFileTypes: true });
+
+for (const file of rootFiles) {
+  if (!file.name.startsWith("lib") || !file.isFile()) continue;
+  fs.renameSync(
+    path.join(ROOT_DIR, file.name),
+    path.join(BUILD_DIR, file.name),
+  );
+}
 
 if (IS_PRODUCTION) console.info(LOG_PREFIX.INFO, `✨  Done in ${ms}ms.`);
 else console.info(LOG_PREFIX.INFO, `compiled successfully in ${ms}ms.`);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@ import importFileIfExists from "./utils/import-file-if-exists";
 
 const rootDir = getRootDir();
 const srcDir = path.join(rootDir, "src");
-const buildDir = path.join(rootDir, "build");
+const buildDir = process.env.BRISA_BUILD_FOLDER ?? path.join(rootDir, "build");
 const PAGE_404 = "/_404";
 const PAGE_500 = "/_500";
 const I18N_CONFIG = (await importFileIfExists("i18n", buildDir))

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,6 +7,23 @@ import { IntrinsicCustomElements } from "@/../build/_brisa/types";
 import { BunPlugin, MatchedRoute, ServerWebSocket, TLSOptions } from "bun";
 import * as CSS from "csstype";
 
+declare module "bun" {
+  interface Env {
+    /**
+     * Description:
+     *
+     * The `BRISA_BUILD_FOLDER` is the path to the build folder.
+     *
+     * Useful to compile C ABI libraries inside the build folder.
+     *
+     * Docs:
+     *
+     * - [How to use `BRISA_BUILD_FOLDER`](https://brisa.build/docs/building-your-application/configuring/zig-rust-c-files#create-a-jsts-bridge)
+     */
+    BRISA_BUILD_FOLDER: string;
+  }
+}
+
 /**
  * Description:
  *

--- a/src/utils/compile-files/index.test.ts
+++ b/src/utils/compile-files/index.test.ts
@@ -142,20 +142,20 @@ describe("utils", () => {
     ${info}
     ${info}Route                               | JS server | JS client (gz)  
     ${info}-------------------------------------------------------------------
-    ${info}λ /pages/_404.js                    | 421 B     | ${green("3 kB")} 
-    ${info}λ /pages/_500.js                    | 427 B     | ${green("3 kB")} 
-    ${info}λ /pages/page-with-web-component.js | 360 B     | ${green("3 kB")} 
-    ${info}λ /pages/somepage.js                | 341 B     | ${green("0 B")} 
-    ${info}λ /pages/somepage-with-context.js   | 327 B     | ${green("0 B")} 
-    ${info}λ /pages/index.js                   | 267 B     | ${green("186 B")}  
-    ${info}λ /pages/user/[username].js         | 175 B     | ${green("0 B")}
-    ${info}ƒ /middleware.js                    | 412 B     |
-    ${info}λ /api/example.js                   | 275 B     |
-    ${info}Δ /layout.js                        | 342 B     |
-    ${info}Ω /i18n.js                          | 154 B     |
-    ${info}Ψ /websocket.js                     | 199 B     |
-    ${info}Φ /chunk-${anotherChunkHash}.js     | 2 kB      |
-    ${info}Φ /chunk-${chunkHash}.js            | 106 B     |
+    ${info}λ /pages/_404.js                    | 429 B     | ${green("3 kB")} 
+    ${info}λ /pages/_500.js                    | 435 B     | ${green("3 kB")} 
+    ${info}λ /pages/page-with-web-component.js | 368 B     | ${green("3 kB")} 
+    ${info}λ /pages/somepage.js                | 349 B     | ${green("0 B")} 
+    ${info}λ /pages/somepage-with-context.js   | 335 B     | ${green("0 B")} 
+    ${info}λ /pages/index.js                   | 275 B     | ${green("186 B")}  
+    ${info}λ /pages/user/[username].js         | 183 B     | ${green("0 B")}
+    ${info}ƒ /middleware.js                    | 420 B     |
+    ${info}λ /api/example.js                   | 283 B     |
+    ${info}Δ /layout.js                        | 350 B     |
+    ${info}Ω /i18n.js                          | 162 B     |
+    ${info}Ψ /websocket.js                     | 207 B     |
+    ${info}Φ /chunk-${chunkHash}.js            | 2 kB      |
+    ${info}Φ /chunk-${anotherChunkHash}.js     | 66 B      |
     ${info}
     ${info}λ Server entry-points
     ${info}Δ Layout

--- a/src/utils/compile-files/index.ts
+++ b/src/utils/compile-files/index.ts
@@ -37,6 +37,8 @@ export default async function compileFiles() {
     outdir: BUILD_DIR,
     sourcemap: IS_PRODUCTION ? undefined : "inline",
     root: SRC_DIR,
+    // Necessary to use bun:ffi and bun API in server files
+    target: "bun",
     minify: IS_PRODUCTION,
     splitting: true,
     plugins: [


### PR DESCRIPTION
Fixes https://github.com/aralroca/brisa/issues/52

You can now run other language files (C ABI) from any server js/ts/jsx/tsx file 💥

- C
- C++
- Rust
- Zig
- C# 
- F# (@amatiasq  maybe you are interested)
- Nim
- Kotlin/Native
- Objective-C
- D
- Fortran
- Go
- Swift

Example executing zig inside a page:

<img width="997" alt="Screenshot 2024-01-13 at 16 53 33" src="https://github.com/aralroca/brisa/assets/13313058/f943e5d7-eb9f-41a7-8b46-59f9780a1be9">

To be possible:

- It is supported to add files inside the build itself to put the compiled files there. To do this we support generating any `lib*` file that is in the root.
- Have access to the environment variable in the build folder.
-  Using the [FFI Bun API](https://bun.sh/docs/api/ffi)

For more details read the documentation

## Docs:

--------

If you need to utilize files from different C ABI languages (Zig, Rust, C/C++, C#, Nim, Kotlin, etc.), you can achieve this as follows:

## Create Your Zig, Rust, or Other File:

Zig:

```zig filename="src/utils/add.zig"
// add.zig
pub export fn add(a: i32, b: i32) i32 {
  return a + b;
}
```

or with Rust:

```rs filename="src/utils/add.rs"
// add.rs
#[no_mangle]
pub extern "C" fn add(a: isize, b: isize) -> isize {
    a + b
}
```

## Compile Your Files

You need to compile it before using it in your Brisa app.

Zig:

```sh
zig build-lib add.zig -dynamic -OReleaseFast
```

or with Rust:

```sh
rustc --crate-type cdylib add.rs
```

Then, we need to move the generated files inside the `build` folder.

We recommend to use the `predev` and `prebuild` script to your `package.json` to compile and move them.

Instead of:

```json
{
  "scripts": {
    "dev": "brisa dev",
    "build": "brisa build",
    "start": "brisa start"
  }
}
```

Add these scripts:

```json
{
  "scripts": {
    "predev": "bun run build-ffi",
    "dev": "brisa dev",
    "prebuild": "bun run build-ffi",
    "build": "brisa build",
    "start": "brisa start",
    "build-ffi": "zig build-lib src/zig/add.zig -dynamic -OReleaseFast"
  }
}
```

> [!IMPORTANT]
>
> During the build process, Brisa automatically moves all generated files starting with `lib*` from the root to the build folder in both development (`predev`) and production (`prebuild`).

## Create a JS/TS Bridge

Develop a JavaScript/TypeScript file to bridge to the compiled file.

```ts filename="src/utils/add.ts"
// src/utils/add.ts
import { dlopen, FFIType, suffix } from "bun:ffi";
import path from "node:path";

// `suffix` is either "dylib", "so", or "dll" depending on the platform
// you don't have to use "suffix", it's just there for convenience
const lib = dlopen(path.join(Bun.env.BRISA_BUILD_FOLDER, `libadd.${suffix}`), {
  add: {
    args: [FFIType.i32, FFIType.i32],
    returns: FFIType.i32,
  },
});

export default lib.symbols.add;
```

Ensure correct typing for the `args` and the `return`.

Access the environment variable `BRISA_BUILD_FOLDER` via `process.env.BRISA_BUILD_FOLDER` or `Bun.env.BRISA_BUILD_FOLDER`. This represents the path to the build folder, where the `lib*` files are located.

## Consume it in Your Server Code

Now, you can use it in any server file: components, layout, middleware, API, response headers, etc.

```tsx filename="src/pages/index.tsx"
// src/pages/index.tsx
import add from "@/utils/add";

export default function HomePage() {
  return <div>5+5 is {add(5, 5)}</div>;
}
```

> [!NOTE]
>
> For more details, such as dealing with pointers, refer to [Bun's FFI documentation](https://bun.sh/docs/api/ffi).
