### PR TITLE
feat(render): add global styles to declarative shadow DOM

### DIFF
--- a/packages/brisa/src/utils/extend-stream-controller/index.ts
+++ b/packages/brisa/src/utils/extend-stream-controller/index.ts
@@ -30,6 +30,7 @@ export type Controller = {
   hasUnsuspense: boolean;
   areSignalsInjected: boolean;
   hasActionRPC: boolean;
+  styleSheetsChunks: string[];
 };
 
 type SuspensedState = {
@@ -58,6 +59,7 @@ export default function extendStreamController({
   const suspensePromises: Promise<void>[] = [];
   const finishDocument = Promise.withResolvers<void>();
   const suspensedMap = new Map<number, SuspensedState>();
+  const styleSheetsChunks: string[] = [];
   const getSuspensedState = (id: number) =>
     suspensedMap.get(id) ?? { chunk: "", openTags: 0, closeTags: 0 };
 
@@ -66,6 +68,7 @@ export default function extendStreamController({
 
   return {
     head,
+    styleSheetsChunks,
     hasHeadTag: false,
     insideHeadTag: false,
     hasUnsuspense: false,

--- a/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
@@ -3511,5 +3511,38 @@ describe("utils", () => {
         `<div key="1">foo</div><div key="2">bar</div><div key="3">baz</div>`,
       );
     });
+
+    it("should add a global style inside the declarative shadow DOM", async () => {
+      const Component = () => <div>test</div>;
+
+      const stream = renderToReadableStream(
+        <html>
+          <head>
+            <link rel="stylesheet" href="test.css"></link>
+          </head>
+          <body>
+            <SSRWebComponent Component={Component} selector="test" />
+          </body>
+        </html>,
+        testOptions,
+      );
+      const result = await Bun.readableStreamToText(stream);
+
+      expect(normalizeQuotes(result)).toBe(
+        normalizeQuotes(`<html>
+            <head>
+              <link rel="stylesheet" href="test.css"></link>
+            </head>
+            <body>
+              <test>
+                <template shadowrootmode="open">
+                  <link rel="stylesheet" href="test.css"></link>
+                  <div>test</div>
+                </template>
+              </test>
+            </body>
+          </html>`),
+      );
+    });
   });
 });

--- a/packages/brisa/src/utils/render-to-readable-stream/index.ts
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.ts
@@ -336,6 +336,11 @@ async function enqueueDuringRendering(
       }
     }
 
+    // Add global styles inside Declarative Shadow DOM of Web Components
+    else if (type === "template" && props.shadowrootmode === "open") {
+      controller.enqueue(controller.styleSheetsChunks.join(""), suspenseId);
+    }
+
     // Node Content
     await enqueueChildren(
       props.children,
@@ -365,6 +370,17 @@ async function enqueueDuringRendering(
           suspenseId,
         );
       }
+    }
+
+    // StyleSheets: save to use it inside Declarative Shadow DOM of Web Components
+    else if (
+      type === "link" &&
+      props.rel === "stylesheet" &&
+      controller.insideHeadTag
+    ) {
+      controller.styleSheetsChunks.push(
+        `<link rel="stylesheet" href="${props.href}"></link>`,
+      );
     }
 
     // Close body tag


### PR DESCRIPTION
Related with https://github.com/brisa-build/brisa/issues/156

This allows SSR web components within the declarative shadow DOM to also adapt the global styles. After hydration, this part was already being done, but now it also applies if the web is loaded without JS where the web component cannot hydrate, in this case the Shadow DOM also has the global style adopted.

Before this PR: if you load the page without JavaScript and use global styles in a web component, you will not see them reflected. If you enable JS then yes.

With this PR: Whether you disable or enable JavaScript, it adopts the global styles, and the web component should display the same before and after hydration.