### PR TITLE
fix(suspense): fix regression in order of suspense

### DIFF
--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -21,7 +21,7 @@ const i18nCode = 3072;
 const brisaSize = 5846; // TODO: Reduce this size :/
 const webComponents = 731;
 const unsuspenseSize = 217;
-const rpcSize = 2367; // TODO: Reduce this size
+const rpcSize = 2368; // TODO: Reduce this size
 const lazyRPCSize = 4000; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
@@ -1109,7 +1109,7 @@ describe("utils", () => {
       const stream = renderToReadableStream(<Page />, testOptions);
       const result = await Bun.readableStreamToText(stream);
       expect(result).toBe(
-        `<html><head></head><body><div id="S:1"><b>Loading...</b></div></body><template id="U:1"><div>Test</div></template><script id="R:1">u$('1')</script></html>`,
+        `<html><head></head><body><div id="S:1"><b>Loading...</b></div></body></html><template id="U:1"><div>Test</div></template><script id="R:1">u$('1')</script>`,
       );
     });
 
@@ -2774,10 +2774,11 @@ describe("utils", () => {
           <body>
             <div id="S:1"><div>Loading...</div></div>
           </body>
-          <template id="U:1"><div>TEST</div></template>
-          <script id="R:1">u$('1')</script>
-          <script>window._S=[["test","test"]]</script>
-        </html>`),
+        </html>
+        <template id="U:1"><div>TEST</div></template>
+        <script id="R:1">u$('1')</script>
+        <script>window._S=[["test","test"]]</script>
+        `),
       );
     });
 
@@ -2840,10 +2841,11 @@ describe("utils", () => {
             <div id="S:1"><div>Loading...</div></div>
             <script>window._S=[["no-suspense","bar"]]</script>
           </body>
-          <template id="U:1"><div>Suspense</div></template>
-          <script id="R:1">u$('1')</script>
-          <script>for(let e of [["suspense","foo"]]) _S.push(e)</script>
-        </html>`),
+        </html>
+        <template id="U:1"><div>Suspense</div></template>
+        <script id="R:1">u$('1')</script>
+        <script>for(let e of [["suspense","foo"]]) _S.push(e)</script>
+        `),
       );
     });
 


### PR DESCRIPTION
Related with https://github.com/brisa-build/brisa/issues/245

I detected a regression with suspense thanks to this issue you reported @AlbertSabate, now with multiple-suspense each one is "unsuspended" in time-order.