### PR TITLE
fix(windows): fix route sep

### DIFF
--- a/packages/brisa/src/utils/compile-files/index.ts
+++ b/packages/brisa/src/utils/compile-files/index.ts
@@ -149,8 +149,8 @@ export default async function compileFiles() {
       success: false,
       logs: [
         { message: "Error compiling web components" } as
-        | BuildMessage
-        | ResolveMessage,
+          | BuildMessage
+          | ResolveMessage,
       ],
       pagesSize,
     };
@@ -270,11 +270,11 @@ async function compileClientCodePage(
   const layoutWebComponents = webComponentsPerEntrypoint[layoutBuildPath];
   const layoutCode = layoutBuildPath
     ? await getClientCodeInPage({
-      pagePath: layoutBuildPath,
-      allWebComponents,
-      pageWebComponents: layoutWebComponents,
-      integrationsPath,
-    })
+        pagePath: layoutBuildPath,
+        allWebComponents,
+        pageWebComponents: layoutWebComponents,
+        integrationsPath,
+      })
     : null;
 
   for (const page of pages) {
@@ -401,11 +401,11 @@ async function compileClientCodePage(
 
   const intrinsicCustomElements = `export interface IntrinsicCustomElements {
   ${Object.entries(allWebComponents)
-      .map(
-        ([name, location]) =>
-          `'${name}': JSX.WebComponentAttributes<typeof import("${location}").default>;`,
-      )
-      .join("\n")}
+    .map(
+      ([name, location]) =>
+        `'${name}': JSX.WebComponentAttributes<typeof import("${location}").default>;`,
+    )
+    .join("\n")}
 }`;
 
   Bun.write(join(internalPath, "types.ts"), intrinsicCustomElements);


### PR DESCRIPTION
related with https://github.com/brisa-build/brisa/issues/151

This is the build of the client components, I see that I was using / instead of “sep” to see if it was a page, maybe that was the reason why the web components were not working in Brisa. Maybe there is another reason, tell me if this fixes it or not, but at least this was incorrect and now with this change will make it work in Windows too.