### PR TITLE
fix(ssr): fix props conflicts changing the brisa prop names

### DIFF
--- a/docs/api-reference/server-apis/SSRWebComponent.md
+++ b/docs/api-reference/server-apis/SSRWebComponent.md
@@ -23,8 +23,8 @@ export function MyComponent() {
   // but without compilation process:
   return (
     <SSRWebComponent
-      selector="my-component"
-      Component={MyComponent}
+      ssr-selector="my-component"
+      ssr-Component={MyComponent}
       someProp="value"
     />
   );
@@ -37,13 +37,13 @@ export function MyComponent() {
 
 > [!CAUTION]
 >
-> The `selector` prop is required and must match the web component's tag name, also the `Component` prop is required and must be the web component itself.
+> The `ssr-selector` prop is required and must match the web component's tag name, also the `ssr-Component` prop is required and must be the web component itself.
 
 ## Types
 
 ```tsx
 export function SSRWebComponent<T>(
-  props: T & { selector: string, Component: ComponentType<T>, children?: JSX.Element },
+  props: T & { 'ssr-selector': string, 'ssr-Component': ComponentType<T>, children?: JSX.Element },
 ): JSX.Element;
 ```
 

--- a/packages/brisa/src/types/server.d.ts
+++ b/packages/brisa/src/types/server.d.ts
@@ -178,7 +178,7 @@ export function serve(options: ServeOptions): {
  * import Component from '@/web-components/web-component';
  *
  * // ...
- * <SSRWebComponent selector="web-component" Component={Component} foo="bar" />
+ * <SSRWebComponent ssr-selector="web-component" ssr-Component={Component} foo="bar" />
  * ```
  *
  * Docs:
@@ -187,8 +187,8 @@ export function serve(options: ServeOptions): {
  */
 export function SSRWebComponent<T>(
   props: T & {
-    selector: string;
-    Component: ComponentType<T>;
+    'ssr-selector': string;
+    'ssr-Component': ComponentType<T>;
     children?: JSX.Element;
   },
 ): JSX.Element;

--- a/packages/brisa/src/utils/compile-files/index.test.ts
+++ b/packages/brisa/src/utils/compile-files/index.test.ts
@@ -279,12 +279,12 @@ describe('utils', () => {
     ${info}Route                            | JS server | JS client (gz)  
     ${info}----------------------------------------------------------------
     ${info}λ /pages/index                   | 821 B     | ${greenLog('3 kB')}
-    ${info}λ /pages/page-with-web-component | 749 B     | ${greenLog('5 kB')}
+    ${info}λ /pages/page-with-web-component | 761 B     | ${greenLog('5 kB')}
     ${info}λ /pages/somepage                | 1 kB      | ${greenLog('0 B')}
     ${info}λ /pages/somepage-with-context   | 1 kB     | ${greenLog('0 B')}  
     ${info}λ /pages/user/[username]         | 437 B     | ${greenLog('0 B')}
-    ${info}λ /pages/_404                    | 810 B     | ${greenLog('5 kB')}
-    ${info}λ /pages/_500                    | 816 B     | ${greenLog('5 kB')}
+    ${info}λ /pages/_404                    | 822 B     | ${greenLog('5 kB')}
+    ${info}λ /pages/_500                    | 828 B     | ${greenLog('5 kB')}
     ${info}ƒ /middleware                    | 828 B     |
     ${info}λ /api/example                   | 283 B     |
     ${info}Δ /layout                        | 604 B     |
@@ -373,7 +373,7 @@ describe('utils', () => {
     ${info}Route           | JS server | JS client (gz)  
     ${info}----------------------------------------------
     ${info}λ /pages/index  | 444 B     | ${greenLog('3 kB')}  
-    ${info}Δ /layout       | 810 B     |
+    ${info}Δ /layout       | 822 B     |
     ${info}
     ${info}λ Server entry-points
     ${info}Δ Layout
@@ -648,7 +648,7 @@ describe('utils', () => {
     ${info}Route           | JS server | JS client (gz)  
     ${info}----------------------------------------------
     ${info}λ /pages/index  | 444 B     | ${greenLog('5 kB')}  
-    ${info}Δ /layout       | 843 B     |
+    ${info}Δ /layout       | 855 B     |
     ${info}Ω /i18n         | 221 B     |
     ${info}
     ${info}λ Server entry-points
@@ -723,7 +723,7 @@ describe('utils', () => {
     ${info}Route           | JS server | JS client (gz)  
     ${info}----------------------------------------------
     ${info}λ /pages/index  | 444 B     | ${greenLog('3 kB')}  
-    ${info}Δ /layout       | 961 B     |
+    ${info}Δ /layout       | 973 B     |
     ${info}
     ${info}λ Server entry-points
     ${info}Δ Layout
@@ -982,7 +982,7 @@ describe('utils', () => {
         ${info}
         ${info}Route           | JS server | JS client (gz)  
         ${info}----------------------------------------------
-        ${info}λ /pages/index  | 716 B      | ${greenLog('3 kB')}  
+        ${info}λ /pages/index  | 728 B      | ${greenLog('3 kB')}  
         ${info}
         ${info}λ Server entry-points
         ${info}Φ JS shared by all

--- a/packages/brisa/src/utils/prerender-util/index.test.ts
+++ b/packages/brisa/src/utils/prerender-util/index.test.ts
@@ -290,7 +290,7 @@ describe('utils', () => {
 		export default function App() {
 			return (
 				<div>
-					<_Brisa_SSRWebComponent Component={Foo} selector="web-component" renderOn="build" foo="bar" />
+					<_Brisa_SSRWebComponent ssr-Component={Foo} ssr-selector="web-component" renderOn="build" foo="bar" />
 				</div>
 			);
 		}
@@ -304,7 +304,7 @@ describe('utils', () => {
 					componentPath: "brisa/server",
 					dir: "./foo",
 					componentModuleName: "SSRWebComponent",
-					componentProps: {Component: '@/foo',selector: "web-component",foo: "bar"}
+					componentProps: {'ssr-Component': '@/foo','ssr-selector': "web-component",foo: "bar"}
 				})}, undefined, false, undefined, this
 			);
 		}
@@ -320,7 +320,7 @@ describe('utils', () => {
 		export default function App() {
 			return (
 				<div>
-					<_Brisa_SSRWebComponent Component={Foo} selector="web-component" renderOn="build" foo="bar" />
+					<_Brisa_SSRWebComponent ssr-Component={Foo} ssr-selector="web-component" renderOn="build" foo="bar" />
 				</div>
 			);
 		}
@@ -333,7 +333,7 @@ describe('utils', () => {
 					componentPath: "brisa/server",
 					dir: "./foo",
 					componentModuleName: "SSRWebComponent",
-					componentProps: {Component: '@/foo',selector: "web-component",foo: "bar"}
+					componentProps: {'ssr-Component': '@/foo','ssr-selector': "web-component",foo: "bar"}
 				})}, undefined, false, undefined, this
 			);
 		}

--- a/packages/brisa/src/utils/prerender-util/index.ts
+++ b/packages/brisa/src/utils/prerender-util/index.ts
@@ -256,7 +256,7 @@ function processPrerenderProperties(
   }
 
   for (const prop of (jsxCall.arguments[1] as any).properties) {
-    if (isSSRWebComponent && prop?.key?.name === 'Component') {
+    if (isSSRWebComponent && prop?.key?.value === 'ssr-Component') {
       const component = imports.get(prop.value.name);
       if (component) {
         (prop.value = {

--- a/packages/brisa/src/utils/prerender-util/prerender.test.tsx
+++ b/packages/brisa/src/utils/prerender-util/prerender.test.tsx
@@ -42,8 +42,8 @@ describe('utils/prerender-util/prerender', () => {
       componentModuleName: 'SSRWebComponent',
       dir: COMPONENTS,
       componentProps: {
-        Component: path.join(COMPONENTS, 'web-component.tsx'),
-        selector: 'web-component',
+        'ssr-Component': path.join(COMPONENTS, 'web-component.tsx'),
+        'ssr-selector': 'web-component',
         name: 'Bar',
       },
     })) as any;

--- a/packages/brisa/src/utils/prerender-util/prerender.tsx
+++ b/packages/brisa/src/utils/prerender-util/prerender.tsx
@@ -23,19 +23,19 @@ async function prerender({
   const { LOG_PREFIX, SRC_DIR } = getConstants();
   const isWebComponent =
     componentPath === 'brisa/server' &&
-    typeof componentProps.Component === 'string' &&
-    componentProps.selector;
+    typeof componentProps['ssr-Component'] === 'string' &&
+    componentProps['ssr-selector'];
   const relativeDir = dir?.replace(SRC_DIR, '') || '';
   let componentRelative = componentPath.replace(SRC_DIR, '');
 
   // SSR of Web Components
   if (isWebComponent) {
     componentPath = brisaServerPath;
-    componentProps.Component = resolveImportSync(
-      componentProps.Component as string,
+    componentProps['ssr-Component'] = resolveImportSync(
+      componentProps['ssr-Component'] as string,
       dir,
     );
-    componentRelative = (componentProps.Component as string).replace(
+    componentRelative = (componentProps['ssr-Component'] as string).replace(
       SRC_DIR,
       '',
     );

--- a/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
@@ -542,8 +542,8 @@ describe('utils', () => {
           <h1>Test</h1>
           {Array.from({ length: 3 }, (_, i) => (
             <SSRWebComponent
-              Component={WebComponent}
-              selector="web-component"
+              ssr-Component={WebComponent}
+              ssr-selector="web-component"
               name={'World' + i}
             >
               <b> Child </b>
@@ -2127,13 +2127,13 @@ describe('utils', () => {
 
       const stream = renderToReadableStream(
         <SSRWebComponent
-          Component={ThemeProvider}
-          selector="theme-provider"
+          ssr-Component={ThemeProvider}
+          ssr-selector="theme-provider"
           color="red"
         >
           <SSRWebComponent
-            Component={ChildComponent}
-            selector="child-component"
+            ssr-Component={ChildComponent}
+            ssr-selector="child-component"
           ></SSRWebComponent>
         </SSRWebComponent>,
         testOptions,
@@ -2181,17 +2181,17 @@ describe('utils', () => {
 
       const stream = renderToReadableStream(
         <SSRWebComponent
-          Component={ThemeProvider}
-          selector="theme-provider"
+          ssr-Component={ThemeProvider}
+          ssr-selector="theme-provider"
           color="red"
         >
           <SSRWebComponent
-            Component={ChildComponent}
-            selector="child-component"
+            ssr-Component={ChildComponent}
+            ssr-selector="child-component"
           ></SSRWebComponent>
           <SSRWebComponent
-            Component={ChildComponent}
-            selector="child-component"
+            ssr-Component={ChildComponent}
+            ssr-selector="child-component"
             slot="with-theme"
           ></SSRWebComponent>
         </SSRWebComponent>,
@@ -2246,18 +2246,18 @@ describe('utils', () => {
 
       const stream = renderToReadableStream(
         <SSRWebComponent
-          Component={ThemeProvider}
-          selector="theme-provider"
+          ssr-Component={ThemeProvider}
+          ssr-selector="theme-provider"
           color="red"
         >
           <div>
             <SSRWebComponent
-              Component={ChildComponent}
-              selector="child-component"
+              ssr-Component={ChildComponent}
+              ssr-selector="child-component"
             ></SSRWebComponent>
             <SSRWebComponent
-              Component={ChildComponent}
-              selector="child-component"
+              ssr-Component={ChildComponent}
+              ssr-selector="child-component"
               slot="with-theme"
             ></SSRWebComponent>
           </div>
@@ -2315,32 +2315,32 @@ describe('utils', () => {
 
       const stream = renderToReadableStream(
         <SSRWebComponent
-          Component={ThemeProvider}
-          selector="theme-provider"
+          ssr-Component={ThemeProvider}
+          ssr-selector="theme-provider"
           color="red"
         >
           <SSRWebComponent
-            Component={ThemeProvider}
-            selector="theme-provider"
+            ssr-Component={ThemeProvider}
+            ssr-selector="theme-provider"
             color="blue"
           >
             <SSRWebComponent
-              Component={ChildComponent}
-              selector="child-component"
+              ssr-Component={ChildComponent}
+              ssr-selector="child-component"
             ></SSRWebComponent>
             <SSRWebComponent
-              Component={ChildComponent}
-              selector="child-component"
+              ssr-Component={ChildComponent}
+              ssr-selector="child-component"
               slot="with-theme"
             ></SSRWebComponent>
           </SSRWebComponent>
           <SSRWebComponent
-            Component={ChildComponent}
-            selector="child-component"
+            ssr-Component={ChildComponent}
+            ssr-selector="child-component"
           ></SSRWebComponent>
           <SSRWebComponent
-            Component={ChildComponent}
-            selector="child-component"
+            ssr-Component={ChildComponent}
+            ssr-selector="child-component"
             slot="with-theme"
           ></SSRWebComponent>
         </SSRWebComponent>,
@@ -2413,18 +2413,18 @@ describe('utils', () => {
 
       const stream = renderToReadableStream(
         <SSRWebComponent
-          Component={ThemeProvider}
-          selector="theme-provider"
+          ssr-Component={ThemeProvider}
+          ssr-selector="theme-provider"
           color="red"
         >
           <div slot="with-theme">
             <SSRWebComponent
-              Component={ChildComponent}
-              selector="child-component"
+              ssr-Component={ChildComponent}
+              ssr-selector="child-component"
             ></SSRWebComponent>
             <SSRWebComponent
-              Component={ChildComponent}
-              selector="child-component"
+              ssr-Component={ChildComponent}
+              ssr-selector="child-component"
               slot="with-theme"
             ></SSRWebComponent>
           </div>
@@ -2484,8 +2484,8 @@ describe('utils', () => {
         return (
           <>
             <SSRWebComponent
-              Component={ChildComponent}
-              selector="child-component"
+              ssr-Component={ChildComponent}
+              ssr-selector="child-component"
               slot={useTheme ? 'with-theme' : undefined}
             ></SSRWebComponent>
           </>
@@ -2494,8 +2494,8 @@ describe('utils', () => {
 
       const stream = renderToReadableStream(
         <SSRWebComponent
-          Component={ThemeProvider}
-          selector="theme-provider"
+          ssr-Component={ThemeProvider}
+          ssr-selector="theme-provider"
           color="red"
         >
           <ServerComponent useTheme={false} />
@@ -2552,22 +2552,22 @@ describe('utils', () => {
 
       const stream = renderToReadableStream(
         <SSRWebComponent
-          Component={ThemeProvider}
-          selector="theme-provider"
+          ssr-Component={ThemeProvider}
+          ssr-selector="theme-provider"
           color="red"
         >
           <SSRWebComponent
-            Component={ChildComponent}
-            selector="child-component"
+            ssr-Component={ChildComponent}
+            ssr-selector="child-component"
             slot="with-theme"
           ></SSRWebComponent>
           <SSRWebComponent
-            Component={ChildComponent}
-            selector="child-component"
+            ssr-Component={ChildComponent}
+            ssr-selector="child-component"
           ></SSRWebComponent>
           <SSRWebComponent
-            Component={ChildComponent}
-            selector="child-component"
+            ssr-Component={ChildComponent}
+            ssr-selector="child-component"
             slot="with-theme"
           ></SSRWebComponent>
         </SSRWebComponent>,
@@ -2628,16 +2628,16 @@ describe('utils', () => {
       function ServerComponent() {
         return (
           <SSRWebComponent
-            Component={ChildComponent}
-            selector="child-component"
+            ssr-Component={ChildComponent}
+            ssr-selector="child-component"
           />
         );
       }
 
       const stream = renderToReadableStream(
         <SSRWebComponent
-          Component={ThemeProvider}
-          selector="theme-provider"
+          ssr-Component={ThemeProvider}
+          ssr-selector="theme-provider"
           color="red"
         >
           {/* @ts-ignore */}
@@ -2689,13 +2689,13 @@ describe('utils', () => {
           <context-provider context={ThemeCtx} value={{ color }}>
             <context-provider context={ThemeCtx} value={{ color: 'blue' }}>
               <SSRWebComponent
-                Component={ChildComponent}
-                selector="child-component"
+                ssr-Component={ChildComponent}
+                ssr-selector="child-component"
               ></SSRWebComponent>
             </context-provider>
             <SSRWebComponent
-              Component={ChildComponent}
-              selector="child-component"
+              ssr-Component={ChildComponent}
+              ssr-selector="child-component"
             ></SSRWebComponent>
           </context-provider>
         );
@@ -2708,8 +2708,8 @@ describe('utils', () => {
 
       const stream = renderToReadableStream(
         <SSRWebComponent
-          Component={ColorTest}
-          selector="theme-provider"
+          ssr-Component={ColorTest}
+          ssr-selector="theme-provider"
           color="red"
         />,
         testOptions,
@@ -3656,7 +3656,7 @@ describe('utils', () => {
             <link rel="stylesheet" href="test.css"></link>
           </head>
           <body>
-            <SSRWebComponent Component={Component} selector="test" />
+            <SSRWebComponent ssr-Component={Component} ssr-selector="test" />
           </body>
         </html>,
         testOptions,
@@ -3693,7 +3693,7 @@ describe('utils', () => {
           <head></head>
           <body>
             <ServerComponent />
-            <SSRWebComponent Component={WebComponent} selector="test" />
+            <SSRWebComponent ssr-Component={WebComponent} ssr-selector="test" />
           </body>
         </html>,
         testOptions,
@@ -3767,7 +3767,7 @@ describe('utils', () => {
             <link rel="stylesheet" href="test.css"></link>
           </head>
           <body>
-            <SSRWebComponent Component={Component} selector="test" />
+            <SSRWebComponent ssr-Component={Component} ssr-selector="test" />
           </body>
         </html>,
         testOptions,

--- a/packages/brisa/src/utils/render-to-readable-stream/index.ts
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.ts
@@ -172,7 +172,7 @@ async function enqueueDuringRendering(
     const isServerProvider = type === CONTEXT_PROVIDER && props.serverOnly;
     const isFragment = type === null;
     const isTagToIgnore = isFragment || isServerProvider;
-    const isWebComponent = type?.__isWebComponent || props?.__isWebComponent;
+    const isWebComponent = props?.['ssr-Component'] || props?.__isWebComponent;
     const isElement = typeof type === 'string';
     const isWebComponentSelector = isWebComponent && isElement;
     let slottedContentProviders: ProviderType[] | undefined;
@@ -632,10 +632,9 @@ function getValueOfComponent(
         throw error;
       }
       if (!isComponent(componentFn.error)) {
-        const isWebComponent = (componentFn as any).__isWebComponent;
-        const componentName =
-          (isWebComponent ? props.selector : componentFn.name) || 'Component';
-        const title = `Error in SSR of ${componentName} ${isWebComponent ? 'web' : 'server'} component with props ${JSON.stringify(
+        const customElementName = props['ssr-selector']
+        const componentName = props['ssr-selector'] || componentFn.name || 'Component';
+        const title = `Error in SSR of ${componentName} ${customElementName ? 'web' : 'server'} component with props ${JSON.stringify(
           props,
         )}`;
         logError({
@@ -643,7 +642,7 @@ function getValueOfComponent(
           messages: [title, error.message],
           stack: error.stack,
           docTitle: 'Documentation about SSR',
-          docLink: isWebComponent
+          docLink: customElementName
             ? 'https://brisa.build/building-your-application/components-details/web-components.html#server-side-rendering'
             : 'https://brisa.build/building-your-application/components-details/server-components.html',
         });

--- a/packages/brisa/src/utils/resolve-action/index.test.tsx
+++ b/packages/brisa/src/utils/resolve-action/index.test.tsx
@@ -397,8 +397,8 @@ describe('utils', () => {
           <div>
             Test{' '}
             <SSRWebComponent
-              selector="some-web-component-to-transfer-store"
-              Component={() => <div />}
+              ssr-selector="some-web-component-to-transfer-store"
+              ssr-Component={() => <div />}
             />
           </div>
         );

--- a/packages/brisa/src/utils/server-component-plugin/index.test.ts
+++ b/packages/brisa/src/utils/server-component-plugin/index.test.ts
@@ -88,8 +88,8 @@ describe('utils', () => {
         
         export default function (props) {
           return jsxDEV(_Brisa_SSRWebComponent, {
-           Component: WebComponent,
-           selector: "web-component",
+           'ssr-Component': WebComponent,
+           'ssr-selector': "web-component",
            ...props
          });
         }
@@ -269,7 +269,7 @@ describe('utils', () => {
         import _Brisa_WC1 from "${webComponentPath}";
 
         export default function ServerComponent() {
-          return <_Brisa_SSRWebComponent Component={_Brisa_WC1} selector="web-component" onClick={() => console.log('clicked')} data-action-onclick="a1_1" data-action />;
+          return <_Brisa_SSRWebComponent ssr-Component={_Brisa_WC1} ssr-selector="web-component" onClick={() => console.log('clicked')} data-action-onclick="a1_1" data-action />;
         }
 
         ServerComponent._hasActions = true;
@@ -299,7 +299,7 @@ describe('utils', () => {
         import _Brisa_WC1 from "${webComponentPath}";
 
         export default function ServerComponent() {
-          return <_Brisa_SSRWebComponent Component={_Brisa_WC1} selector="web-component" __key="foo" key="foo" />;
+          return <_Brisa_SSRWebComponent ssr-Component={_Brisa_WC1} ssr-selector="web-component" __key="foo" key="foo" />;
         }
       `),
       );
@@ -624,7 +624,7 @@ describe('utils', () => {
         import _Brisa_WC1 from "${webComponentPath}";
 
         export default function ServerComponent() {
-          return <_Brisa_SSRWebComponent Component={_Brisa_WC1} selector="web-component" />;
+          return <_Brisa_SSRWebComponent ssr-Component={_Brisa_WC1} ssr-selector="web-component" />;
         }
       `);
 
@@ -664,7 +664,7 @@ describe('utils', () => {
           return (
             <>
             {Array.from({ length: 3 }, (_, i) => (
-              <_Brisa_SSRWebComponent Component={_Brisa_WC1} selector="web-component" name={'Hello'+i}>
+              <_Brisa_SSRWebComponent ssr-Component={_Brisa_WC1} ssr-selector="web-component" name={'Hello'+i}>
                 <b> Child </b>
               </_Brisa_SSRWebComponent>
             ))}
@@ -1021,8 +1021,8 @@ describe('utils', () => {
         export default function ServerComponent() {
           return (
             <>
-              <_Brisa_SSRWebComponent Component={_Brisa_WC1} selector="web-component" />
-              <_Brisa_SSRWebComponent Component={_Brisa_WC1} selector="web-component" />
+              <_Brisa_SSRWebComponent ssr-Component={_Brisa_WC1} ssr-selector="web-component" />
+              <_Brisa_SSRWebComponent ssr-Component={_Brisa_WC1} ssr-selector="web-component" />
             </>
           );
         }
@@ -1074,7 +1074,7 @@ describe('utils', () => {
               <Foo />
               <Bar />
               <Baz />
-              <_Brisa_SSRWebComponent Component={_Brisa_WC1} selector="web-component" />
+              <_Brisa_SSRWebComponent ssr-Component={_Brisa_WC1} ssr-selector="web-component" />
             </>
           );
         }

--- a/packages/brisa/src/utils/server-component-plugin/index.ts
+++ b/packages/brisa/src/utils/server-component-plugin/index.ts
@@ -398,8 +398,8 @@ export default function serverComponentPlugin(
           {
             type: 'Property',
             key: {
-              type: 'Identifier',
-              name: 'Component',
+              type: 'Literal',
+              value: 'ssr-Component',
             },
             value: {
               type: 'Identifier',
@@ -413,8 +413,8 @@ export default function serverComponentPlugin(
           {
             type: 'Property',
             key: {
-              type: 'Identifier',
-              name: 'selector',
+              type: 'Literal',
+              value: 'ssr-selector',
             },
             value: {
               type: 'Literal',

--- a/packages/brisa/src/utils/server-component-plugin/wrap-default-export-with-ssr-web-component/index.test.ts
+++ b/packages/brisa/src/utils/server-component-plugin/wrap-default-export-with-ssr-web-component/index.test.ts
@@ -23,8 +23,8 @@ describe('utils/server-component-plugin/wrap-default-export-with-ssr-web-compone
 
 			export default function (props) {
 				return jsxDEV(_Brisa_SSRWebComponent, {
-						Component: WebComponent,
-						selector: "web-component",
+						'ssr-Component': WebComponent,
+						'ssr-selector': "web-component",
 						...props
 				});
 			}
@@ -43,8 +43,8 @@ describe('utils/server-component-plugin/wrap-default-export-with-ssr-web-compone
       normalizeHTML(`
 			export default function (props) {
 				return jsxDEV(_Brisa_SSRWebComponent, {
-						Component: WebComponent,
-						selector: "web-component",
+						'ssr-Component': WebComponent,
+						'ssr-selector': "web-component",
 						...props
 				});
 			}
@@ -63,8 +63,8 @@ describe('utils/server-component-plugin/wrap-default-export-with-ssr-web-compone
       normalizeHTML(`
 			export default function (props) {
 				return jsxDEV(_Brisa_SSRWebComponent, {
-						Component: () => 'hello',
-						selector: "web-component",
+						'ssr-Component': () => 'hello',
+						'ssr-selector': "web-component",
 						...props
 				});
 			}

--- a/packages/brisa/src/utils/server-component-plugin/wrap-default-export-with-ssr-web-component/index.ts
+++ b/packages/brisa/src/utils/server-component-plugin/wrap-default-export-with-ssr-web-component/index.ts
@@ -49,7 +49,7 @@ export default function wrapDefaultExportWithSSRWebComponent(
                   properties: [
                     {
                       type: 'Property',
-                      key: { type: 'Identifier', name: 'Component' },
+                      key: { type: 'Literal', value: 'ssr-Component' },
                       value:
                         exportDefaultDeclaration.id ?? exportDefaultDeclaration,
                       kind: 'init',
@@ -59,7 +59,7 @@ export default function wrapDefaultExportWithSSRWebComponent(
                     },
                     {
                       type: 'Property',
-                      key: { type: 'Identifier', name: 'selector' },
+                      key: { type: 'Literal', value: 'ssr-selector' },
                       value: { type: 'Literal', value: selector },
                       kind: 'init',
                       computed: false,

--- a/packages/brisa/src/utils/ssr-web-component/index.test.tsx
+++ b/packages/brisa/src/utils/ssr-web-component/index.test.tsx
@@ -38,7 +38,7 @@ describe('utils', () => {
       const Component = () => <div>hello world</div>;
       const selector = 'my-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -54,8 +54,8 @@ describe('utils', () => {
       const selector = 'my-component';
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          'ssr-selector': selector,
           name: 'world',
         },
         requestContext,
@@ -82,7 +82,7 @@ describe('utils', () => {
       };
       const selector = 'my-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -108,7 +108,7 @@ describe('utils', () => {
       };
       const selector = 'my-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -129,7 +129,7 @@ describe('utils', () => {
       };
       const selector = 'my-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -151,7 +151,7 @@ describe('utils', () => {
       };
       const selector = 'my-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -174,7 +174,7 @@ describe('utils', () => {
       };
       const selector = 'my-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -195,7 +195,7 @@ describe('utils', () => {
       };
       const selector = 'my-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -216,7 +216,7 @@ describe('utils', () => {
       };
       const selector = 'my-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -235,7 +235,7 @@ describe('utils', () => {
 
       const selector = 'my-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -254,7 +254,7 @@ describe('utils', () => {
 
       const selector = 'my-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -276,8 +276,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          'ssr-Component': Component,
+          'ssr-selector': selector,
           children: 'world',
         },
         requestContext,
@@ -301,8 +301,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          'ssr-Component': Component,
+          'ssr-selector': selector,
           children: 'world',
         },
         requestContext,
@@ -327,8 +327,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          'ssr-Component': Component,
+          'ssr-selector': selector,
           children: 'world',
         },
         requestContext,
@@ -355,8 +355,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          'ssr-selector': selector,
           name: 'world',
         },
         requestContext,
@@ -386,8 +386,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -409,8 +409,8 @@ describe('utils', () => {
       try {
         (await SSRWebComponent(
           {
-            Component,
-            selector,
+            'ssr-Component': Component,
+            'ssr-selector': selector,
           },
           requestContext,
         )) as any;
@@ -438,8 +438,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -483,8 +483,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         request,
       )) as any;
@@ -514,8 +514,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component: ComponentWithAsyncEvent,
-          selector,
+          'ssr-Component': ComponentWithAsyncEvent,
+          'ssr-selector': selector,
         },
         requestContext,
       )) as any;
@@ -546,8 +546,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -576,7 +576,7 @@ describe('utils', () => {
       req.store.set(AVOID_DECLARATIVE_SHADOW_DOM_SYMBOL, true);
 
       const output = (await SSRWebComponent(
-        { Component, selector, children: <h1>CHILD</h1> },
+        { 'ssr-Component': Component, 'ssr-selector': selector, children: <h1>CHILD</h1> },
         req,
       )) as any;
 
@@ -621,8 +621,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -644,8 +644,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -666,8 +666,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -686,8 +686,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -707,8 +707,8 @@ describe('utils', () => {
 
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -724,7 +724,7 @@ describe('utils', () => {
       const __key = 'some-key';
 
       const output = (await SSRWebComponent(
-        { Component, selector, foo: 'bar', __key },
+        { 'ssr-Component': Component, 'ssr-selector': selector, foo: 'bar', __key },
         requestContext,
       )) as any;
 
@@ -740,8 +740,8 @@ describe('utils', () => {
       const selector = 'my-component';
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -757,8 +757,8 @@ describe('utils', () => {
       const selector = 'my-component';
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -774,8 +774,8 @@ describe('utils', () => {
       const selector = 'my-component';
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -791,8 +791,8 @@ describe('utils', () => {
       const selector = 'my-component';
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -809,8 +809,8 @@ describe('utils', () => {
       const selector = 'my-component';
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          "ssr-Component": Component,
+          "ssr-selector": selector
         },
         requestContext,
       )) as any;
@@ -823,7 +823,7 @@ describe('utils', () => {
       const Component = webComponentPath;
       const selector = 'web-component';
       const output = (await SSRWebComponent(
-        { Component, selector },
+        { 'ssr-Component': Component, 'ssr-selector': selector },
         requestContext,
       )) as any;
 
@@ -836,8 +836,8 @@ describe('utils', () => {
       const selector = 'web-component';
       const output = (await SSRWebComponent(
         {
-          Component,
-          selector,
+          'ssr-Component': Component,
+          'ssr-selector': selector,
           foo: <span id="server-part">bar</span>,
         },
         requestContext,

--- a/packages/brisa/src/utils/ssr-web-component/index.tsx
+++ b/packages/brisa/src/utils/ssr-web-component/index.tsx
@@ -8,17 +8,24 @@ export const AVOID_DECLARATIVE_SHADOW_DOM_SYMBOL = Symbol.for(
 );
 
 type Props = {
-  Component: any;
-  selector: string;
+  'ssr-Component': any;
+  'ssr-selector': string;
   [key: string]: any;
 };
 
 const voidFn = () => {};
 
 export default async function SSRWebComponent(
-  { Component, selector, __key, ...props }: Props,
+  { 'ssr-Component': Component, 'ssr-selector': selector, __key, ...props }: Props,
   { store, useContext, i18n, indicate, route }: RequestContext,
 ) {
+  // Note: only can happen with libraries in old versions of Brisa
+  // TODO: Remove in the future
+  if(!Component) {
+    Component = props.Component
+    selector = props.selector
+  }
+
   const { WEB_CONTEXT_PLUGINS } = getConstants();
   const showContent = !store.has(AVOID_DECLARATIVE_SHADOW_DOM_SYMBOL);
   const self = { shadowRoot: {}, attachInternals: voidFn } as any;
@@ -71,11 +78,11 @@ export default async function SSRWebComponent(
 
   if (showContent) {
     try {
-      content = await (typeof Component.suspense === 'function'
+      content = await (typeof Component?.suspense === 'function'
         ? Component.suspense(componentProps, webContext)
         : Component(componentProps, webContext));
     } catch (error) {
-      if (Component.error) {
+      if (Component?.error) {
         content = await Component.error(
           { ...componentProps, error },
           webContext,
@@ -104,5 +111,3 @@ export default async function SSRWebComponent(
     </Selector>
   );
 }
-
-SSRWebComponent.__isWebComponent = true;

--- a/packages/www/src/components/breadcrumb-nav.tsx
+++ b/packages/www/src/components/breadcrumb-nav.tsx
@@ -13,7 +13,7 @@ export default function BreadcrumbNav({}, { route }: RequestContext) {
   return (
     <div class="breadcrumb-wrapper">
       <nav aria-label="Breadcrumb" class="breadcrumb">
-        <menu-btn selector=".sidebar" useOverlay skipSSR>
+        <menu-btn selector=".sidebar" useOverlay>
           <MenuIcon />
           <CrossIcon />
         </menu-btn>

--- a/packages/www/src/components/navigation.tsx
+++ b/packages/www/src/components/navigation.tsx
@@ -33,7 +33,7 @@ export default function Nav({}, { route }: RequestContext) {
           </a>
           <search-engine-wc jsonUrl="/content.json" />
         </div>
-        <menu-btn selector="#nav-list" skipSSR>
+        <menu-btn selector="#nav-list">
           <MenuIcon />
           <CrossIcon />
         </menu-btn>


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/496

using `<web-component selector=".foo" />` was breaking the SSR. Now we changed the `SSRWebComponent` adding some prefix like `ssr-selector` and `ssr-Component` to be harder to have this kind of conflicts.