### PR TITLE
feat: allow transitions in suspense phase

### DIFF
--- a/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
@@ -779,6 +779,30 @@ describe("utils", () => {
       );
     });
 
+    it("should work an async generator component with css", async () => {
+      const Component = async function* ({}, { css }: RequestContext) {
+        yield <div class="red">Hello</div>;
+
+        css`
+          .red {
+            color: red;
+          }
+        `;
+
+        yield <div class="red">Foo</div>;
+      };
+
+      const stream = renderToReadableStream(<Component />, testOptions);
+      const result = await Bun.readableStreamToText(stream);
+      expect(result).toBe(
+        toInline(`
+          <div class="red">Hello</div>
+          <style>.red {color: red;}</style>
+          <div class="red">Foo</div>
+        `),
+      );
+    });
+
     it("should render the suspense component before if the async component support it", async () => {
       const Component = async () => {
         await Promise.resolve();

--- a/packages/brisa/src/utils/render-to-readable-stream/index.ts
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.ts
@@ -389,18 +389,13 @@ async function enqueueComponent(
     request,
   )) as JSX.Element;
 
-  // Inject CSS
-  if ((request as any)._style) {
-    controller.enqueue(
-      `<style>${toInline((request as any)._style)}</style>`,
-      suspenseId,
-    );
-    (request as any)._style = "";
-  }
+  injectCSS(controller, request, suspenseId);
 
   // Async generator list
   if (typeof componentValue.next === "function") {
     for await (let val of componentValue) {
+      injectCSS(controller, request, suspenseId);
+
       await enqueueChildren(
         val,
         request,
@@ -530,4 +525,18 @@ async function isInPathList(pathname: string, request: RequestContext) {
   const route = (request.route?.filePath ?? "").replace(BUILD_DIR, "");
 
   return new Set(listText.split("\n")).has(route);
+}
+
+function injectCSS(
+  controller: Controller,
+  request: RequestContext,
+  suspenseId?: number,
+) {
+  if ((request as any)._style) {
+    controller.enqueue(
+      `<style>${toInline((request as any)._style)}</style>`,
+      suspenseId,
+    );
+    (request as any)._style = "";
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/140

It is not directly implemented through the suspense, but documented as it is possible to do it with async generators (server components) or store signals (web components).

I have fixed in this PR to work well the css injection in the async generators to inject it in the chunk that you want.

I think the important thing is that it can be possible to do. If we see that it is a very popular feature, we will try to make it more integrated to the suspense. 

### Transitions between suspense-content

There is an important difference between the web and server components when it comes to making transitions between the suspense phase and the real content.

The suspense phase **by default does not support animations** as it is replaced by the real content, so if you need to implement animations during these phases you can do it with two different strategies.

#### First strategy: Using store signals (Web Components)

The first strategy is to continue using the suspense offered by Brisa but use the store to communicate between the two phases.

```tsx
import type { WebContext } from "brisa";

export default async function WebComponent({}, { store }: WebContext) {
  // Wait the delay (fetch, whatever)
  const data = await fetch(/* */).then((r) => r.json());

  // Start the animation to replace the content
  await transitionOnSuspense(store, 200);

  return <div class="start">{data.content}</div>;
}

WebComponent.suspense = ({}, { store }: WebContext) => {
  return (
    <div class={store.get("content-ready") ? "exit" : ""}>Loading ....</div>
  );
};

async function transitionOnSuspense(store: WebContext["store"], duration) {
  store.set("content-ready", true);
  // Wait for the suspense transition to finish
  await new Promise((resolve) => setTimeout(resolve, duration));
}
```

Example of css:

```css
@keyframes start {
  from {
    opacity: 0;
  }
  to {
    opacity: 1;
  }
}

@keyframes exit {
  from {
    opacity: 1;
  }
  to {
    opacity: 0;
  }
}

.exit {
  animation: exit 200ms;
}
.start {
  animation: start 200ms;
}
```

> [!WARNING]
>
> Only works in **Web Components**.

#### Second strategy: Using async generators (Server Components)

The second strategy is instead of using the suspense that Brisa offers, to use the async generator together with the [`css`](/building-your-application/data-fetching/request-context#css) helper to inject styles after the suspense phase to hide them with an animation.

```tsx
import type { RequestContext } from "brisa";

async function* ServerComponent({}, { css }: RequestContext) {
  yield <div class="suspense">Loading ....</div>;

  // Wait the delay (fetch, whatever)
  const data = await fetch(/* */).then((r) => r.json());

  // Start the animation to replace the content
  css`
    @keyframes slideaway {
      from {
        display: block;
      }
      to {
        transform: translateY(40px);
        opacity: 0;
      }
    }

    .suspense {
      animation: slideaway 200ms;
      display: none;
    }

    @keyframes slidein {
      from {
        transform: translateY(40px);
        opacity: 1;
      }
      to {
        display: block;
      }
    }

    .content {
      animation: slidein 200ms;
    }
  `;

  // Yield the real content
  yield <div class="content">{data.content}</div>;
}
```

> [!WARNING]
>
> Only works in **Server Components**.
