### PR TITLE
feat: transfer store client-server and server-client during navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 <div align="center">
   <a href="https://brisa.build">Documentation</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://discord.com/invite/89Y9HMYZ">Discord</a>
+  <a href="https://discord.gg/MsE9RN3FU4">Discord</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://github.com/brisa-build/brisa/issues/new">Issues</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
@@ -125,7 +125,7 @@ See [Contributing Guide](CONTRIBUTING.md) and please follow our [Code of Conduct
 
 ## Discord
 
-Come join the [Discord community channel~](https://discord.gg/89Y9HMYZ)
+Come join the [Discord community channel~](https://discord.gg/MsE9RN3FU4)
 
 ## License
 

--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -21,7 +21,7 @@ const i18nCode = 3072;
 const brisaSize = 5650; // TODO: Reduce this size
 const webComponents = 684;
 const unsuspenseSize = 217;
-const rpcSize = 2240; // TODO: Reduce this size
+const rpcSize = 2273; // TODO: Reduce this size
 const lazyRPCSize = 3509; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/response-rendered-page/index.test.ts
+++ b/packages/brisa/src/utils/response-rendered-page/index.test.ts
@@ -116,5 +116,25 @@ describe("utils", () => {
 
       expect(response.headers.get("X-Test")).toBe("test");
     });
+
+    it("should transfer the store from client to server and server to client", async () => {
+      const req = extendRequestContext({
+        originalRequest: new Request("http://localhost:1234/es", {
+          headers: {
+            "x-s": encodeURIComponent(JSON.stringify([["key", "value"]])),
+          },
+        }),
+      });
+      const response = await responseRenderedPage({
+        req,
+        route: {
+          filePath: path.join(PAGES_DIR, "index.tsx"),
+        } as MatchedRoute,
+      });
+
+      expect(response.headers.get("X-S")).toBe(
+        encodeURIComponent(JSON.stringify([["key", "value"]])),
+      );
+    });
   });
 });

--- a/packages/brisa/src/utils/rpc/rpc.ts
+++ b/packages/brisa/src/utils/rpc/rpc.ts
@@ -9,6 +9,12 @@ const $Promise = Promise;
 let controller = new AbortController();
 let isReady = false;
 
