### PR TITLE
feat: expose SSRWebComponent wrapper

### DIFF
--- a/packages/brisa/src/types/server.d.ts
+++ b/packages/brisa/src/types/server.d.ts
@@ -165,3 +165,30 @@ export function serve(options: ServeOptions): {
   hostname: string;
   server: Server;
 };
+
+/**
+ * SSRWebComponent is to render a web component on the server side without the help of the compiler.
+ *
+ * The Brisa compiler already does this work for you, so you can write `<web-component foo="bar" />`
+ * directly without worrying. However, there are cases where you want to have a little more control.
+ * This component is for this, the previous equivalent would be:
+ *
+ * ```tsx
+ * import { SSRWebComponent } from 'brisa/server';
+ * import Component from '@/web-components/web-component';
+ *
+ * // ...
+ * <SSRWebComponent selector="web-component" Component={Component} foo="bar" />
+ * ```
+ *
+ * Docs:
+ *
+ * - [SSRWebComponent](https://brisa.build/api-reference/server-apis/ssr-web-component)
+ */
+export function SSRWebComponent<T>(
+  props: T & {
+    selector: string;
+    Component: ComponentType<T>;
+    children?: JSX.Element;
+  },
+): JSX.Element;

--- a/packages/docs/.vitepress/config.mts
+++ b/packages/docs/.vitepress/config.mts
@@ -530,6 +530,10 @@ export default defineConfig({
                 link: '/api-reference/server-apis/serve',
               },
               {
+                text: 'SSRWebComponent',
+                link: '/api-reference/server-apis/ssr-web-component',
+              },
+              {
                 text: 'Node.js APIs',
                 items: [
                   {

--- a/packages/docs/api-reference/server-apis/ssr-web-component.md
+++ b/packages/docs/api-reference/server-apis/ssr-web-component.md
@@ -1,0 +1,49 @@
+---
+description: SSRWebComponent is a compoment wrapper that allows you to render a web component on the server side.
+---
+
+# `SSRWebComponent`
+
+## Reference
+
+### `SSRWebComponent`
+
+The `SSRWebComponent` is a component wrapper that allows you to render a web component on the server side taking care of [Declarative Shadow DOM](https://web.dev/articles/declarative-shadow-dom) and Custom Elements.
+
+## Example usage:
+
+In the next example, we use the `SSRWebComponent` to render a web component on the server side.
+
+```tsx
+import { SSRWebComponent } from "brisa/server";
+import MyComponent from "@/web-components/my-component";
+
+export function MyComponent() {
+  // It's the same than: <my-component someProp="foo" /> 
+  // but without compilation process:
+  return (
+    <SSRWebComponent
+      selector="my-component"
+      Component={MyComponent}
+      someProp="value"
+    />
+  );
+}
+```
+
+> [!IMPORTANT]
+>
+> This work is usually **done by Brisa for you during compilation**, so you can use `<web-component />` directly in your code without having to do 2 imports and use this wrapper. However, it is exposed in case someone needs to do it manually for some reason.
+
+> [!CAUTION]
+>
+> The `selector` prop is required and must match the web component's tag name, also the `Component` prop is required and must be the web component itself.
+
+## Types
+
+```tsx
+export function SSRWebComponent<T>(
+  props: T & { selector: string, Component: ComponentType<T>, children?: JSX.Element },
+): JSX.Element;
+```
+


### PR DESCRIPTION
It has been around for a long time, but was only used internally. I have exposed it because I realized that it can be very useful in some situations, such as plugins or libraries.

-----


# `SSRWebComponent`

## Reference

### `SSRWebComponent`

The `SSRWebComponent` is a component wrapper that allows you to render a web component on the server side taking care of [Declarative Shadow DOM](https://web.dev/articles/declarative-shadow-dom) and Custom Elements.

## Example usage:

In the next example, we use the `SSRWebComponent` to render a web component on the server side.

```tsx
import { SSRWebComponent } from "brisa/server";
import MyComponent from "@/web-components/my-component";

export function MyComponent() {
  // It's the same than: <my-component someProp="foo" /> 
  // but without compilation process:
  return (
    <SSRWebComponent
      selector="my-component"
      Component={MyComponent}
      someProp="value"
    />
  );
}
```

> [!IMPORTANT]
>
> This work is usually **done by Brisa for you during compilation**, so you can use `<web-component />` directly in your code without having to do 2 imports and use this wrapper. However, it is exposed in case someone needs to do it manually for some reason.

> [!CAUTION]
>
> The `selector` prop is required and must match the web component's tag name, also the `Component` prop is required and must be the web component itself.

## Types

```tsx
export function SSRWebComponent<T>(
  props: T & { selector: string, Component: ComponentType<T>, children?: JSX.Element },
): JSX.Element;
```

