### PR TITLE
feat: navigate keeping the state of web components

### DIFF
--- a/packages/brisa/src/__fixtures__/pages/somepage.tsx
+++ b/packages/brisa/src/__fixtures__/pages/somepage.tsx
@@ -6,6 +6,8 @@ export default async function SomePage() {
   return (
     <context-provider serverOnly context={context} value="bar">
       <h1>Some page</h1>
+      {/* @ts-ignore */}
+      <with-link />
     </context-provider>
   );
 }

--- a/packages/brisa/src/__fixtures__/web-components/with-link.tsx
+++ b/packages/brisa/src/__fixtures__/web-components/with-link.tsx
@@ -1,0 +1,3 @@
+export default function WithLink() {
+  return <a href="/somepage">Some page</a>;
+}

--- a/packages/brisa/src/utils/analyze-server-ast/index.test.ts
+++ b/packages/brisa/src/utils/analyze-server-ast/index.test.ts
@@ -202,7 +202,7 @@ describe("utils", () => {
       expect(res.webComponents).toEqual({});
       expect(res.useActions).toBeFalse();
       expect(res.useHyperlink).toBeFalse();
-    })
+    });
 
     it("should detect hyperlink if there are a lot of links and one of them is relative path", () => {
       const ast = parseCodeToAST(`
@@ -226,6 +226,6 @@ describe("utils", () => {
       expect(res.webComponents).toEqual({});
       expect(res.useActions).toBeFalse();
       expect(res.useHyperlink).toBeTrue();
-    })
+    });
   });
 });

--- a/packages/brisa/src/utils/analyze-server-ast/index.ts
+++ b/packages/brisa/src/utils/analyze-server-ast/index.ts
@@ -45,7 +45,7 @@ export default function analyzeServerAst(
 
       for (let prop of value.arguments[1].properties) {
         // avoid target="_blank"
-        if(prop.key.name === "target" && prop.value.value === "_blank") {
+        if (prop.key.name === "target" && prop.value.value === "_blank") {
           detected = false;
           break;
         }

--- a/packages/brisa/src/utils/compile-files/index.test.ts
+++ b/packages/brisa/src/utils/compile-files/index.test.ts
@@ -441,7 +441,7 @@ describe("utils", () => {
     ${info}
     ${info}Route           | JS server | JS client (gz)  
     ${info}----------------------------------------------
-    ${info}λ /pages/index  | 190 B     | ${greenLog("2 kB")}  
+    ${info}λ /pages/index  | 190 B     | ${greenLog("3 kB")}  
     ${info}Δ /layout       | 435 B     |
     ${info}
     ${info}λ Server entry-points

--- a/packages/brisa/src/utils/compile-files/index.ts
+++ b/packages/brisa/src/utils/compile-files/index.ts
@@ -269,29 +269,21 @@ async function compileClientCodePage(
 
     if (!pageCode) return null;
 
-    let {
-      size,
-      actionRPC,
-      actionRPCLazy,
-      code,
-      unsuspense,
-      useI18n,
-      i18nKeys,
-    } = pageCode;
+    let { size, rpc, lazyRPC, code, unsuspense, useI18n, i18nKeys } = pageCode;
 
     // If there are no actions in the page but there are actions in
     // the layout, then it is as if the page also has actions.
-    if (!actionRPC && layoutCode?.actionRPC) {
-      size += layoutCode.actionRPC.length;
-      actionRPC = layoutCode.actionRPC;
+    if (!rpc && layoutCode?.rpc) {
+      size += layoutCode.rpc.length;
+      rpc = layoutCode.rpc;
     }
 
     // It is not necessary to increase the size here because this
     // code even if it is necessary to generate it if it does not
     // exist yet, it is not part of the initial size of the page
     // because it is loaded in a lazy way.
-    if (!actionRPCLazy && layoutCode?.actionRPCLazy) {
-      actionRPCLazy = layoutCode.actionRPCLazy;
+    if (!lazyRPC && layoutCode?.lazyRPC) {
+      lazyRPC = layoutCode.lazyRPC;
     }
 
     // If there is no unsuspense in the page but there is unsuspense
@@ -326,13 +318,13 @@ async function compileClientCodePage(
     });
 
     // create _rpc-[versionhash].js and _rpc.txt (list of pages with actions)
-    clientSizesPerPage[route] += addExtraChunk(actionRPC, "_rpc", {
+    clientSizesPerPage[route] += addExtraChunk(rpc, "_rpc", {
       pagesClientPath,
       pagePath,
     });
 
     // create _rpc-lazy-[versionhash].js
-    clientSizesPerPage[route] += addExtraChunk(actionRPCLazy, "_rpc-lazy", {
+    clientSizesPerPage[route] += addExtraChunk(lazyRPC, "_rpc-lazy", {
       pagesClientPath,
       pagePath,
       skipList: true,

--- a/packages/brisa/src/utils/get-web-components-list/index.test.ts
+++ b/packages/brisa/src/utils/get-web-components-list/index.test.ts
@@ -46,6 +46,7 @@ describe("utils", () => {
           "web-components",
           "with-context.tsx",
         ),
+        "with-link": path.join(fixturesDir, "web-components", "with-link.tsx"),
       });
     });
 
@@ -76,6 +77,7 @@ describe("utils", () => {
           "web-components",
           "with-context.tsx",
         ),
+        "with-link": path.join(fixturesDir, "web-components", "with-link.tsx"),
       });
     });
 
@@ -105,6 +107,7 @@ describe("utils", () => {
           "web-components",
           "with-context.tsx",
         ),
+        "with-link": path.join(fixturesDir, "web-components", "with-link.tsx"),
       });
     });
 

--- a/packages/brisa/src/utils/rpc/index.ts
+++ b/packages/brisa/src/utils/rpc/index.ts
@@ -2,12 +2,12 @@ import path from "node:path";
 import constants from "@/constants";
 
 // Should be used via macro
-export async function injectActionRPCCode() {
+export async function injectRPCCode() {
   return await buildRPC("rpc.ts");
 }
 
 // Should be used via macro
-export async function injectActionRPCLazyCode() {
+export async function injectRPCLazyCode() {
   return await buildRPC(path.join("resolve-rpc", "index.ts"));
 }
 


### PR DESCRIPTION
Related with https://github.com/brisa-build/brisa/issues/75

The idea is that you can browse and HTML streaming is handled by the RPC. In this way:

1. you don't lose the state of the web components that are still in the page, either because they are in the layout or because you translate the page to another language, etc.
2. It will be possible to activate transitions between pages (View Transition API), I will do it in another future PR.
3. It will be possible to make prefetch by means of an attribute that we will add in another future PR.
4. The store signals can be shared between pages


![ezgif-1-91476ddc09](https://github.com/brisa-build/brisa/assets/13313058/d7e91a9a-0d56-4469-9e43-09b5e9eb3aaa)

Tweet: https://twitter.com/aralroca/status/1781801233398804530

