### PR TITLE
fix(signals): avoid derived trigger if value doesn't change

### DIFF
--- a/packages/brisa/src/utils/signals/index.ts
+++ b/packages/brisa/src/utils/signals/index.ts
@@ -169,7 +169,8 @@ export default function signals() {
     const derivedState = state<T>();
 
     effect(() => {
-      derivedState.value = fn();
+      const result = fn();
+      if (result !== derivedState.value) derivedState.value = result;
     });
 
     return derivedState;


### PR DESCRIPTION
With this change, a signal created from `derived` will not trigger it's effects if the value hasn't changed.