### PR TITLE
feat(testing): add `toBeInTheDocument` matcher

### DIFF
--- a/packages/brisa/src/core/test/matchers/index.test.ts
+++ b/packages/brisa/src/core/test/matchers/index.test.ts
@@ -444,4 +444,34 @@ describe("test matchers", () => {
       );
     });
   });
+
+  describe("toBeInTheDocument", () => {
+    it("should pass if the element is in the document body", () => {
+      const div = document.createElement("div");
+      document.body.appendChild(div);
+
+      expect(div).toBeInTheDocument();
+    });
+
+    it("should pass if the element is in the document head", () => {
+      const link = document.createElement("link");
+      document.head.appendChild(link);
+
+      expect(link).toBeInTheDocument();
+    });
+
+    it("should fail if the element is not in the document", () => {
+      const div = document.createElement("div");
+
+      expect(() => expect(div).toBeInTheDocument()).toThrowError(
+        "expected element to be in the document",
+      );
+    });
+
+    it("should fail when the received is not an element", () => {
+      expect(() => expect("foo").toBeInTheDocument()).toThrowError(
+        "Invalid usage of toBeInTheDocument(received). The argument received should be an HTMLElement",
+      );
+    });
+  });
 });

--- a/packages/brisa/src/core/test/matchers/index.ts
+++ b/packages/brisa/src/core/test/matchers/index.ts
@@ -227,6 +227,19 @@ function toBeInputTypeOf(received: unknown, type: InputType) {
   };
 }
 
+function toBeInTheDocument(received: unknown) {
+  if (received instanceof HTMLElement === false) {
+    throw new Error(
+      "Invalid usage of toBeInTheDocument(received). The argument received should be an HTMLElement",
+    );
+  }
+
+  return {
+    pass: document.documentElement.contains(received),
+    message: () => "expected element to be in the document",
+  };
+}
+
 export default {
   toBeChecked,
   toHaveAttribute,
@@ -245,4 +258,5 @@ export default {
   toBeValid,
   toBeInvalid,
   toBeInputTypeOf,
+  toBeInTheDocument,
 };

--- a/packages/brisa/src/types/index.d.ts
+++ b/packages/brisa/src/types/index.d.ts
@@ -9785,6 +9785,18 @@ export interface BrisaTestMatchers {
    * @see [More details](https://brisa.build/building-your-application/testing/matchers#tobeinputtypeof)
    */
   toBeInputTypeOf(type: InputType): void;
+  /**
+   * Use `toBeInTheDocument` to assert that an element is in the document.
+   *
+   * Example:
+   *
+   * ```ts
+   * expect(element).toBeInTheDocument();
+   * ```
+   *
+   * @see [More details](https://brisa.build/building-your-application/testing/matchers#tobeinvalid)
+   */
+  toBeInTheDocument(): void;
 }
 
 declare module "bun:test" {

--- a/packages/create-brisa/create-brisa.cjs
+++ b/packages/create-brisa/create-brisa.cjs
@@ -120,10 +120,7 @@ bun start
 }`,
   );
 
-  fs.writeFileSync(
-    "bunfig.toml",
-    '[test]\npreload = "brisa/test"',
-  );
+  fs.writeFileSync("bunfig.toml", '[test]\npreload = "brisa/test"');
 
   fs.writeFileSync(".gitignore", "build\nnode_modules\nout\n");
 

--- a/packages/docs/building-your-application/testing/matchers.md
+++ b/packages/docs/building-your-application/testing/matchers.md
@@ -292,3 +292,20 @@ Types:
 ```ts
 toBeInputTypeOf(type: string): void;
 ```
+
+## `toBeInTheDocument`
+
+Checks if the target element is present in the DOM.
+
+Example:
+
+```ts
+expect(element).toBeInTheDocument();
+expect(element).not.toBeInTheDocument();
+```
+
+Types:
+
+```ts
+toBeInTheDocument(): void;
+```


### PR DESCRIPTION
Related to https://github.com/brisa-build/brisa/issues/144

And related to this PR: https://github.com/brisa-build/brisa/pull/189

## `toBeInTheDocument`

Checks if the target element is present in the DOM.

Example:

```ts
expect(element).toBeInTheDocument();
expect(element).not.toBeInTheDocument();
```

Types:

```ts
toBeInTheDocument(): void;
```
