### PR TITLE
Effect callback returns unknown instead of void

### DIFF
--- a/packages/brisa/src/utils/signals/index.ts
+++ b/packages/brisa/src/utils/signals/index.ts
@@ -2,7 +2,7 @@ import { type IndicatorSignal, type WebContext } from "@/types";
 
 type Effect = ((
   addSubEffect: (effect: Effect) => Effect,
-) => void | Promise<void>) & { id?: Effect };
+) => unknown | Promise<unknown>) & { id?: Effect };
 type Cleanup = () => void | Promise<void>;
 type Listener = (...params: any[]) => void;
 type State<T> = {


### PR DESCRIPTION
We've updated the return type of the effect callback from void to unknown. This change allows the passing of functions that return a value, even though the effect itself does not utilize this returned value.

![Screenshot 2024-04-25 at 18 56 03](https://github.com/brisa-build/brisa/assets/1533589/22a11a10-9cc1-4016-9ac0-628de46ab3d8)
