### PR TITLE
refactor(actions): rename `mode` from `rerenderInAction` to `renderMode`

### DIFF
--- a/packages/brisa/src/types/server.d.ts
+++ b/packages/brisa/src/types/server.d.ts
@@ -9,7 +9,7 @@ export type Options = {
 
 export type RerenderInActionProps = {
   type?: "component" | "page";
-  mode?: "reactivity" | "transition";
+  renderMode?: "reactivity" | "transition";
 };
 
 /**
@@ -54,7 +54,7 @@ export async function renderToString(
  *
  * - `type`: The type of the rerender. It can be `component` or `page`.
  *           By default, it is `component`.
- * - `mode`: The type of the rerender. It can be `reactivity` or `transition`.
+ * - `renderMode`: The type of the rerender. It can be `reactivity` or `transition`.
  *           By default, it is `reactivity`.
  *
  * Example:

--- a/packages/brisa/src/utils/rerender-in-action/index.test.ts
+++ b/packages/brisa/src/utils/rerender-in-action/index.test.ts
@@ -10,59 +10,59 @@ describe("utils", () => {
         expect(error.name).toBe("rerender");
         expect(error.message).toContain(PREFIX_MESSAGE);
         expect(error.message).toContain(
-          JSON.stringify({ type: "component", mode: "reactivity" }),
+          JSON.stringify({ type: "component", renderMode: "reactivity" }),
         );
         expect(error.message).toContain(SUFFIX_MESSAGE);
       }
     });
 
-    it("should throw the correct error with type='component' and mode='reactivity'", () => {
+    it("should throw the correct error with type='component' and renderMode='reactivity'", () => {
       try {
-        rerenderInAction({ type: "component", mode: "reactivity" });
+        rerenderInAction({ type: "component", renderMode: "reactivity" });
       } catch (error: any) {
         expect(error.name).toBe("rerender");
         expect(error.message).toContain(PREFIX_MESSAGE);
         expect(error.message).toContain(
-          JSON.stringify({ type: "component", mode: "reactivity" }),
+          JSON.stringify({ type: "component", renderMode: "reactivity" }),
         );
         expect(error.message).toContain(SUFFIX_MESSAGE);
       }
     });
 
-    it("should throw the correct error with type='page' and mode='transition'", () => {
+    it("should throw the correct error with type='page' and renderMode='transition'", () => {
       try {
-        rerenderInAction({ type: "page", mode: "transition" });
+        rerenderInAction({ type: "page", renderMode: "transition" });
       } catch (error: any) {
         expect(error.name).toBe("rerender");
         expect(error.message).toContain(PREFIX_MESSAGE);
         expect(error.message).toContain(
-          JSON.stringify({ type: "page", mode: "transition" }),
+          JSON.stringify({ type: "page", renderMode: "transition" }),
         );
         expect(error.message).toContain(SUFFIX_MESSAGE);
       }
     });
 
-    it("should throw the correct error with type='page' and mode='reactivity'", () => {
+    it("should throw the correct error with type='page' and renderMode='reactivity'", () => {
       try {
         rerenderInAction({ type: "page" });
       } catch (error: any) {
         expect(error.name).toBe("rerender");
         expect(error.message).toContain(PREFIX_MESSAGE);
         expect(error.message).toContain(
-          JSON.stringify({ type: "page", mode: "reactivity" }),
+          JSON.stringify({ type: "page", renderMode: "reactivity" }),
         );
         expect(error.message).toContain(SUFFIX_MESSAGE);
       }
     });
 
-    it("should throw the correct error with type='component' and mode='transition'", () => {
+    it("should throw the correct error with type='component' and renderMode='transition'", () => {
       try {
-        rerenderInAction({ mode: "transition" });
+        rerenderInAction({ renderMode: "transition" });
       } catch (error: any) {
         expect(error.name).toBe("rerender");
         expect(error.message).toContain(PREFIX_MESSAGE);
         expect(error.message).toContain(
-          JSON.stringify({ type: "component", mode: "transition" }),
+          JSON.stringify({ type: "component", renderMode: "transition" }),
         );
         expect(error.message).toContain(SUFFIX_MESSAGE);
       }

--- a/packages/brisa/src/utils/rerender-in-action/index.ts
+++ b/packages/brisa/src/utils/rerender-in-action/index.ts
@@ -6,10 +6,10 @@ export const SUFFIX_MESSAGE =
 
 export default function rerenderInAction({
   type = "component",
-  mode = "reactivity",
+  renderMode = "reactivity",
 }: RerenderInActionProps = {}) {
   const throwable = new Error(
-    `${PREFIX_MESSAGE}${JSON.stringify({ type, mode })}${SUFFIX_MESSAGE}`,
+    `${PREFIX_MESSAGE}${JSON.stringify({ type, renderMode })}${SUFFIX_MESSAGE}`,
   );
   throwable.name = "rerender";
   throw throwable;

--- a/packages/brisa/src/utils/resolve-action/index.test.tsx
+++ b/packages/brisa/src/utils/resolve-action/index.test.tsx
@@ -74,7 +74,7 @@ describe("utils", () => {
     it("should log an error trying to rerender a invalid page", async () => {
       const error = new Error(
         PREFIX_MESSAGE +
-          JSON.stringify({ type: "page", mode: "reactivity" }) +
+          JSON.stringify({ type: "page", renderMode: "reactivity" }) +
           SUFFIX_MESSAGE,
       );
       error.name = "rerender";
@@ -93,7 +93,7 @@ describe("utils", () => {
     it("should rerender the page with reactivity without declarative shadow DOM", async () => {
       const error = new Error(
         PREFIX_MESSAGE +
-          JSON.stringify({ type: "page", mode: "reactivity" }) +
+          JSON.stringify({ type: "page", renderMode: "reactivity" }) +
           SUFFIX_MESSAGE,
       );
       error.name = "rerender";
@@ -112,7 +112,7 @@ describe("utils", () => {
     it("should rerender the page with reactivity with declarative shadow DOM if is called without JS", async () => {
       const error = new Error(
         PREFIX_MESSAGE +
-          JSON.stringify({ type: "page", mode: "reactivity" }) +
+          JSON.stringify({ type: "page", renderMode: "reactivity" }) +
           SUFFIX_MESSAGE,
       );
       error.name = "rerender";
@@ -132,7 +132,7 @@ describe("utils", () => {
     it('should rerender the page with reactivity and "x-s" store header', async () => {
       const error = new Error(
         PREFIX_MESSAGE +
-          JSON.stringify({ type: "page", mode: "reactivity" }) +
+          JSON.stringify({ type: "page", renderMode: "reactivity" }) +
           SUFFIX_MESSAGE,
       );
       error.name = "rerender";
@@ -154,7 +154,7 @@ describe("utils", () => {
     it("should rerender the page with transition", async () => {
       const error = new Error(
         PREFIX_MESSAGE +
-          JSON.stringify({ type: "page", mode: "transition" }) +
+          JSON.stringify({ type: "page", renderMode: "transition" }) +
           SUFFIX_MESSAGE,
       );
       error.name = "rerender";

--- a/packages/brisa/src/utils/resolve-action/index.ts
+++ b/packages/brisa/src/utils/resolve-action/index.ts
@@ -102,7 +102,7 @@ export default async function resolveAction({
 
     const res = await responseRenderedPage({ req, route });
 
-    res.headers.set("X-Mode", options.mode);
+    res.headers.set("X-Mode", options.renderMode);
 
     return res;
   }
@@ -112,7 +112,7 @@ export default async function resolveAction({
     status: 200,
     headers: {
       ...headers,
-      "X-Mode": options.mode,
+      "X-Mode": options.renderMode,
     },
   });
 }

--- a/packages/brisa/src/utils/rpc/rpc-integration.test.ts
+++ b/packages/brisa/src/utils/rpc/rpc-integration.test.ts
@@ -446,7 +446,7 @@ describe("utils", () => {
     });
 
     it("should not work SPA navigation with renderMode='native'", async () => {
-      document.activeElement?.setAttribute("rendermode", "native");
+      document.activeElement?.setAttribute("renderMode", "native");
       await simulateSPANavigation("http://localhost/some-page");
       expect(mockNavigationIntercept).not.toHaveBeenCalled();
     });
@@ -459,7 +459,7 @@ describe("utils", () => {
           constructor() {
             super();
             const shadowRoot = this.attachShadow({ mode: "open" });
-            shadowRoot.innerHTML = `<a href="${page}" rendermode="native">Click me</a>`;
+            shadowRoot.innerHTML = `<a href="${page}" renderMode="native">Click me</a>`;
           }
         },
       );
@@ -487,7 +487,7 @@ describe("utils", () => {
           constructor() {
             super();
             const shadowRoot = this.attachShadow({ mode: "open" });
-            shadowRoot.innerHTML = `<a href="${page}" rendermode="reactivity">Click me</a>`;
+            shadowRoot.innerHTML = `<a href="${page}" renderMode="reactivity">Click me</a>`;
           }
         },
       );
@@ -515,7 +515,7 @@ describe("utils", () => {
           constructor() {
             super();
             const shadowRoot = this.attachShadow({ mode: "open" });
-            shadowRoot.innerHTML = `<a href="${page}" rendermode="transition">Click me</a>`;
+            shadowRoot.innerHTML = `<a href="${page}" renderMode="transition">Click me</a>`;
           }
         },
       );

--- a/packages/docs/api-reference/server-apis/rerenderInAction.md
+++ b/packages/docs/api-reference/server-apis/rerenderInAction.md
@@ -6,7 +6,7 @@ description: rerender the component or the page inside a server action
 
 ## Reference
 
-### `rerenderInPage({ type, mode }: { type: 'component' | 'page', mode: 'reactivity' | 'transition' }): Never`
+### `rerenderInPage({ type, renderMode }: { type: 'component' | 'page', renderMode: 'reactivity' | 'transition' }): Never`
 
 The `rerenderInAction` method is used to rerender the component or the page
 inside a server action. Outside of an action, it throws an error.
@@ -32,7 +32,7 @@ function handleEvent() {
 #### Parameters:
 
 - `type`: The type of the rerender. It can be `component` or `page`. By default, it is `component`.
-- `mode`: The type of the rerender. It can be `reactivity` or `transition`. By default, it is `reactivity`. When using `transition` it is done under [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API).
+- `renderMode`: The type of the rerender. It can be `reactivity` or `transition`. By default, it is `reactivity`. When using `transition` it is done under [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API).
 
 #### Returns:
 


### PR DESCRIPTION
Related to https://github.com/brisa-build/brisa/issues/73

Since the attribute in hyperlinks is called renderMode because the mode attribute already exists in HTML and renderMode gives more context, to be consistent it is better that all sites are called the same, both for navigation through hyperlinks, through imperative navigation (navigate function) and both for the rerenderInAction.