### PR TITLE
fix: hide playground footer to avoid scroll issues

### DIFF
--- a/packages/www/src/layout/index.tsx
+++ b/packages/www/src/layout/index.tsx
@@ -81,7 +81,7 @@ export default function Layout(
           <Nav />
         </header>
         {children}
-        <Footer />
+        {route.pathname !== '/playground' && <Footer />}
       </body>
     </html>
   );


### PR DESCRIPTION
Related https://github.com/brisa-build/brisa/issues/158