### PR TITLE
fix(build): optimize signals register inside an async effect 

### DIFF
--- a/packages/brisa/src/utils/client-build-plugin/optimize-effects/index.test.ts
+++ b/packages/brisa/src/utils/client-build-plugin/optimize-effects/index.test.ts
@@ -657,7 +657,7 @@ describe("utils", () => {
         expect(output).toEqual(expected);
       });
 
-      it('should await the effect if it returns a promise', () => {
+      it("should await the effect if it returns a promise", () => {
         const input = `
           export default function Component({ propName }, { effect }) {
             effect(async () => {
@@ -685,7 +685,7 @@ describe("utils", () => {
         expect(output).toEqual(expected);
       });
 
-      it('should await the effect if it returns a promise from an arrow function component', () => {
+      it("should await the effect if it returns a promise from an arrow function component", () => {
         const input = `
           export default ({ propName }, { effect }) => {
             effect(async () => {
@@ -713,7 +713,7 @@ describe("utils", () => {
         expect(output).toEqual(expected);
       });
 
-      it('should await all effect and subeffects only when one of them returns a promise', () => {
+      it("should await all effect and subeffects only when one of them returns a promise", () => {
         const input = `
           export default function Component({ propName }, { effect }) {
             effect(() => {

--- a/packages/brisa/src/utils/client-build-plugin/optimize-effects/index.ts
+++ b/packages/brisa/src/utils/client-build-plugin/optimize-effects/index.ts
@@ -28,13 +28,13 @@ const EFFECT_EXECUTION_TYPES = new Set([
  * 1. Register each sub-effect of each effect function with the 'r' function. These way each time
  *    an effect is called, all its sub-effects are cleaned up and re-registered.
  * 2. Pass the effect id to the cleanup function so it can be cleaned up individually.
- * 3. If it detects an async effect it adds the await to make each effect isolated without any 
- *    conflict when registering signals between them or with the render. So: 
- * 
- *    'effect(async () => {})' -> translates to -> 'await effect(async () => {})' 
- * 
- *    In this way, if the "get" of a signal is done just after the effect, the registration of 
- *    signals of the effect will be finished, otherwise it will detect it as if this signal 
+ * 3. If it detects an async effect it adds the await to make each effect isolated without any
+ *    conflict when registering signals between them or with the render. So:
+ *
+ *    'effect(async () => {})' -> translates to -> 'await effect(async () => {})'
+ *
+ *    In this way, if the "get" of a signal is done just after the effect, the registration of
+ *    signals of the effect will be finished, otherwise it will detect it as if this signal
  *    is part of the effect when it is not.
  *
  * @param {ESTree.FunctionDeclaration} componentBranch - The component branch to optimize.
@@ -223,7 +223,7 @@ export default function optimizeEffects(
             {
               ...eff.arguments[0],
               async: true,
-            }
+            },
           ],
         },
       };
@@ -298,7 +298,11 @@ function propagateEffectDeps(node: EffectNode, parent: EffectNode) {
  * @example
  * const wrappedEffect = wrapEffectWithDependencies(effect, parent);
  */
-function wrapEffectWithDependencies(effect: EffectNode, parent: EffectNode, async = false) {
+function wrapEffectWithDependencies(
+  effect: EffectNode,
+  parent: EffectNode,
+  async = false,
+) {
   const deps = parent.effectDeps ?? [];
   let newEffectNode: EffectNode = effect;
 


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/163

Issue details: 

In this example:

```tsx
export default ({ foo }, { state, effect }) => {
  const bar = state<any>()

 effect(async () => {
    if (foo === 'bar') {
      bar.value = await Promise.resolve({ someField: 'someValue' })
    } else {
      bar.value = null
    }
  })

  return bar.value && <div>{bar.value.someField}</div>;
};
```

This is causing an infinite loop of registers because when being async the following line of the effect is interpreted as being inside the effect and when being a "get" of the signal then it is like that this signal is registered in the effect, and inside the effect this signal is changed and therefore as it has this register, the effect is executed again, it is modified again and so on infinitely.

As a workaround, you can put an await and it solves it:

```tsx
export default async ({ foo }, { state, effect }) => {
  const bar = state<any>()

 // add await to avoid next line (return bar.value && <div>{bar.value.someField}</div>) 
 // to be executed during the effect register
  await effect(async () => {
    if (foo === 'bar') {
      bar.value = await Promise.resolve({ someField: 'someValue' })
    } else {
      bar.value = null
    }
  })

  return bar.value && <div>{bar.value.someField}</div>;
};
```

 However, since in build-time we have the optimization of the effects, this can be solved so that it is not necessary to use the workaround, because it would be that the developers know the framework internals instead of using it in a natural way.

So, this code should be valid now:

```tsx
export default ({ foo }, { state, effect }) => {
  const bar = state<any>()

 effect(async () => {
    if (foo === 'bar') {
      bar.value = await Promise.resolve({ someField: 'someValue' })
    } else {
      bar.value = null
    }
  })

  return bar.value && <div>{bar.value.someField}</div>;
};
```
