### PR TITLE
fix(rpc): allow transfering empty string outside events

### DIFF
--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -21,7 +21,7 @@ const i18nCode = 3072;
 const brisaSize = 5846; // TODO: Reduce this size :/
 const webComponents = 758;
 const unsuspenseSize = 217;
-const rpcSize = 2357; // TODO: Reduce this size
+const rpcSize = 2446; // TODO: Reduce this size
 const lazyRPCSize = 4132; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/rpc/rpc.ts
+++ b/packages/brisa/src/utils/rpc/rpc.ts
@@ -1,10 +1,10 @@
 import { registerActions } from "@/utils/rpc/register-actions";
+import { stringifyAndCleanEvent } from "@/utils/rpc/serialize-and-clean-event";
 
 const INDICATOR = "indicator";
 const BRISA_REQUEST_CLASS = "brisa-request";
 const $document = document;
 const $window = window;
-const stringify = JSON.stringify;
 const method = "POST";
 const $Promise = Promise;
 let controller = new AbortController();
@@ -18,11 +18,11 @@ const bodyWithStore = (args?: unknown[], isFormData?: boolean) => {
     const form = new FormData(
       (args![0] as SubmitEvent).target as HTMLFormElement,
     );
-    form.append("x-s", stringify(xs));
+    form.append("x-s", stringifyAndCleanEvent(xs));
     return form;
   }
 
-  return stringify({ "x-s": xs, args }, serialize);
+  return stringifyAndCleanEvent({ "x-s": xs, args });
 };
 
 function loadRPCResolver() {
@@ -95,23 +95,6 @@ async function rpc(
     }
     store?.set(indicator, false);
   }
