### PR TITLE
feat(dx): improve error feedback of rerenderInAction fail

### DIFF
--- a/packages/brisa/src/cli/serve/index.tsx
+++ b/packages/brisa/src/cli/serve/index.tsx
@@ -2,6 +2,7 @@ import constants from "@/constants";
 import { getServeOptions } from "./serve-options";
 import type { ServeOptions, Server } from "bun";
 import { blueLog, boldLog } from "@/utils/log/log-color";
+import { logError } from "@/utils/log/log-build";
 
 const { LOG_PREFIX } = constants;
 
@@ -29,32 +30,20 @@ function init(options: ServeOptions) {
 
 function handleError(errorName: string) {
   return (e: Error) => {
-    console.error(
-      LOG_PREFIX.ERROR,
-      `Oops! An ${errorName} occurred: ${boldLog(e.message)}.`,
-    );
-    console.error(LOG_PREFIX.ERROR);
-    console.error(LOG_PREFIX.ERROR, `Please don't worry, we are here to help.`);
-    console.error(
-      LOG_PREFIX.ERROR,
-      `This happened because there might be an unexpected issue in the code or an unforeseen situation.`,
-    );
-    console.error(
-      LOG_PREFIX.ERROR,
-      `You can try restarting the application or checking the documentation for troubleshooting tips.`,
-    );
-    console.error(LOG_PREFIX.ERROR);
-    console.error(
-      LOG_PREFIX.ERROR,
-      `If the problem persists, please report this error to the Brisa team:`,
-    );
-    console.error(
-      LOG_PREFIX.ERROR,
-      blueLog("🔗 https://github.com/brisa-build/brisa/issues/new"),
-    );
-    console.error(LOG_PREFIX.ERROR);
-    console.error(LOG_PREFIX.ERROR, "More details about the error:");
-    throw e; // To display the error message, the stack trace and exit the process
+    logError({
+      messages: [
+        `Oops! An ${errorName} occurred:`,
+        '',
+        ...e.message.split('\n').map(boldLog),
+        '',
+        `This happened because there might be an unexpected issue in the code or an unforeseen situation.`,
+        `If the problem persists, please report this error to the Brisa team:`,
+        blueLog("🔗 https://github.com/brisa-build/brisa/issues/new"),
+        `Please don't worry, we are here to help.`,
+        "More details about the error:"
+      ], stack: e.stack
+    });
+    // throw e; // To display the error message, the stack trace and exit the process
   };
 }
 

--- a/packages/brisa/src/utils/rerender-in-action/index.ts
+++ b/packages/brisa/src/utils/rerender-in-action/index.ts
@@ -1,8 +1,9 @@
 import type { RerenderInActionProps } from "@/types/server";
+import { blueLog } from "@/utils/log/log-color";
 
 export const PREFIX_MESSAGE = "Error rerendering within action: ";
 export const SUFFIX_MESSAGE =
-  "\nPlease use the 'rerenderInAction' function inside a server action.\nMore details: https://brisa.build/api-reference/server-apis/rerenderInAction#rerenderinaction";
+  `\n\nPlease use the 'rerenderInAction' function inside a server action without using a try-catch block\nbecause 'rerenderInAction' is a throwable caught by Brisa to rerender the component or page.\n\nMore details: ${blueLog('https://brisa.build/api-reference/server-apis/rerenderInAction#rerenderinaction')}`;
 
 export default function rerenderInAction({
   type = "component",


### PR DESCRIPTION
Related with https://github.com/brisa-build/brisa/issues/31 and https://github.com/brisa-build/brisa/issues/248

It improves a little bit the error message + avoid a process exit of the app

<img width="817" alt="Screenshot 2024-06-17 at 22 55 13" src="https://github.com/brisa-build/brisa/assets/13313058/d482cbb4-53c5-4996-a6c3-47aceecc0683">
