### PR TITLE
fix: try to fix path

### DIFF
--- a/packages/brisa/cli.cjs
+++ b/packages/brisa/cli.cjs
@@ -23,7 +23,7 @@ async function main() {
   const __CRYPTO_KEY__ = crypto.randomBytes(32).toString('hex');
   const __CRYPTO_IV__ = crypto.randomBytes(8).toString('hex');
   const BRISA_BUILD_FOLDER =
-    env.BRISA_BUILD_FOLDER || path.join(cwd(), 'build');
+    env.BRISA_BUILD_FOLDER || path.resolve(cwd(), 'build');
 
   const prodOptions = {
     stdio: 'inherit',

--- a/packages/brisa/src/constants.ts
+++ b/packages/brisa/src/constants.ts
@@ -18,13 +18,14 @@ const staticExportOutputOption = new Set([
   'android',
   'ios',
 ]);
-const srcDir = path.join(rootDir, 'src');
-const buildDir = process.env.BRISA_BUILD_FOLDER ?? path.join(rootDir, 'build');
+const srcDir = path.resolve(rootDir, 'src');
+const buildDir =
+  process.env.BRISA_BUILD_FOLDER ?? path.resolve(rootDir, 'build');
 const PAGE_404 = '/_404';
 const PAGE_500 = '/_500';
 const integrations = await importFileIfExists(
   '_integrations',
-  path.join(buildDir, 'web-components'),
+  path.resolve(buildDir, 'web-components'),
 );
 const I18N_CONFIG = (await importFileIfExists('i18n', buildDir))
   ?.default as I18nConfig;
@@ -111,8 +112,8 @@ const constants = {
   BUILD_DIR: buildDir,
   ROOT_DIR: rootDir,
   SRC_DIR: srcDir,
-  ASSETS_DIR: path.join(buildDir, 'public'),
-  PAGES_DIR: path.join(buildDir, 'pages'),
+  ASSETS_DIR: path.resolve(buildDir, 'public'),
+  PAGES_DIR: path.resolve(buildDir, 'pages'),
   I18N_CONFIG,
   LOG_PREFIX: {
     WAIT: cyanLog('[ wait ]') + ' ',


### PR DESCRIPTION
Related https://github.com/brisa-build/brisa/issues/151

I have changed it to `path.resolve` so that it resolves to the absolute path. It's more of an experiment since I don't have Windows. I am waiting for feedback to see if this solves it or not. Next week I have managed to get a Windows, which will make fixing this issue easier.