### PR TITLE
feat: add support of async generator server components

### DIFF
--- a/src/utils/render-to-readable-stream/index.test.tsx
+++ b/src/utils/render-to-readable-stream/index.test.tsx
@@ -2416,5 +2416,22 @@ describe("utils", () => {
         ),
       );
     });
+
+    it("should render a server component with async generator", async () => {
+      async function* List() {
+        yield <h2>Count: 0</h2>;
+        yield <h2>Count: 1</h2>;
+        yield <h2>Count: 2</h2>;
+        yield <h2>Count: 3</h2>;
+      }
+
+      const stream = renderToReadableStream(<List />, testOptions);
+
+      const result = await Bun.readableStreamToText(stream);
+
+      expect(result).toBe(
+        "<h2>Count: 0</h2><h2>Count: 1</h2><h2>Count: 2</h2><h2>Count: 3</h2>",
+      );
+    });
   });
 });

--- a/src/utils/render-to-readable-stream/index.ts
+++ b/src/utils/render-to-readable-stream/index.ts
@@ -383,6 +383,20 @@ async function enqueueComponent(
     request,
   )) as JSX.Element;
 
+  // Async generator list
+  if (typeof componentValue.next === "function") {
+    for await (let val of componentValue) {
+      await enqueueChildren(
+        val,
+        request,
+        controller,
+        suspenseId,
+        isSlottedPosition,
+      );
+    }
+    return;
+  }
+
   if (ALLOWED_PRIMARIES.has(typeof componentValue)) {
     return controller.enqueue(
       Bun.escapeHTML(componentValue.toString()),


### PR DESCRIPTION
Fixes https://github.com/aralroca/brisa/issues/95

now is possible to do this:

```tsx
async function* List() {
  yield <li>{await foo()}</li>;
  yield <li>{await bar()}</li>;
  yield <li>{await baz()}</li>;
}
```

This can be used as a server component:

```tsx
<List />
```

And the HTML is resolved via streaming.