-}
-
-/**
- * Serialize function used to convert events to JSON.
- */
-function serialize(k: string, v: unknown) {
-  const isInstanceOf = (Instance: any) => v instanceof Instance;
-  const isNode = isInstanceOf(Node);
-
-  if (isInstanceOf(Event) || (isNode && k.match(/target/i))) {
-    const ev: Record<string, any> = {};
-    for (let field in v as any) ev[field] = (v as any)[field];
-    if (isInstanceOf(CustomEvent)) ev._wc = true;
-    return ev;
-  }
-
-  if (v != null && v !== "" && !isNode && !isInstanceOf(Window)) return v;
 }
 
 function spaNavigation(event: any) {

--- a/packages/brisa/src/utils/rpc/serialize-and-clean-event/index.test.ts
+++ b/packages/brisa/src/utils/rpc/serialize-and-clean-event/index.test.ts
@@ -1,0 +1,188 @@
+import { stringifyAndCleanEvent } from "@/utils/rpc/serialize-and-clean-event";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+
+describe("RPC", () => {
+  beforeEach(() => {
+    GlobalRegistrator.register();
+  });
+  afterEach(() => {
+    if (typeof window === "undefined") return;
+    GlobalRegistrator.unregister();
+  });
+  describe("stringifyAndCleanEvent", () => {
+    it("should stringify correctly an event", () => {
+      const dataToSerialize = { args: [new Event("click")] };
+      const result = JSON.parse(stringifyAndCleanEvent(dataToSerialize));
+      expect(result).toEqual({
+        args: [
+          {
+            defaultPrevented: false,
+            eventPhase: 0,
+            timeStamp: expect.any(Number),
+            NONE: 0,
+            CAPTURING_PHASE: 1,
+            AT_TARGET: 2,
+            BUBBLING_PHASE: 3,
+            type: "click",
+            bubbles: false,
+            cancelable: false,
+            composed: false,
+          },
+        ],
+      });
+    });
+
+    it("should add _wc property to CustomEvent", () => {
+      const customEvent = new CustomEvent("custom");
+      const dataToSerialize = { args: [customEvent] };
+      const result = JSON.parse(stringifyAndCleanEvent(dataToSerialize));
+      expect(result.args[0]._wc).toBeTrue();
+    });
+
+    it("should remove null/undefined/empty string values from the event", () => {
+      const customEvent = new CustomEvent("custom", {
+        detail: {
+          foo: null,
+          bar: undefined,
+          baz: "",
+          another: "value",
+        },
+      });
+
+      const dataToSerialize = { args: [customEvent] };
+      const result = JSON.parse(stringifyAndCleanEvent(dataToSerialize));
+      expect(result).toEqual({
+        args: [
+          {
+            AT_TARGET: 2,
+            BUBBLING_PHASE: 3,
+            CAPTURING_PHASE: 1,
+            NONE: 0,
+            _wc: true,
+            detail: {
+              another: "value",
+            },
+            eventPhase: 0,
+            defaultPrevented: false,
+            timeStamp: expect.any(Number),
+            type: "custom",
+            bubbles: false,
+            cancelable: false,
+            composed: false,
+          },
+        ],
+      });
+    });
+
+    it("should remove Window instances from the event", () => {
+      const customEvent = new CustomEvent("custom", {
+        detail: {
+          foo: new Window(), // workaround to create a Window instance on happy-dom
+        },
+      });
+
+      const dataToSerialize = { args: [customEvent] };
+      const result = JSON.parse(stringifyAndCleanEvent(dataToSerialize));
+      expect(result).toEqual({
+        args: [
+          {
+            AT_TARGET: 2,
+            BUBBLING_PHASE: 3,
+            CAPTURING_PHASE: 1,
+            NONE: 0,
+            _wc: true,
+            detail: {},
+            eventPhase: 0,
+            defaultPrevented: false,
+            timeStamp: expect.any(Number),
+            type: "custom",
+            bubbles: false,
+            cancelable: false,
+            composed: false,
+          },
+        ],
+      });
+    });
+
+    it("should remove Node instances from the event", () => {
+      const customEvent = new CustomEvent("custom", {
+        detail: {
+          foo: document.createElement("div"),
+          bar: document.createElement("span"),
+        },
+      });
+
+      const dataToSerialize = { args: [customEvent] };
+      const result = JSON.parse(stringifyAndCleanEvent(dataToSerialize));
+      expect(result).toEqual({
+        args: [
+          {
+            AT_TARGET: 2,
+            BUBBLING_PHASE: 3,
+            CAPTURING_PHASE: 1,
+            NONE: 0,
+            _wc: true,
+            detail: {},
+            eventPhase: 0,
+            defaultPrevented: false,
+            timeStamp: expect.any(Number),
+            type: "custom",
+            bubbles: false,
+            cancelable: false,
+            composed: false,
+          },
+        ],
+      });
+    });
+
+    it("should allow empoty string on another arguments that are not event", () => {
+      const dataToSerialize = { args: [new Event("click"), ""] };
+      const result = JSON.parse(stringifyAndCleanEvent(dataToSerialize));
+      expect(result).toEqual({
+        args: [
+          {
+            defaultPrevented: false,
+            eventPhase: 0,
+            timeStamp: expect.any(Number),
+            NONE: 0,
+            CAPTURING_PHASE: 1,
+            AT_TARGET: 2,
+            BUBBLING_PHASE: 3,
+            type: "click",
+            bubbles: false,
+            cancelable: false,
+            composed: false,
+          },
+          "",
+        ],
+      });
+    });
+
+    it("should allow empty string on store", () => {
+      const dataToSerialize = { "x-s": [["foo", ""]] };
+      const result = JSON.parse(stringifyAndCleanEvent(dataToSerialize));
+      expect(result).toEqual({
+        "x-s": [["foo", ""]],
+      });
+    });
+
+    it("should allow null on store", () => {
+      const dataToSerialize = { "x-s": [["foo", null]] };
+      const result = JSON.parse(stringifyAndCleanEvent(dataToSerialize));
+      expect(result).toEqual({
+        "x-s": [["foo", null]],
+      });
+    });
+
+    // For now is converted to "null" by JSON.stringify, it would be nice to fix
+    // this case: https://github.com/brisa-build/brisa/issues/279
+    it.todo("should allow undefined on store", () => {
+      const dataToSerialize = { "x-s": [["foo", undefined]] };
+      const result = JSON.parse(stringifyAndCleanEvent(dataToSerialize));
+      expect(result).toEqual({
+        "x-s": [["foo", undefined]],
+      });
+    });
+  });
+});

--- a/packages/brisa/src/utils/rpc/serialize-and-clean-event/index.ts
+++ b/packages/brisa/src/utils/rpc/serialize-and-clean-event/index.ts
@@ -1,0 +1,29 @@
+const { stringify, parse } = JSON;
+
+/**
+ * Serialize function used to convert events to JSON.
+ */
+export function stringifyAndCleanEvent(dataToSerialize: any) {
+  const event = dataToSerialize?.args?.[0] as Event;
+
+  // Replace the original event object with a serialized version of it.
+  if (event instanceof Event) {
+    dataToSerialize.args[0] = parse(
+      stringify(event, (k, v) => {
+        const isInstanceOf = (Instance: any) => v instanceof Instance;
+        const isNode = isInstanceOf(Node);
+
+        if (isInstanceOf(Event) || (isNode && k.match(/target/i))) {
+          const ev: Record<string, any> = {};
+          for (let field in v as any) ev[field] = (v as any)[field];
+          if (isInstanceOf(CustomEvent)) ev._wc = true;
+          return ev;
+        }
+
+        if (v != null && v !== "" && !isNode && !isInstanceOf(Window)) return v;
+      }),
+    );
+  }
+
+  return stringify(dataToSerialize);
+}

--- a/packages/brisa/src/utils/serialization/index.test.ts
+++ b/packages/brisa/src/utils/serialization/index.test.ts
@@ -63,5 +63,36 @@ describe("utils", () => {
       const deserialized = deserialize(serialized);
       expect(deserialized).toEqual(entries);
     });
+
+    it("should serialize and deserialize entries with null as value", () => {
+      const map = new Map<string, null>();
+      map.set("foo", null);
+      map.set("bar", null);
+      const entries = [...map];
+
+      const serialized = serialize(entries);
+      expect(serialized).toBe("[['foo',null],['bar',null]]");
+
+      const deserialized = deserialize(serialized);
+      expect(deserialized).toEqual(entries);
+    });
+
+    // For now is converted to "null" by JSON.stringify, it would be nice to fix
+    // this case: https://github.com/brisa-build/brisa/issues/279
+    it.todo(
+      "should serialize and deserialize entries with undefined as value",
+      () => {
+        const map = new Map<string, undefined>();
+        map.set("foo", undefined);
+        map.set("bar", undefined);
+        const entries = [...map];
+
+        const serialized = serialize(entries);
+        expect(serialized).toBe("[['foo'],['bar']]");
+
+        const deserialized = deserialize(serialized);
+        expect(deserialized).toEqual(entries);
+      },
+    );
   });
 });


### PR DESCRIPTION
Related with https://github.com/brisa-build/brisa/issues/279

This PR fixes the transfer of empty strings, still missing `undefined`. Curious that `null` and `undefined` are considered `nil` in JSON and then transformed to `null` when returning to JS.