### PR TITLE
fix(web-components): fix WICG issue importing styles

### DIFF
--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -142,8 +142,14 @@ export default function brisaElement(
       // Add global CSS to apply to the shadowRoot
       const css: string[] = [];
       for (const sheet of $document.styleSheets) {
-        if (sheet.href) css.push(`@import url('${sheet.href}');`);
-        else for (const rule of sheet.cssRules) css.push(rule.cssText);
+        try {
+          for (const rule of sheet.cssRules) css.push(rule.cssText);
+        } catch (e) {
+          // We only want to @import() when there aren't any rules, otherwise
+          // it's a WICG issue:
+          // https://github.com/WICG/construct-stylesheets/issues/119#issuecomment-588352418
+          css.push(`@import url('${sheet.href}');`);
+        }
       }
       sheet.replaceSync(css.join(''));
       shadowRoot.adoptedStyleSheets.push(sheet);

--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -18,10 +18,10 @@ const pageWebComponents = {
 };
 
 const i18nCode = 3072;
-const brisaSize = 5949; // TODO: Reduce this size :/
+const brisaSize = 5947; // TODO: Reduce this size :/
 const webComponents = 792;
 const unsuspenseSize = 217;
-const rpcSize = 2479; // TODO: Reduce this size
+const rpcSize = 2477; // TODO: Reduce this size
 const lazyRPCSize = 4188; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size


### PR DESCRIPTION
Related with https://github.com/brisa-build/brisa/issues/331

Fix this issue https://github.com/WICG/construct-stylesheets/issues/119#issuecomment-588352418

This happened when there were both the rules and the href, in this case you have to load the rules and not the @import, otherwise a warning came out and did not do it right:

<img width="600" alt="Screenshot 2024-07-31 at 02 47 26" src="https://github.com/user-attachments/assets/8e0e89ee-4662-425f-9c4d-52ec34017acc">
