### PR TITLE
fix(render): fix bug translating link using hash

### DIFF
--- a/packages/brisa/src/cli/serve/serve-options.test.tsx
+++ b/packages/brisa/src/cli/serve/serve-options.test.tsx
@@ -38,7 +38,6 @@ async function testRequest(
 
 describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
   beforeEach(async () => {
-    globalThis.__BASE_PATH__ = "";
     globalThis.mockConstants = {
       ...(getConstants() ?? {}),
       PAGES_DIR,

--- a/packages/brisa/src/test-setup.ts
+++ b/packages/brisa/src/test-setup.ts
@@ -5,6 +5,7 @@ const dec = new TextDecoder();
 
 Bun.env.__CRYPTO_KEY__ = crypto.randomBytes(32).toString("hex");
 Bun.env.__CRYPTO_IV__ = crypto.randomBytes(8).toString("hex");
+globalThis.__BASE_PATH__ = "";
 
 // All tests about this diff dom streaming algorithm are inside the library
 mock.module("diff-dom-streaming", () => ({

--- a/packages/brisa/src/utils/render-attributes/index.test.ts
+++ b/packages/brisa/src/utils/render-attributes/index.test.ts
@@ -367,6 +367,69 @@ describe("utils", () => {
       );
     });
 
+    it('should translate the "a" href attribute with params and hash', () => {
+      globalThis.mockConstants = {
+        ...(getConstants() ?? {}),
+        I18N_CONFIG: {
+          locales: ["en", "es"],
+          defaultLocale: "en",
+          pages: {
+            "/some-page": {
+              es: "/alguna-pagina",
+            },
+            "/user/[id]": {
+              es: "/usuario/[id]",
+            },
+            "/catch/[[...catchAll]]": {
+              es: "/atrapar/[[...catchAll]]",
+            },
+            "/dynamic/[id]/catch/[...rest]": {
+              es: "/dinamico/[id]/atrapar/[...rest]",
+            },
+          },
+        },
+      };
+
+      const request = extendRequestContext({
+        originalRequest: new Request("https://example.com/es?foo=bar#baz"),
+      });
+
+      request.i18n = {
+        locale: "es",
+        locales: ["en", "es"],
+        defaultLocale: "en",
+        pages: {},
+        t: () => "" as any,
+        overrideMessages: () => {},
+      };
+
+      const hrefOfATag = (href: string) =>
+        renderAttributes({
+          elementProps: {
+            href,
+          },
+          request,
+          type: "a",
+        });
+
+      expect(hrefOfATag("/?foo=bar#baz")).toBe(' href="/es/?foo=bar#baz"');
+      expect(hrefOfATag("/some-page?foo=bar#baz")).toBe(
+        ' href="/es/alguna-pagina?foo=bar#baz"',
+      );
+      expect(hrefOfATag("/user/aral?foo=bar#baz")).toBe(
+        ' href="/es/usuario/aral?foo=bar#baz"',
+      );
+      expect(hrefOfATag("https://example.com?foo=bar#baz")).toBe(
+        ' href="https://example.com?foo=bar#baz"',
+      );
+      expect(hrefOfATag("/catch/first/second?foo=bar#baz")).toBe(
+        ' href="/es/atrapar/first/second?foo=bar#baz"',
+      );
+      expect(hrefOfATag("/dynamic/1/catch/first/second?foo=bar#baz")).toBe(
+        ' href="/es/dinamico/1/atrapar/first/second?foo=bar#baz"',
+      );
+    });
+
     it("should work with trailing slash enable in the config", () => {
       globalThis.mockConstants = {
         ...(getConstants() ?? {}),

--- a/packages/brisa/src/utils/render-attributes/index.ts
+++ b/packages/brisa/src/utils/render-attributes/index.ts
@@ -15,6 +15,7 @@ import { addBasePathToStringURL } from "@/utils/base-path";
 
 const PROPS_TO_IGNORE = new Set(["children", "__isWebComponent"]);
 const VALUES_TYPE_TO_IGNORE = new Set(["function", "undefined"]);
+const fakeOrigin = "http://localhost";
 
 export default function renderAttributes({
   elementProps,
@@ -229,9 +230,12 @@ export function renderHrefAttribute(
   return addBasePathToStringURL(fixedUrl);
 }
 
-function findTranslatedPage(pages: I18nConfig["pages"], pathname: string) {
+function findTranslatedPage(pages: I18nConfig["pages"], href: string) {
+  const url = new URL(href, fakeOrigin);
+  const pathnameWithoutTrailingSlash = url.pathname.replace(/\/$/, "");
+
   for (const page of Object.entries(pages ?? {})) {
-    if (routeMatchPathname(page[0], pathname)) return page;
+    if (routeMatchPathname(page[0], pathnameWithoutTrailingSlash)) return page;
   }
 }
 
@@ -240,7 +244,6 @@ function manageTrailingSlash(urlString: string) {
 
   if (!CONFIG.trailingSlash) return urlString;
 
-  const fakeOrigin = "http://localhost";
   const url = new URL(urlString, fakeOrigin);
 
   url.pathname = url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;

--- a/packages/brisa/src/utils/substitute-i18n-route-values/index.test.ts
+++ b/packages/brisa/src/utils/substitute-i18n-route-values/index.test.ts
@@ -55,5 +55,29 @@ describe("utils", () => {
 
       expect(output).toBe("/example/1/settings/2/3");
     });
+
+    it("should work with params and hash routes", () => {
+      mock.module("@/constants", () => ({
+        default: () => ({
+          ...constants,
+          I18N_CONFIG: {
+            locales: ["es", "en"],
+            defaultLocale: "es",
+            pages: {
+              "/example": {
+                es: "/ejemplo",
+              },
+            },
+          },
+        }),
+      }));
+
+      const output = substituteI18nRouteValues(
+        "/example",
+        "/ejemplo?foo=bar#baz",
+      );
+
+      expect(output).toBe("/example?foo=bar#baz");
+    });
   });
 });

--- a/packages/brisa/src/utils/substitute-i18n-route-values/index.ts
+++ b/packages/brisa/src/utils/substitute-i18n-route-values/index.ts
@@ -5,19 +5,19 @@ const { REGEX } = constants;
 /**
  *
  * @description Transforms:
- * - route: /usuario/[username]/configuracion
- * - pathname: /user/john/settings
+ * - route: /usuario/[username]/configuracion?foo=bar#baz
+ * - href: /user/john/settings?foo=bar#baz
  *
  * into:
  * - /usuario/john/configuracion
  */
-export default function substituteI18nRouteValues(
-  route: string,
-  pathname: string,
-) {
-  if (!route.match(REGEX.DYNAMIC)?.length) return route;
+export default function substituteI18nRouteValues(route: string, href: string) {
+  const url = new URL(href, "http://localhost");
+  const paramsAndHash = url.search + url.hash;
 
-  const pathnameParts = pathname.split("/");
+  if (!route.match(REGEX.DYNAMIC)?.length) return route + paramsAndHash;
+
+  const pathnameParts = url.pathname.split("/");
   const routeParts = route.split("/");
 
   const routePartsReplaced = routeParts.map((routePart, index) => {
@@ -38,5 +38,5 @@ export default function substituteI18nRouteValues(
     return pathnamePart;
   });
 
-  return routePartsReplaced.join("/");
+  return routePartsReplaced.join("/") + paramsAndHash;
 }


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/176

Fixes a page translation bug that didn't work when there was a `#hash`