### PR TITLE
fix(build): configure meriyah parser to use latest ECMA features

### DIFF
--- a/packages/brisa/src/utils/ast/index.ts
+++ b/packages/brisa/src/utils/ast/index.ts
@@ -18,6 +18,7 @@ export default function AST(loader: JavaScriptLoader = "tsx") {
       return parseScript(transpiler.transformSync(code), {
         jsx: true,
         module: true,
+        next: true
       });
     },
     generateCodeFromAST(ast: ESTree.Program) {


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/310

It is only one line of code, but this allows to use the latest ECMAScript features in our database, related with the crash error of #310 