### PR TITLE
fix: resolve exports inside package.json during build

### DIFF
--- a/packages/brisa/src/utils/replace-ast-imports-to-absolute/index.test.ts
+++ b/packages/brisa/src/utils/replace-ast-imports-to-absolute/index.test.ts
@@ -115,7 +115,7 @@ describe('utils', () => {
         'Error resolving import path:',
       );
       expect(mockLogError.mock.calls.toString()).toContain(
-        `Cannot find module "@/foo/unknown" from "${utilsDir}/replace-ast-imports-to-absolute/index.test.ts`,
+        `Cannot find module "@/foo/unknown" from "file://${utilsDir}/replace-ast-imports-to-absolute`,
       );
       expect(result).toEqual(expected);
       mockLogError.mockRestore();

--- a/packages/brisa/src/utils/resolve-import-sync/index.ts
+++ b/packages/brisa/src/utils/resolve-import-sync/index.ts
@@ -2,21 +2,33 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 
+const isBun = typeof Bun !== 'undefined';
+
 /**
  * Synchronously resolves the path of an import, which is particularly useful
  * for converting relative imports or TypeScript aliases to absolute paths.
  */
 export default function resolveImportSync(id: string, parent?: string) {
-  const req = createRequire(parent ?? path.resolve(process.cwd(), 'src'));
+  try {
+    const req = createRequire(parent ?? path.resolve(process.cwd(), 'src'));
 
-  return req.resolve(id, {
-    paths: parent
-      ? [
-          path.resolve(
-            parent.startsWith('file://') ? fileURLToPath(parent) : parent,
-            '..',
-          ),
-        ]
-      : undefined,
-  });
+    return req.resolve(id, {
+      paths: parent
+        ? [
+            path.resolve(
+              parent.startsWith('file://') ? fileURLToPath(parent) : parent,
+              '..',
+            ),
+          ]
+        : undefined,
+    });
+  } catch (e) {
+    if (!isBun) throw e;
+    // This resolves "exports" inside the package.json of dependencies in Bun runtime
+    // Issue: https://github.com/brisa-build/brisa/issues/434
+    return Bun.resolveSync(
+      id,
+      parent ? path.dirname(parent) : import.meta.dirname,
+    );
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/434

The builds will always be done with Bun (not Node), and one solution was to use `Bun.resolveSync` using the dirname with `file://`. This solves it, and since it only happens in Bun, the same module is solved in Node which only works in runtime.