### PR TITLE
fix(signals): restore lost `store` signals after SPA navigation

### DIFF
--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -18,7 +18,7 @@ const pageWebComponents = {
 };
 
 const i18nCode = 3072;
-const brisaSize = 5725; // TODO: Reduce this size
+const brisaSize = 5732; // TODO: Reduce this size
 const webComponents = 731;
 const unsuspenseSize = 217;
 const rpcSize = 2322; // TODO: Reduce this size

--- a/packages/brisa/src/utils/signals/index.test.ts
+++ b/packages/brisa/src/utils/signals/index.test.ts
@@ -7,7 +7,7 @@ const transpiler = new Bun.Transpiler({
   loader: "ts",
   exports: {
     eliminate: ["default"],
-  }
+  },
 });
 
 const signals = () =>
@@ -665,7 +665,7 @@ describe("signals", () => {
     reset();
   });
 
-  it('should expose subscriptions to window.sub and keep registered listeners after re-executing the file script', async () => { 
+  it("should expose subscriptions to window.sub and keep registered listeners after re-executing the file script", async () => {
     const firstSubscriptions = (window as any).sub;
     expect((window as any).sub).toBeDefined();
 
@@ -675,5 +675,5 @@ describe("signals", () => {
 
     expect((window as any).sub).toBeDefined();
     expect((window as any).sub).toBe(firstSubscriptions);
-  })
+  });
 });

--- a/packages/brisa/src/utils/signals/index.ts
+++ b/packages/brisa/src/utils/signals/index.ts
@@ -15,21 +15,21 @@ const SUBSCRIBE = "s";
 const UNSUBSCRIBE = "u";
 const INDICATE_PREFIX = "__ind:";
 const ORIGINAL_PREFIX = "__o:";
-const $window = window as any;
 
-const storeMap = new Map($window._S);
-const globalStore = ($window._s = {
-  Map: storeMap,
-} as Record<string, any>);
+const $window = window as any;
+const globalStore = ($window._s = { Map: new Map($window._S) } as Record<
+  string,
+  any
+>);
 
 // Create a subscription object only once (keeping SPA behavior)
-$window.sub ??= createSubscription();
+const sub = ($window.sub ??= createSubscription());
 
 // Only get/set/delete from store are reactive
 for (let op of ["get", "set", "delete"]) {
   globalStore[op] = (key: string, value: any) => {
-    const res = storeMap[op as StoreOperation](key, value);
-    $window.sub[NOTIFY](key, value, op === "get");
+    const res = globalStore.Map[op as StoreOperation](key, value);
+    sub[NOTIFY](key, value, op === "get");
     return res;
   };
 }
@@ -159,7 +159,7 @@ export default function signals() {
   function manageStoreSubscription(subscribe = true) {
     if (subscribed === subscribe) return;
     subscribed = subscribe;
-    $window.sub[subscribe ? SUBSCRIBE : UNSUBSCRIBE](manageStore);
+    sub[subscribe ? SUBSCRIBE : UNSUBSCRIBE](manageStore);
   }
 
   function cleanup(fn: Cleanup, eff: Effect) {


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/208 bug. 

This bug was introduced after SPA behavior. The problem is that the subscription was re-created again, without keeping the listeners that are still alive after browsing with SPA because the web components that are still alive in the same place are kept alive without disconnecting them.
