### PR TITLE
feat: separate serve and build + fix hotreload

### DIFF
--- a/packages/brisa/src/cli/dev-live-reload.tsx
+++ b/packages/brisa/src/cli/dev-live-reload.tsx
@@ -56,7 +56,10 @@ export async function activateHotReload() {
 
   async function recompile(filename: string) {
     semaphore = true;
-    globalThis.Loader.registry.clear();
+
+    if (typeof Bun !== 'undefined') {
+      globalThis.Loader.registry.clear();
+    }
 
     const nsStart = nanoseconds();
     const { error } = spawnSync(


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/404
Related https://github.com/brisa-build/brisa/issues/318
Related https://github.com/brisa-build/brisa/issues/195

This PR:

- Separates the “serve” from the “build”, so the serve can be run with Bun or Node.js (more agnostic), while the build does depend on Bun.
- By loading a new separate build process each time a new build process would have to solve bundler cache problems and Bun crashes. You will confirm @gariasf  if in the new Brisa version you already have the hot-reload in Windows, with this change in principle it should be fine.

