### PR TITLE
fix(web-components): adopt link with href to global styles

### DIFF
--- a/packages/brisa/src/utils/brisa-element/index.test.ts
+++ b/packages/brisa/src/utils/brisa-element/index.test.ts
@@ -3052,6 +3052,33 @@ describe('utils', () => {
       ]);
     });
 
+    it('should automatic adopt the global styles sheets with link with href from document.styleSheets', () => {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = 'styles.css';
+
+      document.head.appendChild(link);
+
+      const Component = () => {
+        return ['div', {}, ''];
+      };
+
+      customElements.define('style-sheet-component', brisaElement(Component));
+      document.body.innerHTML = '<style-sheet-component />';
+
+      const styleSheetComponent = document.querySelector(
+        'style-sheet-component',
+      ) as HTMLElement;
+
+      const expectedSheet = new CSSStyleSheet();
+
+      expectedSheet.replaceSync('@import url(styles.css);');
+
+      expect(styleSheetComponent?.shadowRoot?.adoptedStyleSheets).toEqual([
+        expectedSheet,
+      ]);
+    });
+
     it('should adopt more than one style sheet from document.styleSheets', async () => {
       const style = document.createElement('style');
       const style2 = document.createElement('style');

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -141,8 +141,9 @@ export default function brisaElement(
 
       // Add global CSS to apply to the shadowRoot
       const css: string[] = [];
-      for (const { cssRules } of $document.styleSheets) {
-        for (const rule of cssRules) css.push(rule.cssText);
+      for (const sheet of $document.styleSheets) {
+        if (sheet.href) css.push(`@import url('${sheet.href}');`);
+        else for (const rule of sheet.cssRules) css.push(rule.cssText);
       }
       sheet.replaceSync(css.join(''));
       shadowRoot.adoptedStyleSheets.push(sheet);

--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -18,10 +18,10 @@ const pageWebComponents = {
 };
 
 const i18nCode = 3072;
-const brisaSize = 5898; // TODO: Reduce this size :/
+const brisaSize = 5949; // TODO: Reduce this size :/
 const webComponents = 792;
 const unsuspenseSize = 217;
-const rpcSize = 2479; // TODO: Reduce this size
+const rpcSize = 2478; // TODO: Reduce this size
 const lazyRPCSize = 4188; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/331

This fixes it. We will have to take into account the link styles with href. We will have to dedicate to reduce the size of the client build since it is growing a lot lately, but better in another PR.