### PR TITLE
feat: do readableStreamToText runtime-agnostic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Bunjs
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.22
+          bun-version: 1.1.24
       - name: Install dependencies
         run: bun install
       - run: bun run build

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "validate-urls": "bun run scripts/validate-urls.ts",
     "www:dev": "bun run --cwd packages/www dev"
   },
-  "packageManager": "bun@1.1.22",
+  "packageManager": "bun@1.1.24",
   "engines": {
-    "bun": ">= 1.1.22",
+    "bun": ">= 1.1.24",
     "npm": "please-use-bun",
     "yarn": "please-use-bun",
     "pnpm": "please-use-bun"

--- a/packages/brisa/package.json
+++ b/packages/brisa/package.json
@@ -88,9 +88,9 @@
   "peerDependencies": {
     "typescript": "5.5.4"
   },
-  "packageManager": "bun@1.1.22",
+  "packageManager": "bun@1.1.24",
   "engines": {
-    "bun": ">= 1.1.22",
+    "bun": ">= 1.1.24",
     "npm": "please-use-bun",
     "yarn": "please-use-bun",
     "pnpm": "please-use-bun"

--- a/packages/brisa/src/utils/readable-stream-to-text/index.test.ts
+++ b/packages/brisa/src/utils/readable-stream-to-text/index.test.ts
@@ -1,0 +1,62 @@
+import { agnosticReadableStreamToText } from '@/utils/readable-stream-to-text';
+import { it, expect, describe } from 'bun:test';
+
+describe('utils', () => {
+  describe('readable-stream-to-text', () => {
+    it('should convert a readable stream to text', async () => {
+      const text = 'Hello, world!';
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(text));
+          controller.close();
+        },
+      });
+
+      const result = await agnosticReadableStreamToText(stream);
+
+      expect(result).toBe(text);
+    });
+
+    it('should convert a readable stream to text with multiple chunks', async () => {
+      const text = 'Hello, world!';
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(text.slice(0, 6)));
+          controller.enqueue(new TextEncoder().encode(text.slice(6)));
+          controller.close();
+        },
+      });
+
+      const result = await agnosticReadableStreamToText(stream);
+
+      expect(result).toBe(text);
+    });
+
+    it('should convert empty readable stream to empty text', async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+
+      const result = await agnosticReadableStreamToText(stream);
+
+      expect(result).toBe('');
+    });
+
+    it('should correctly handle binary data in the readable stream', async () => {
+      // "Hello" in ASCII
+      const binaryData = new Uint8Array([72, 101, 108, 108, 111]);
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(binaryData);
+          controller.close();
+        },
+      });
+
+      const result = await agnosticReadableStreamToText(stream);
+
+      expect(result).toBe('Hello');
+    });
+  });
+});

--- a/packages/brisa/src/utils/readable-stream-to-text/index.ts
+++ b/packages/brisa/src/utils/readable-stream-to-text/index.ts
@@ -1,0 +1,21 @@
+// Version of Bun.readableStreamToText but more runtime agnostic
+export async function agnosticReadableStreamToText(
+  stream: ReadableStream<ArrayBufferView | ArrayBuffer>,
+) {
+  let result = '';
+  const reader = stream.pipeThrough(new TextDecoderStream()).getReader();
+
+  while (true) {
+    const { done, value } = await reader.read();
+
+    if (done || !value || !value?.length) break;
+
+    result += value;
+  }
+
+  return result;
+}
+
+export default typeof Bun !== 'undefined'
+  ? Bun.readableStreamToText
+  : agnosticReadableStreamToText;

--- a/packages/brisa/src/utils/render-to-string/index.tsx
+++ b/packages/brisa/src/utils/render-to-string/index.tsx
@@ -1,3 +1,4 @@
+import readableStreamToText from '@/utils/readable-stream-to-text';
 import renderToReadableStream from '@/utils/render-to-readable-stream';
 
 export default async function renderToString(
@@ -7,7 +8,7 @@ export default async function renderToString(
     applySuspense = false,
   }: { request?: Request; applySuspense?: boolean } = {},
 ): Promise<string> {
-  return await Bun.readableStreamToText(
+  return await readableStreamToText(
     renderToReadableStream(element, { request, isPage: false, applySuspense }),
   );
 }

--- a/packages/create-brisa/package.json
+++ b/packages/create-brisa/package.json
@@ -20,9 +20,9 @@
   "bin": {
     "create-brisa": "./create-brisa.cjs"
   },
-  "packageManager": "bun@1.1.22",
+  "packageManager": "bun@1.1.24",
   "engines": {
-    "bun": ">= 1.1.22",
+    "bun": ">= 1.1.24",
     "npm": "please-use-bun",
     "yarn": "please-use-bun",
     "pnpm": "please-use-bun"

--- a/packages/docs/building-your-application/deploying/docker.md
+++ b/packages/docs/building-your-application/deploying/docker.md
@@ -14,7 +14,7 @@ To _containerize_ our application, we define a `Dockerfile`. This file contains 
 
 ```Dockerfile
 # Adjust BUN_VERSION as desired
-ARG BUN_VERSION=1.1.22
+ARG BUN_VERSION=1.1.24
 FROM oven/bun:${BUN_VERSION}-slim AS base
 
 # Brisa app lives here

--- a/packages/docs/getting-started/quick-start.md
+++ b/packages/docs/getting-started/quick-start.md
@@ -11,7 +11,7 @@ related:
 
 ### System Requirements
 
-- Bun [<Badge type="tip" text="1.1.22" />](https://bun.sh/) or later
+- Bun [<Badge type="tip" text="1.1.24" />](https://bun.sh/) or later
 - macOS, Windows (including WSL), and Linux are supported.
 
 ### Automatic Installation

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -5,7 +5,7 @@
   "author": "Brisa Team",
   "homepage": "https://brisa.build/",
   "license": "MIT",
-  "packageManager": "bun@1.1.22",
+  "packageManager": "bun@1.1.24",
   "private": true,
   "bugs": "https://github.com/brisa-build/brisa.git",
   "repository": {
@@ -22,7 +22,7 @@
     "vitepress-plugin-tabs": "0.5.0"
   },
   "engines": {
-    "bun": ">= 1.1.22",
+    "bun": ">= 1.1.24",
     "npm": "please-use-bun",
     "yarn": "please-use-bun",
     "pnpm": "please-use-bun"


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/400
Related https://github.com/brisa-build/brisa/issues/195
Related https://github.com/brisa-build/brisa/issues/318

`Bun.readableStreamToText` is fine, but if it detects a non-Bun environment, it uses an implementation of passing the stream to text and returns the text.

Note: I updated Bun to 1.1.23 to use [`TextDecoderStream`](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoderStream), new Bun API, but supported everywhere (Node, browsers, etc) except old versions of Bun