+const serializeStore = () =>
+  encodeURIComponent(
+    // @ts-ignore
+    stringify($window._s ? [..._s.Map.entries()] : $window._S) ?? "",
+  );
+
 function loadRPCResolver() {
   return $window._rpc
     ? $Promise.resolve()
@@ -56,10 +62,7 @@ async function rpc(
       headers: {
         "x-action": actionId,
         "x-actions": actionsDeps ?? "",
-        "x-s": encodeURIComponent(
-          // @ts-ignore
-          stringify(store ? [..._s.Map.entries()] : $window._S) ?? "",
-        ),
+        "x-s": serializeStore(),
       },
       body: isFormData
         ? new FormData((args[0] as SubmitEvent).target as HTMLFormElement)
@@ -158,6 +161,9 @@ function spaNavigation(event: any) {
       // We do not validate res.ok because we also want to render 404 or 500 pages.
       const res = await fetch(event.destination.url, {
         signal: getAbortSignal(),
+        headers: {
+          "x-s": serializeStore(),
+        },
       });
       await loadRPCResolver();
       event.scroll();

--- a/packages/brisa/src/utils/signals/index.ts
+++ b/packages/brisa/src/utils/signals/index.ts
@@ -138,6 +138,7 @@ export default function signals() {
   async function effect(fn: Effect) {
     stack.unshift(fn);
     const p = fn(addSubEffect(fn));
+    // @ts-ignore
     if (p?.then) await p;
     removeFromStack(fn);
   }

--- a/packages/brisa/src/utils/transfer-store-service/index.test.ts
+++ b/packages/brisa/src/utils/transfer-store-service/index.test.ts
@@ -1,0 +1,81 @@
+import { encrypt } from "@/utils/crypto";
+import extendRequestContext from "@/utils/extend-request-context";
+import transferStoreService from "@/utils/transfer-store-service";
+import { describe, it, expect } from "bun:test";
+
+describe("utils", () => {
+  describe("transferStoreService", () => {
+    it("should transfer store from client to server", () => {
+      const req = extendRequestContext({
+        originalRequest: new Request("http://localhost:3000", {
+          headers: {
+            "x-s": encodeURIComponent(JSON.stringify([["key", "value"]])),
+          },
+        }),
+      });
+
+      const transferStore = transferStoreService(req);
+      transferStore.transfeClientStoreToServer();
+
+      expect(req.store.get("key")).toBe("value");
+    });
+
+    it("should transfer store from server to client", () => {
+      const req = extendRequestContext({
+        originalRequest: new Request("http://localhost:3000", {
+          headers: {
+            "x-s": encodeURIComponent(JSON.stringify([["key", "value"]])),
+          },
+        }),
+      });
+
+      const res = new Response();
+      const transferStore = transferStoreService(req);
+      transferStore.transfeClientStoreToServer();
+      transferStore.transferServerStoreToClient(res);
+
+      expect(res.headers.get("X-S")).toBe(
+        encodeURIComponent(JSON.stringify([["key", "value"]])),
+      );
+    });
+
+    it("should transfer store from client to server with encrypted value", () => {
+      const req = extendRequestContext({
+        originalRequest: new Request("http://localhost:3000", {
+          headers: {
+            "x-s": encodeURIComponent(
+              JSON.stringify([["key", encrypt("value")]]),
+            ),
+          },
+        }),
+      });
+
+      const transferStore = transferStoreService(req);
+      transferStore.transfeClientStoreToServer();
+
+      expect(req.store.get("key")).toBe("value");
+    });
+
+    it("should transfer store from server to client with encrypted value", () => {
+      const valueEncrypted = encrypt("value");
+      const req = extendRequestContext({
+        originalRequest: new Request("http://localhost:3000", {
+          headers: {
+            "x-s": encodeURIComponent(
+              JSON.stringify([["key", valueEncrypted]]),
+            ),
+          },
+        }),
+      });
+
+      const res = new Response();
+      const transferStore = transferStoreService(req);
+      transferStore.transfeClientStoreToServer();
+      transferStore.transferServerStoreToClient(res);
+
+      expect(res.headers.get("X-S")).toBe(
+        encodeURIComponent(JSON.stringify([["key", valueEncrypted]])),
+      );
+    });
+  });
+});

--- a/packages/brisa/src/utils/transfer-store-service/index.ts
+++ b/packages/brisa/src/utils/transfer-store-service/index.ts
@@ -1,0 +1,51 @@
+import type { RequestContext } from "@/types";
+import {
+  ENCRYPT_NONTEXT_PREFIX,
+  ENCRYPT_PREFIX,
+  decrypt,
+} from "@/utils/crypto";
+import getClientStoreEntries from "@/utils/get-client-store-entries";
+import { logError } from "@/utils/log/log-build";
+
+export default function transferStoreService(req: RequestContext) {
+  const encryptedKeys = new Set<string>();
+  const storeRaw = req.headers.get("x-s");
+
+  return {
+    transfeClientStoreToServer() {
+      if (!storeRaw) return;
+
+      let entries = JSON.parse(decodeURIComponent(storeRaw));
+
+      for (const [key, value] of entries) {
+        try {
+          let storeValue = value;
+
+          if (
+            typeof value === "string" &&
+            (value.startsWith(ENCRYPT_PREFIX) ||
+              value.startsWith(ENCRYPT_NONTEXT_PREFIX))
+          ) {
+            encryptedKeys.add(key);
+            storeValue = decrypt(value);
+          }
+
+          req.store.set(key, storeValue);
+        } catch (e: any) {
+          logError([
+            `Error transferring client "${key}" store to server store`,
+            e.message,
+          ]);
+        }
+      }
+    },
+    transferServerStoreToClient(res: Response) {
+      res.headers.set(
+        "X-S",
+        encodeURIComponent(
+          JSON.stringify(getClientStoreEntries(req, encryptedKeys)),
+        ),
+      );
+    },
+  };
+}

--- a/packages/docs/.vitepress/config.mts
+++ b/packages/docs/.vitepress/config.mts
@@ -410,7 +410,7 @@ export default defineConfig({
     socialLinks: [
       { icon: "github", link: "https://github.com/brisa-build/brisa" },
       { icon: "twitter", link: "https://twitter.com/brisadotbuild" },
-      { icon: "discord", link: "https://discord.com/invite/89Y9HMYZ" },
+      { icon: "discord", link: "https://discord.gg/MsE9RN3FU4" },
     ],
     editLink: {
       text: "Edit this page on GitHub",


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/75

The navigation preserves the state of the web components thanks to the diff of the DOM with HTML streaming. Nevertheless the store communicates with the server components, this way you can have a shared store between client-server-client during the navigation, if for something during the render some property of the store is modified, all the web components after the navigation react to the changes through the signals.

The same was already done for server actions, now this behavior is extended to browser navigation as well.
