### PR TITLE
feat(store): allow `store.transferToClient` before setting the value

### DIFF
--- a/packages/brisa/src/utils/extend-request-context/index.test.ts
+++ b/packages/brisa/src/utils/extend-request-context/index.test.ts
@@ -8,6 +8,7 @@ import { type RequestContext } from "@/types";
 import { ENCRYPT_NONTEXT_PREFIX, ENCRYPT_PREFIX } from "@/utils/crypto";
 import { toInline } from "@/helpers";
 import { RenderInitiator } from "@/core/server";
+import { getTransferedServerStoreToClient } from "@/utils/transfer-store-service";
 
 describe("brisa core", () => {
   afterEach(() => {
@@ -83,8 +84,8 @@ describe("brisa core", () => {
       requestContext.store.set("foo", "bar");
       requestContext.store.transferToClient(["foo"], { encrypt: true });
 
-      // @ts-ignore
-      const value = requestContext.webStore.get("foo");
+      const transferedStore = getTransferedServerStoreToClient(requestContext);
+      const value = transferedStore.get("foo");
 
       expect(value).not.toBe("bar");
       expect(value).toBeTypeOf("string");
@@ -104,8 +105,8 @@ describe("brisa core", () => {
       requestContext.store.set("foo", { bar: "baz" });
       requestContext.store.transferToClient(["foo"], { encrypt: true });
 
-      // @ts-ignore
-      const value = requestContext.webStore.get("foo");
+      const transferedStore = getTransferedServerStoreToClient(requestContext);
+      const value = transferedStore.get("foo");
 
       expect(value).not.toBe("bar");
       expect(value).toBeTypeOf("string");
@@ -231,8 +232,9 @@ describe("brisa core", () => {
       requestContext.store.set("foo", "bar");
       requestContext.store.set("baz", "qux");
       requestContext.store.transferToClient(["foo"]);
-      expect((requestContext as any).webStore.get("foo")).toBe("bar");
-      expect((requestContext as any).webStore.get("baz")).toBe(undefined);
+      const transferedStore = getTransferedServerStoreToClient(requestContext);
+      expect(transferedStore.get("foo")).toBe("bar");
+      expect(transferedStore.get("baz")).toBe(undefined);
     });
 
     it("should add the indicate function", () => {

--- a/packages/brisa/src/utils/extend-request-context/index.ts
+++ b/packages/brisa/src/utils/extend-request-context/index.ts
@@ -46,13 +46,8 @@ export default function extendRequestContext({
     keys: string[],
     options?: TransferOptions,
   ) => {
-    const shouldEncrypt = options?.encrypt ?? false;
-    const store = originalRequest.store;
-    const webStore = originalRequest.webStore;
-
     for (let key of keys) {
-      const value = store.get(key);
-      webStore.set(key, shouldEncrypt ? encrypt(value) : value);
+      originalRequest.webStore.set(key, options);
     }
   };
 

--- a/packages/brisa/src/utils/extend-stream-controller/index.test.ts
+++ b/packages/brisa/src/utils/extend-stream-controller/index.test.ts
@@ -286,8 +286,29 @@ describe("extendStreamController", () => {
       originalRequest: new Request("http://localhost"),
     });
 
-    // @ts-ignore
-    req.webStore.set("test", "test");
+    req.store.set("test", "test");
+    req.store.transferToClient(["test"]);
+
+    const controller = extendStreamController({
+      controller: mockController,
+      request: req,
+    });
+    controller.transferStoreToClient();
+
+    expect(mockController.enqueue.mock.calls).toEqual([
+      [`<script>window._S=[["test","test"]]</script>`],
+    ]);
+  });
+
+  it("should transferStoreToClient can be declared before the setter", () => {
+    const req = extendRequestContext({
+      originalRequest: new Request("http://localhost"),
+    });
+
+    // First the transfer
+    req.store.transferToClient(["test"]);
+    // After the set
+    req.store.set("test", "test");
 
     const controller = extendStreamController({
       controller: mockController,
@@ -307,8 +328,8 @@ describe("extendStreamController", () => {
       }),
     });
 
-    // @ts-ignore
-    req.webStore.set("test", "test");
+    req.store.set("test", "test");
+    req.store.transferToClient(["test"]);
 
     const controller = extendStreamController({
       controller: mockController,
@@ -330,8 +351,8 @@ describe("extendStreamController", () => {
 
     req.renderInitiator = RenderInitiator.SPA_NAVIGATION;
 
-    // @ts-ignore
-    req.webStore.set("test", "test");
+    req.store.set("test", "test");
+    req.store.transferToClient(["test"]);
 
     const controller = extendStreamController({
       controller: mockController,
@@ -351,8 +372,8 @@ describe("extendStreamController", () => {
 
     req.renderInitiator = RenderInitiator.SERVER_ACTION;
 
-    // @ts-ignore
-    req.webStore.set("test", "test");
+    req.store.set("test", "test");
+    req.store.transferToClient(["test"]);
 
     const controller = extendStreamController({
       controller: mockController,
@@ -370,8 +391,8 @@ describe("extendStreamController", () => {
       originalRequest: new Request("http://localhost"),
     });
 
-    // @ts-ignore
-    req.webStore.set("some", "foo");
+    req.store.set("some", "foo");
+    req.store.transferToClient(["some"]);
 
     const controller = extendStreamController({
       controller: mockController,
@@ -379,8 +400,8 @@ describe("extendStreamController", () => {
     });
     controller.transferStoreToClient();
 
-    // @ts-ignore
-    req.webStore.set("another", "bar");
+    req.store.set("another", "bar");
+    req.store.transferToClient(["another"]);
 
     controller.transferStoreToClient();
 
@@ -395,8 +416,8 @@ describe("extendStreamController", () => {
       originalRequest: new Request("http://localhost"),
     });
 
-    // @ts-ignore
-    req.webStore.set("some", "foo");
+    req.store.set("some", "foo");
+    req.store.transferToClient(["some"]);
 
     const controller = extendStreamController({
       controller: mockController,
@@ -405,8 +426,8 @@ describe("extendStreamController", () => {
     controller.transferStoreToClient();
 
     controller.areSignalsInjected = true;
-    // @ts-ignore
-    req.webStore.set("another", "bar");
+    req.store.set("another", "bar");
+    req.store.transferToClient(["another"]);
 
     controller.transferStoreToClient();
 
@@ -423,8 +444,8 @@ describe("extendStreamController", () => {
       originalRequest: new Request("http://localhost"),
     });
 
-    // @ts-ignore
-    req.webStore.set("some", "foo");
+    req.store.set("some", "foo");
+    req.store.transferToClient(["some"]);
 
     const controller = extendStreamController({
       controller: mockController,

--- a/packages/brisa/src/utils/extend-stream-controller/index.ts
+++ b/packages/brisa/src/utils/extend-stream-controller/index.ts
@@ -1,5 +1,6 @@
 import { RenderInitiator } from "@/public-constants";
 import type { ComponentType, RequestContext } from "@/types";
+import { getTransferedServerStoreToClient } from "@/utils/transfer-store-service";
 
 export type ChunksOptions = {
   chunk: string;
@@ -101,7 +102,7 @@ export default function extendStreamController({
       ids.add(id);
     },
     transferStoreToClient(suspenseId?: number) {
-      const store = (request as any).webStore as Map<string, any>;
+      const store = getTransferedServerStoreToClient(request);
       const areSignalsInjected = this.areSignalsInjected;
 
       if (store.size === 0) return;
@@ -126,7 +127,7 @@ export default function extendStreamController({
 
       this.enqueue(script, suspenseId);
 
-      store.clear();
+      (request as any).webStore.clear();
       storeTransfered = true;
     },
     hasId(id) {

--- a/packages/brisa/src/utils/feedback-error/index.test.ts
+++ b/packages/brisa/src/utils/feedback-error/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, spyOn, expect, it, beforeEach, afterEach } from "bun:test";
 import feedbackError from ".";
 import extendRequestContext from "@/utils/extend-request-context";
+import { getTransferedServerStoreToClient } from "@/utils/transfer-store-service";
 
 let logSpy: ReturnType<typeof spyOn>;
 
@@ -34,7 +35,8 @@ describe("feedbackError", () => {
     feedbackError(error, req);
     expect(logSpy).toHaveBeenCalled();
 
-    const storeErrors = (req as any).webStore.get("__BRISA_ERRORS__");
+    const webStore = getTransferedServerStoreToClient(req);
+    const storeErrors = webStore.get("__BRISA_ERRORS__");
     expect(storeErrors).toHaveLength(1);
     expect(storeErrors[0].title).toBe("ERR_DLOPEN_FAILED");
   });

--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -21,7 +21,7 @@ const i18nCode = 3072;
 const brisaSize = 5888; // TODO: Reduce this size :/
 const webComponents = 792;
 const unsuspenseSize = 217;
-const rpcSize = 2457; // TODO: Reduce this size
+const rpcSize = 2456; // TODO: Reduce this size
 const lazyRPCSize = 4189; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/log/log-build.test.ts
+++ b/packages/brisa/src/utils/log/log-build.test.ts
@@ -3,6 +3,7 @@ import { logTable, logError, logBuildError } from "./log-build";
 import { getConstants } from "@/constants";
 import extendRequestContext from "@/utils/extend-request-context";
 import type { RequestContext } from "@/types";
+import { getTransferedServerStoreToClient } from "@/utils/transfer-store-service";
 
 describe("utils", () => {
   describe("logTable", () => {
@@ -52,7 +53,7 @@ describe("utils", () => {
       logError({ messages, docTitle, docLink, req, stack });
 
       const output = mockLog.mock.results.map((t) => t.value).join("\n");
-      const store = (req as any).webStore as RequestContext["store"];
+      const store = getTransferedServerStoreToClient(req);
 
       expect(output).toContain("Error message 1");
       expect(output).toContain("Error message 2");

--- a/packages/brisa/src/utils/resolve-action/index.ts
+++ b/packages/brisa/src/utils/resolve-action/index.ts
@@ -8,6 +8,7 @@ import { AVOID_DECLARATIVE_SHADOW_DOM_SYMBOL } from "@/utils/ssr-web-component";
 import { getNavigateMode, isNavigateThrowable } from "@/utils/navigate/utils";
 import renderToReadableStream from "@/utils/render-to-readable-stream";
 import getPageComponentWithHeaders from "@/utils/get-page-component-with-headers";
+import { getTransferedServerStoreToClient } from "@/utils/transfer-store-service";
 
 type ResolveActionParams = {
   req: RequestContext;
@@ -150,7 +151,7 @@ export default async function resolveAction({
 }
 
 export function resolveStore(req: RequestContext) {
-  return JSON.stringify([...(req as any).webStore]);
+  return JSON.stringify([...getTransferedServerStoreToClient(req)]);
 }
 
 function extractComponentId(dependencies: Dependencies, actionId: string) {

--- a/packages/brisa/src/utils/transfer-store-service/index.test.ts
+++ b/packages/brisa/src/utils/transfer-store-service/index.test.ts
@@ -1,6 +1,8 @@
 import { encrypt } from "@/utils/crypto";
 import extendRequestContext from "@/utils/extend-request-context";
-import transferStoreService from "@/utils/transfer-store-service";
+import transferStoreService, {
+  getTransferedServerStoreToClient,
+} from "@/utils/transfer-store-service";
 import { describe, it, expect } from "bun:test";
 
 describe("utils", () => {
@@ -31,11 +33,11 @@ describe("utils", () => {
         }),
       });
 
-      const res = new Response();
       const transferStore = await transferStoreService(req);
       transferStore.transferClientStoreToServer();
+      const webStore = getTransferedServerStoreToClient(req);
 
-      expect((req as any).webStore).toEqual(new Map([["key", "value"]]));
+      expect(webStore).toEqual(new Map([["key", "value"]]));
     });
 
     it("should transfer store to req.store without encrypted value", async () => {
@@ -69,9 +71,10 @@ describe("utils", () => {
 
       const transferStore = await transferStoreService(req);
       transferStore.transferClientStoreToServer();
+      const webStore = getTransferedServerStoreToClient(req);
 
       // Encrypt value
-      expect((req as any).webStore).toEqual(new Map([["key", valueEncrypted]]));
+      expect(webStore).toEqual(new Map([["key", valueEncrypted]]));
     });
 
     // TODO: awaiting this Bun issue to be solved:
@@ -108,6 +111,32 @@ describe("utils", () => {
 
       const transferStore = await transferStoreService(req);
       expect(transferStore.body).toEqual({ key: "value" });
+    });
+  });
+
+  describe("getTransferedServerStoreToClient", () => {
+    it("should return the webStore", () => {
+      const req = extendRequestContext({
+        originalRequest: new Request("http://localhost:3000"),
+      });
+      req.store.set("key", "foo");
+      (req as any).webStore = new Map([["key", { encrypt: false }]]);
+
+      const webStore = getTransferedServerStoreToClient(req);
+
+      expect(webStore).toEqual(new Map([["key", "foo"]]));
+    });
+
+    it("should return the webStore with encrypted value", () => {
+      const req = extendRequestContext({
+        originalRequest: new Request("http://localhost:3000"),
+      });
+      req.store.set("key", "foo");
+      (req as any).webStore = new Map([["key", { encrypt: true }]]);
+
+      const webStore = getTransferedServerStoreToClient(req);
+
+      expect(webStore.get("key")).toStartWith("__encrypted:");
     });
   });
 });

--- a/packages/brisa/src/utils/transfer-store-service/index.ts
+++ b/packages/brisa/src/utils/transfer-store-service/index.ts
@@ -3,6 +3,7 @@ import {
   ENCRYPT_NONTEXT_PREFIX,
   ENCRYPT_PREFIX,
   decrypt,
+  encrypt,
 } from "@/utils/crypto";
 import { logError } from "@/utils/log/log-build";
 
@@ -57,4 +58,17 @@ export default async function transferStoreService(req: RequestContext) {
       }
     },
   };
+}
+
+export function getTransferedServerStoreToClient(request: RequestContext) {
+  const store = new Map();
+  const webStore = (request as any).webStore as Map<string, any>;
+
+  for (const key of webStore.keys()) {
+    const shouldEncrypt = webStore.get(key)?.encrypt ?? false;
+    const value = request.store.get(key);
+    store.set(key, shouldEncrypt ? encrypt(value) : value);
+  }
+
+  return store;
 }


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/316

This PR addresses the issue where transferToClient was executed immediately upon being called, resulting in an intermediate transfer to webStore. The proposed change defers the actual transfer to the end, allowing webStore to temporarily store the property and options (e.g., encrypt) until the final execution. This ensures that both of the following sequences are valid:

```tsx
store.set('foo', 'bar');
store.transferToClient(['foo']);
```

and 

```tsx
store.transferToClient(['foo']);
store.set('foo', 'bar');
```

This enhancement allows for `store.transferToClient` to be set once during the initial render, eliminating the need to set it again during subsequent server actions.

