### PR TITLE
feat: disable global styles on web components also on SSR

### DIFF
--- a/packages/brisa/src/types/index.d.ts
+++ b/packages/brisa/src/types/index.d.ts
@@ -615,7 +615,7 @@ export interface BaseWebContext {
    *
    * - [How to use `self`](https://brisa.build/api-reference/components/web-context#self)
    */
-  self?: HTMLElement;
+  self: HTMLElement;
 }
 
 /**

--- a/packages/brisa/src/utils/render-attributes/index.test.ts
+++ b/packages/brisa/src/utils/render-attributes/index.test.ts
@@ -1434,5 +1434,21 @@ describe("utils", () => {
 
       expect(attributes).toBe(` data-action`);
     });
+
+    it("should ignore __skipGlobalCSS attribute", () => {
+      const request = extendRequestContext({
+        originalRequest: new Request("https://example.com"),
+      });
+
+      const attributes = renderAttributes({
+        elementProps: {
+          __skipGlobalCSS: true,
+        },
+        request,
+        type: "div",
+      });
+
+      expect(attributes).toBe("");
+    });
   });
 });

--- a/packages/brisa/src/utils/render-attributes/index.ts
+++ b/packages/brisa/src/utils/render-attributes/index.ts
@@ -13,7 +13,11 @@ import substituteI18nRouteValues from "@/utils/substitute-i18n-route-values";
 import isAnAction from "@/utils/is-an-action";
 import { addBasePathToStringURL } from "@/utils/base-path";
 
-const PROPS_TO_IGNORE = new Set(["children", "__isWebComponent"]);
+const PROPS_TO_IGNORE = new Set([
+  "children",
+  "__isWebComponent",
+  "__skipGlobalCSS",
+]);
 const VALUES_TYPE_TO_IGNORE = new Set(["function", "undefined"]);
 const fakeOrigin = "http://localhost";
 

--- a/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
@@ -13,7 +13,13 @@ import {
 import renderToReadableStream from ".";
 import { getConstants } from "@/constants";
 import { normalizeQuotes, toInline } from "@/helpers";
-import type { ComponentType, I18n, RequestContext, Translate } from "@/types";
+import type {
+  ComponentType,
+  I18n,
+  RequestContext,
+  Translate,
+  WebContext,
+} from "@/types";
 import createContext from "@/utils/create-context";
 import navigate from "@/utils/navigate";
 import dangerHTML from "@/utils/danger-html";
@@ -3537,6 +3543,41 @@ describe("utils", () => {
               <test>
                 <template shadowrootmode="open">
                   <link rel="stylesheet" href="test.css"></link>
+                  <div>test</div>
+                </template>
+              </test>
+            </body>
+          </html>`),
+      );
+    });
+
+    it("should NOT add a global style inside the declarative shadow DOM with 'self.shadowRoot.adoptedStyleSheets = []'", async () => {
+      const Component = ({}, { self }: WebContext) => {
+        self.shadowRoot!.adoptedStyleSheets = [];
+        return <div>test</div>;
+      };
+
+      const stream = renderToReadableStream(
+        <html>
+          <head>
+            <link rel="stylesheet" href="test.css"></link>
+          </head>
+          <body>
+            <SSRWebComponent Component={Component} selector="test" />
+          </body>
+        </html>,
+        testOptions,
+      );
+      const result = await Bun.readableStreamToText(stream);
+
+      expect(normalizeQuotes(result)).toBe(
+        normalizeQuotes(`<html>
+            <head>
+              <link rel="stylesheet" href="test.css"></link>
+            </head>
+            <body>
+              <test>
+                <template shadowrootmode="open">
                   <div>test</div>
                 </template>
               </test>

--- a/packages/brisa/src/utils/render-to-readable-stream/index.ts
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.ts
@@ -337,7 +337,11 @@ async function enqueueDuringRendering(
     }
 
     // Add global styles inside Declarative Shadow DOM of Web Components
-    else if (type === "template" && props.shadowrootmode === "open") {
+    else if (
+      type === "template" &&
+      props.shadowrootmode === "open" &&
+      !props.__skipGlobalCSS
+    ) {
       controller.enqueue(controller.styleSheetsChunks.join(""), suspenseId);
     }
 

--- a/packages/brisa/src/utils/ssr-web-component/index.test.tsx
+++ b/packages/brisa/src/utils/ssr-web-component/index.test.tsx
@@ -661,5 +661,46 @@ describe("utils", () => {
         "hello world",
       );
     });
+
+    it('should work "self.shadowRoot.adoptedStyleSheets = []" in SSR', async () => {
+      const Component = ({}, { self }: WebContext) => {
+        self.shadowRoot!.adoptedStyleSheets = [];
+        return <div>hello world</div>;
+      };
+      const selector = "my-component";
+
+      const output = (await SSRWebComponent(
+        {
+          Component,
+          selector,
+        },
+        requestContext,
+      )) as any;
+
+      expect(output.type).toBe(selector);
+      expect(output.props.children[0].type).toBe("template");
+      expect(output.props.children[0].props.shadowrootmode).toBe("open");
+      expect(output.props.children[0].props.__skipGlobalCSS).toBe(true);
+    });
+
+    it('should __skipGlobalCSS be false whithout "self.shadowRoot.adoptedStyleSheets = []"', async () => {
+      const Component = ({}, { self }: WebContext) => {
+        return <div>hello world</div>;
+      };
+      const selector = "my-component";
+
+      const output = (await SSRWebComponent(
+        {
+          Component,
+          selector,
+        },
+        requestContext,
+      )) as any;
+
+      expect(output.type).toBe(selector);
+      expect(output.props.children[0].type).toBe("template");
+      expect(output.props.children[0].props.shadowrootmode).toBe("open");
+      expect(output.props.children[0].props.__skipGlobalCSS).toBe(false);
+    });
   });
 });

--- a/packages/docs/building-your-application/styling/web-components.md
+++ b/packages/docs/building-your-application/styling/web-components.md
@@ -31,10 +31,9 @@ However, if you want to disable the automatic adopted global style sheets, you c
 ```tsx
 import type { WebContext } from "brisa";
 
-export default function MyWebComponent({}, { effect, self, css }: WebContext) {
-  effect(() => {
-    self.shadowRoot.adoptedStyleSheets = [];
-  });
+export default function MyWebComponent({}, { self, css }: WebContext) {
+  // Turn off the automatic adopted global style sheets (also work in SSR)
+  self.shadowRoot.adoptedStyleSheets = [];
 
   // It only applies this encapsulated style:
   css`
@@ -49,6 +48,10 @@ export default function MyWebComponent({}, { effect, self, css }: WebContext) {
   return <div>Hello World</div>;
 }
 ```
+
+> [!TIP]
+>
+> You can use the `self` object to access the shadow DOM and manipulate it directly. During SSR, the `self` object is an object with an empty `shadowRoot`, but when you add an empty array on `adoptedStyleSheets` property, it will disable the automatic adopted global style sheets on [Declarative Shadow DOM](https://developer.chrome.com/docs/css-ui/declarative-shadow-dom) too.
 
 ## CSS Template String
 


### PR DESCRIPTION
Related with https://github.com/brisa-build/brisa/issues/156

I have done that by doing:

```js
self.shadowRoot.adoptedStyleSheets = [];
```

Also in SSR it works to disable the adopted global style sheets. As soon as this empty array exists during the server rendering, the styles are not put in the Declarative Shadow DOM.

By default the global styles are always set to the web components, however there is this option to disable it if necessary.

-----

## Global Styles in Web Components

Web components by default encapsulate their styles inside their shadow DOM, the downside of this is that you can't style them from the outside, so global styles won't affect them. In Brisa, we adopted by default the global style sheets to the shadow DOM, in this way works more like others frameworks like React or Vue and you don't need to worry about this.

To apply global styles, you need to import the CSS file in the [**`src/layout.tsx`**](/building-your-application/routing/pages-and-layouts) file:

```tsx
import "./global.css";
```

> [!NOTE]
>
> For more information about global styles, check the [Global Styles](/building-your-application/styling/global-styles) page.

However, if you want to disable the automatic adopted global style sheets, you can do it by resetting the [`adoptedStyleSheets`](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets) property:

```tsx
import type { WebContext } from "brisa";

export default function MyWebComponent({}, { self, css }: WebContext) {
  // Turn off the automatic adopted global style sheets (also work in SSR)
  self.shadowRoot.adoptedStyleSheets = [];

  // It only applies this encapsulated style:
  css`
    div {
      color: red;
    }
  `;

  // It doesn't apply the "div" styles defined in the
  // global style sheets, only the ones defined in the
  // CSS template literal will be applied
  return <div>Hello World</div>;
}
```

> [!TIP]
>
> You can use the `self` object to access the shadow DOM and manipulate it directly. During SSR, the `self` object is an object with an empty `shadowRoot`, but when you add an empty array on `adoptedStyleSheets` property, it will disable the automatic adopted global style sheets on [Declarative Shadow DOM](https://developer.chrome.com/docs/css-ui/declarative-shadow-dom) too.