### PR TITLE
fix(hotreloading): use native navigation to reload + avoid multiple reconnections

### DIFF
--- a/packages/brisa/src/cli/dev-live-reload.test.tsx
+++ b/packages/brisa/src/cli/dev-live-reload.test.tsx
@@ -1,39 +1,20 @@
 import { describe, it, expect } from "bun:test";
 import { LiveReloadScript } from "./dev-live-reload";
-import { normalizeQuotes } from "@/helpers";
 
 describe("dev-live-reload", () => {
   it("should return live reload script for port 3000", () => {
     const output = LiveReloadScript({ port: 3000, children: null });
 
-    expect(
-      normalizeQuotes(output.props.children[0].props.children.props.html),
-    ).toBe(
-      normalizeQuotes(`
-      function wsc() {
-        let s = new WebSocket("ws://0.0.0.0:3000/__brisa_live_reload__");
-        s.onclose = wsc;
-        s.onmessage = e => e.data === "reload" && location.reload();
-      }
-      wsc();
-    `),
+    expect(output.props.children[0].props.children.props.html).toContain(
+      "ws://0.0.0.0:3000/__brisa_live_reload__",
     );
   });
 
   it("should return live reload script for port 4000", () => {
     const output = LiveReloadScript({ port: 4000, children: null });
 
-    expect(
-      normalizeQuotes(output.props.children[0].props.children.props.html),
-    ).toBe(
-      normalizeQuotes(`
-      function wsc() {
-        let s = new WebSocket("ws://0.0.0.0:4000/__brisa_live_reload__");
-        s.onclose = wsc;
-        s.onmessage = e => e.data === "reload" && location.reload();
-      }
-      wsc();
-    `),
+    expect(output.props.children[0].props.children.props.html).toContain(
+      "ws://0.0.0.0:4000/__brisa_live_reload__",
     );
   });
 });

--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -21,7 +21,7 @@ const i18nCode = 3072;
 const brisaSize = 5650; // TODO: Reduce this size
 const webComponents = 684;
 const unsuspenseSize = 217;
-const rpcSize = 2308; // TODO: Reduce this size
+const rpcSize = 2315; // TODO: Reduce this size
 const lazyRPCSize = 3568; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/rpc/rpc.ts
+++ b/packages/brisa/src/utils/rpc/rpc.ts
@@ -114,7 +114,8 @@ function spaNavigation(event: any) {
     renderMode === "native" ||
     event.hashChange ||
     event.downloadRequest !== null ||
-    !event.canIntercept
+    !event.canIntercept ||
+    $window._nn // Native navigation
   ) {
     return;
   }


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/93
Related to https://github.com/brisa-build/brisa/issues/151

@gariasf  I have fixed a couple of hotreloading bugs that I have detected on Mac. Surely some of them can be related to the windows bug, but I'm not closing the windows bug task yet until it is confirmed as there is probably something else.