### PR TITLE
fix(dx) #240: improve error feedback when build fail

### DIFF
--- a/packages/brisa/src/utils/brisa-error-dialog/inject-code.ts
+++ b/packages/brisa/src/utils/brisa-error-dialog/inject-code.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import clientBuildPlugin from "@/utils/client-build-plugin";
+import { logBuildError } from "@/utils/log/log-build";
 
 // Should be used via macro
 export async function injectBrisaDialogErrorCode() {
@@ -32,7 +33,9 @@ export async function injectBrisaDialogErrorCode() {
     ],
   });
 
-  if (!success) console.error(logs);
+  if (!success) {
+    logBuildError("Failed to use brisa dialog error in development", logs);
+  }
 
   return (await outputs?.[0]?.text?.()) ?? "";
 }

--- a/packages/brisa/src/utils/compile-actions/index.ts
+++ b/packages/brisa/src/utils/compile-actions/index.ts
@@ -7,6 +7,7 @@ import { getConstants } from "@/constants";
 import type { ActionInfo } from "./get-actions-info";
 import getActionsInfo from "./get-actions-info";
 import { getPurgedBody } from "./get-purged-body";
+import { logBuildError, logError } from "@/utils/log/log-build";
 
 type CompileActionsParams = {
   actionsEntrypoints: string[];
@@ -40,6 +41,10 @@ export default async function compileActions({
     define,
     plugins: [actionPlugin({ actionsEntrypoints })],
   });
+
+  if (!res.success) {
+    logBuildError("Failed to compile actions", res.logs);
+  }
 
   fs.rmSync(rawActionsDir, { recursive: true });
 

--- a/packages/brisa/src/utils/compile-all/index.ts
+++ b/packages/brisa/src/utils/compile-all/index.ts
@@ -1,5 +1,6 @@
 import compileAssets from "@/utils/compile-assets";
 import compileFiles from "@/utils/compile-files";
+import { logBuildError } from "@/utils/log/log-build";
 
 export default async function compileAll() {
   await compileAssets();
@@ -7,7 +8,7 @@ export default async function compileAll() {
   const { success, logs, pagesSize } = await compileFiles();
 
   if (!success) {
-    logs.forEach((log) => console.error(log));
+    logBuildError("Failed to compile pages", logs);
   }
 
   return { success, logs, pagesSize };

--- a/packages/brisa/src/utils/compile-files/index.ts
+++ b/packages/brisa/src/utils/compile-files/index.ts
@@ -147,7 +147,11 @@ export default async function compileFiles() {
   if (!pagesSize) {
     return {
       success: false,
-      logs: ["Error compiling web components"],
+      logs: [
+        { message: "Error compiling web components" } as
+          | BuildMessage
+          | ResolveMessage,
+      ],
       pagesSize,
     };
   }

--- a/packages/brisa/src/utils/context-provider/inject-client.ts
+++ b/packages/brisa/src/utils/context-provider/inject-client.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import clientBuildPlugin from "@/utils/client-build-plugin";
+import { logBuildError } from "@/utils/log/log-build";
 
 // Should be used via macro
 export async function injectClientContextProviderCode() {
@@ -28,7 +29,9 @@ export async function injectClientContextProviderCode() {
     ],
   });
 
-  if (!success) console.error(logs);
+  if (!success) {
+    logBuildError("Failed to compile client context provider", logs);
+  }
 
   return (await outputs?.[0]?.text?.()) ?? "";
 }

--- a/packages/brisa/src/utils/get-client-code-in-page/index.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.ts
@@ -14,6 +14,7 @@ import clientBuildPlugin from "@/utils/client-build-plugin";
 import createContextPlugin from "@/utils/create-context/create-context-plugin";
 import snakeToCamelCase from "@/utils/snake-to-camelcase";
 import analyzeServerAst from "@/utils/analyze-server-ast";
+import { logBuildError } from "@/utils/log/log-build";
 
 type TransformOptions = {
   webComponentsList: Record<string, string>;
@@ -258,7 +259,7 @@ export async function transformToWebComponents({
   await rm(webEntrypoint);
 
   if (!success) {
-    logs.forEach((log) => console.error(log));
+    logBuildError("Failed to compile web components", logs);
     return null;
   }
 

--- a/packages/brisa/src/utils/inject-unsuspense-code/index.ts
+++ b/packages/brisa/src/utils/inject-unsuspense-code/index.ts
@@ -1,3 +1,4 @@
+import { logBuildError } from "@/utils/log/log-build";
 import path from "node:path";
 
 // Should be used via macro
@@ -8,7 +9,9 @@ export async function injectUnsuspenseCode() {
     minify: true,
   });
 
-  if (!success) console.error(logs);
+  if (!success) {
+    logBuildError("Failed to compile unsuspense code", logs);
+  }
 
   return (await outputs?.[0]?.text?.()) ?? "";
 }

--- a/packages/brisa/src/utils/log/log-build.ts
+++ b/packages/brisa/src/utils/log/log-build.ts
@@ -97,3 +97,27 @@ export function logError({
 export function logWarning(messages: string[], footer?: string) {
   return log("Warning")(messages, footer);
 }
+
+export function logBuildError(
+  title: string,
+  logs: (BuildMessage | ResolveMessage)[],
+) {
+  const messages = [title, "", ...logs.map((l) => l.message)];
+  const isJSXRuntimeError = messages.some((m) => m.includes("react/jsx"));
+
+  if (isJSXRuntimeError) {
+    messages.push("");
+    messages.push("The error above is usually caused by the following:");
+    messages.push(
+      "Verify inside tsconfig.json the 'jsx' option set to 'react-jsx' and the 'jsxImportSource' option set to 'brisa'",
+    );
+  }
+
+  messages.push("");
+
+  logError({
+    messages,
+    docTitle: "Please, if you can't solve the problem, open an issue on GitHub",
+    docLink: "https://github.com/brisa-build/brisa/issues/new",
+  });
+}

--- a/packages/brisa/src/utils/rpc/index.ts
+++ b/packages/brisa/src/utils/rpc/index.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import constants from "@/constants";
+import { logBuildError } from "@/utils/log/log-build";
 
 // Should be used via macro
 export async function injectRPCCode() {
@@ -21,7 +22,9 @@ async function buildRPC(file: string) {
     },
   });
 
-  if (!success) console.error(logs);
+  if (!success) {
+    logBuildError("Failed to compile RPC code", logs);
+  }
 
   const code = (await outputs?.[0]?.text?.()) ?? "";
 


### PR DESCRIPTION
Fixes #240

@AlbertSabate In front of the advantage of the [Bun's bug](https://github.com/oven-sh/bun/issues/5277) that you detected, I take the opportunity to fix the error feedback to make it more intuitive. Now it warns that it fails by the jsx-runtime and how to fix it + a call to action to open the issue if it is not solved.

<img width="922" alt="Screenshot 2024-06-14 at 18 28 50" src="https://github.com/brisa-build/brisa/assets/13313058/4e40832f-8a30-4519-be34-0e53d63a62bd">

With this, we will give the issue as "solved" on Brisa's side, although [Bun's bug](https://github.com/oven-sh/bun/issues/5277) on the `tsconfig` extends is still pending.