### PR TITLE
fix(dx): improve error feedback

### DIFF
--- a/packages/brisa/src/utils/brisa-error-dialog/web-components/brisa-error-dialog.tsx
+++ b/packages/brisa/src/utils/brisa-error-dialog/web-components/brisa-error-dialog.tsx
@@ -82,7 +82,7 @@ export default function ErrorDialog(
         ...(store.get<Error[]>('__BRISA_ERRORS__') ?? []),
         {
           title: 'Uncaught Error',
-          details: [e.error?.message ?? 'Unknown error'],
+          details: [e.error?.message ?? e.message ?? 'Unknown error'],
           stack: e.error?.stack,
         },
       ]);

--- a/packages/www/src/pages/playground/index.tsx
+++ b/packages/www/src/pages/playground/index.tsx
@@ -60,6 +60,7 @@ export default function Playground() {
                const preview = document.querySelector('#preview-iframe');
                const editor = monaco.editor.create(document.querySelector('#code-editor'), {
                   theme: document.body.classList.contains('dark') ? "vs-dark" : "vs-light",
+                  automaticLayout: true,
               });
               editor.setModel(codeModel);
               editor.onDidChangeModelContent((e) => {


### PR DESCRIPTION
@enzonotario now the error feedback at least looks better:

<img width="714" alt="Screenshot 2024-09-29 at 09 59 33" src="https://github.com/user-attachments/assets/da1b907c-9a33-41c4-b60d-cca2a102ebb7">
