### PR TITLE
fix(jsx-runtime): fix key on jsx-runtime

### DIFF
--- a/packages/brisa/src/jsx-runtime/index.test.ts
+++ b/packages/brisa/src/jsx-runtime/index.test.ts
@@ -26,5 +26,14 @@ describe("utils", () => {
         },
       });
     });
+
+    it('should append the "key" attribute to the props', () => {
+      const node = jsx("div", { id: "test", children: "Hello World" }, "key");
+
+      expect(node).toEqual({
+        type: "div",
+        props: { id: "test", children: "Hello World", key: "key" },
+      });
+    });
   });
 });

--- a/packages/brisa/src/jsx-runtime/index.ts
+++ b/packages/brisa/src/jsx-runtime/index.ts
@@ -1,7 +1,10 @@
 import type { Type, Props } from "@/types";
 
 const Fragment = (props: Props) => props.children;
-const createNode = (type: Type, props: Props) => ({ type, props });
+const createNode = (type: Type, props: Props, key: string) => {
+  Object.assign(props, { key });
+  return { type, props };
+};
 
 Fragment.__isFragment = true;
 

--- a/packages/brisa/src/utils/compile-files/index.test.ts
+++ b/packages/brisa/src/utils/compile-files/index.test.ts
@@ -368,8 +368,8 @@ describe("utils", () => {
     ${info}
     ${info}Route           | JS server | JS client (gz)  
     ${info}----------------------------------------------
-    ${info}λ /pages/index  | 190 B     | ${greenLog("3 kB")}  
-    ${info}Δ /layout       | 641 B     |
+    ${info}λ /pages/index  | 222 B     | ${greenLog("3 kB")}  
+    ${info}Δ /layout       | 705 B     |
     ${info}
     ${info}λ Server entry-points
     ${info}Δ Layout
@@ -457,8 +457,8 @@ describe("utils", () => {
     ${info}
     ${info}Route           | JS server | JS client (gz)  
     ${info}----------------------------------------------
-    ${info}λ /pages/index  | 190 B     | ${greenLog("3 kB")}  
-    ${info}Δ /layout       | 452 B     |
+    ${info}λ /pages/index  | 222 B     | ${greenLog("3 kB")}  
+    ${info}Δ /layout       | 484 B     |
     ${info}
     ${info}λ Server entry-points
     ${info}Δ Layout
@@ -528,8 +528,8 @@ describe("utils", () => {
     ${info}
     ${info}Route           | JS server | JS client (gz)  
     ${info}----------------------------------------------
-    ${info}λ /pages/index  | 190 B     | ${greenLog("187 B")}  
-    ${info}Δ /layout       | 536 B     |
+    ${info}λ /pages/index  | 222 B     | ${greenLog("187 B")}  
+    ${info}Δ /layout       | 568 B     |
     ${info}
     ${info}λ Server entry-points
     ${info}Δ Layout
@@ -636,8 +636,8 @@ describe("utils", () => {
     ${info}
     ${info}Route           | JS server | JS client (gz)  
     ${info}----------------------------------------------
-    ${info}λ /pages/index  | 190 B     | ${greenLog("4 kB")}  
-    ${info}Δ /layout       | 674 B     |
+    ${info}λ /pages/index  | 222 B     | ${greenLog("4 kB")}  
+    ${info}Δ /layout       | 738 B     |
     ${info}Ω /i18n         | 257 B     |
     ${info}
     ${info}λ Server entry-points
@@ -774,8 +774,8 @@ describe("utils", () => {
       const expected = minifyText(`
     ${info}Route                        | JS server | JS client (gz)  
     ${info}-------------------------------------------------------
-    ${info}λ /pages/index               | 190 B   | ${greenLog("0 B")}
-    ${info}λ /pages/pokemon/[slug]      | 258 B   | ${greenLog("0 B")}
+    ${info}λ /pages/index               | 222 B   | ${greenLog("0 B")}
+    ${info}λ /pages/pokemon/[slug]      | 290 B   | ${greenLog("0 B")}
     ${info}| ○ /pokemon/charizard       | 0 B     | ${greenLog("0 B")}
     ${info}| ○ /pokemon/pikachu         | 0 B     | ${greenLog("0 B")}
     ${info}
@@ -844,7 +844,7 @@ describe("utils", () => {
     ${info}Route                        | JS server | JS client (gz)  
     ${info}-------------------------------------------------------
     ${info}○ /pages/index               | 0 B     | ${greenLog("0 B")}
-    ${info}λ /pages/pokemon/[slug]      | 258 B   | ${greenLog("0 B")}
+    ${info}λ /pages/pokemon/[slug]      | 290 B   | ${greenLog("0 B")}
     ${info}| ○ /pokemon/charizard       | 0 B     | ${greenLog("0 B")}
     ${info}| ○ /pokemon/pikachu         | 0 B     | ${greenLog("0 B")}
     ${info}
@@ -913,7 +913,7 @@ describe("utils", () => {
   ${info}
   ${info}Route                                | JS server | JS client (gz)  
   ${info}-------------------------------------------------------------------
-  ${info}λ /pages/page-without-web-component  | 190 B     | ${greenLog("0 B")}  
+  ${info}λ /pages/page-without-web-component  | 222 B     | ${greenLog("0 B")}  
   ${info}λ /pages/index                       | 1 kB      | ${greenLog(
     "3 kB",
   )}  

--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -19,9 +19,9 @@ const pageWebComponents = {
 
 const i18nCode = 3072;
 const brisaSize = 5888; // TODO: Reduce this size :/
-const webComponents = 758;
+const webComponents = 792;
 const unsuspenseSize = 217;
-const rpcSize = 2445; // TODO: Reduce this size
+const rpcSize = 2446; // TODO: Reduce this size
 const lazyRPCSize = 4132; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
@@ -3494,5 +3494,22 @@ describe("utils", () => {
         ),
       );
     });
+
+    it('should render the "key" attribute on a list of elements', async () => {
+      const List = () => (
+        <>
+          <div key="1">foo</div>
+          <div key="2">bar</div>
+          <div key="3">baz</div>
+        </>
+      );
+
+      const stream = renderToReadableStream(<List />, testOptions);
+      const result = await Bun.readableStreamToText(stream);
+
+      expect(result).toBe(
+        `<div key="1">foo</div><div key="2">bar</div><div key="3">baz</div>`,
+      );
+    });
   });
 });

--- a/packages/brisa/src/utils/server-component-plugin/index.ts
+++ b/packages/brisa/src/utils/server-component-plugin/index.ts
@@ -28,9 +28,12 @@ const FN_DECLARATIONS = new Set([
 export const workaroundText = `
 const Fragment = props => props.children;
 
-function jsxDEV(type, props){ return { type, props }};
-function jsx(type, props){ return { type, props }};
-function jsxs(type, props){ return { type, props }};
+function jsx(type, props, key) {
+  Object.assign(props, { key });
+  return { type, props }
+}
+const jsxDEV = jsx;
+const jsxs = jsx;
 
 Fragment.__isFragment = true;
 `;


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/282

Example of list with server components + server actions + diffing algorithm after fix the keys:

![keys-server-components](https://github.com/brisa-build/brisa/assets/13313058/78229ec5-7b28-441e-a755-2e2622b88539)

This bug was a problem with the `key` attribute that was not right in the JSX Runtime. Now in the server components also the key attribute works. 