### PR TITLE
fix: define `process.env.CSS_TRANSFORMER_WASM` to `false` (fix lightningcss build issue)

### DIFF
--- a/packages/brisa/src/utils/compile-serve-internals-into-build/index.test.ts
+++ b/packages/brisa/src/utils/compile-serve-internals-into-build/index.test.ts
@@ -170,4 +170,16 @@ describe('utils/compileServeInternalsIntoBuild', () => {
       },
     });
   });
+
+  it('should define process.env.CSS_TRANSFORMER_WASM to "false"', async () => {
+    const servePath = path.join(import.meta.dirname, 'out', 'cli', 'serve');
+    fs.mkdirSync(servePath, { recursive: true });
+    fs.writeFileSync(
+      path.join(servePath, 'index.js'),
+      'console.log(process.env.CSS_TRANSFORMER_WASM)',
+    );
+    await compileBrisaInternalsToDoBuildPortable(import.meta.dirname);
+    const server = fs.readFileSync(path.join(BUILD_DIR, 'server.js'), 'utf-8');
+    expect(server).toContain('console.log(false);');
+  });
 });


### PR DESCRIPTION
Fixes #449

Converting `process.env.CSS_TRANSFORMER_WASM` to `false` during the build solve the problem. It'ts an acceptable workaround to solve an external library issue (https://github.com/parcel-bundler/lightningcss/issues/701) that crash during the build, after this, is adding the corrent files in the build:

![Screenshot from 2024-09-02 21-56-58](https://github.com/user-attachments/assets/845462c9-87d5-4866-ab52-d40e3e41dd19)
