### PR TITLE
dx: improvement type generation

### DIFF
--- a/packages/brisa/src/cli/build.test.ts
+++ b/packages/brisa/src/cli/build.test.ts
@@ -62,13 +62,19 @@ describe('cli', () => {
       globalThis.mockConstants = undefined;
     });
 
-    it('should remove the build directory if it exists', async () => {
+    it('should remove the content of build directory if it exists (except _brisa)', async () => {
       spyOn(fs, 'existsSync').mockImplementationOnce((v) => true);
+      spyOn(fs, 'readdirSync').mockImplementationOnce(
+        () => ['_brisa', 'pages'] as any,
+      );
       spyOn(fs, 'rmSync').mockImplementationOnce((v) => null);
 
       await build();
       expect(fs.existsSync).toHaveBeenCalled();
-      expect(fs.rmSync).toHaveBeenCalled();
+      expect(fs.rmSync).toHaveBeenCalledWith(
+        path.join(getConstants()?.BUILD_DIR, 'pages'),
+        { recursive: true },
+      );
     });
 
     it('should NOT remove the build directory if does not exist', async () => {

--- a/packages/brisa/src/cli/build.ts
+++ b/packages/brisa/src/cli/build.ts
@@ -28,7 +28,12 @@ export default async function build() {
   const start = Bun.nanoseconds();
 
   if (fs.existsSync(BUILD_DIR)) {
-    fs.rmSync(BUILD_DIR, { recursive: true });
+    // Remove all files and folders except _brisa folder
+    const files = fs.readdirSync(BUILD_DIR);
+    for (const file of files) {
+      if (file === '_brisa') continue;
+      fs.rmSync(path.join(BUILD_DIR, file), { recursive: true });
+    }
   }
 
   // Copy prebuild folder inside build

--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 3072;
 const brisaSize = 5959; // TODO: Reduce this size :/
 const webComponents = 792;
 const unsuspenseSize = 217;
-const rpcSize = 2467; // TODO: Reduce this size
+const rpcSize = 2466; // TODO: Reduce this size
 const lazyRPCSize = 4187; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/431

With this change instead of recreating the whole build, everything is recreated except the _brisa folder to overwrite the types, this way there are no milliseconds deleted where the editor as VSCode can suddenly see all the red and then reconfigure, with this change is solved.