### PR TITLE
feat: add `useId` to `WebContext`

### DIFF
--- a/docs/api-reference/components/web-context.md
+++ b/docs/api-reference/components/web-context.md
@@ -25,6 +25,9 @@ export default function WebComponent(props, webContext: WebContext) {
     onMount,
     reset,
 
+    // Generate unique identifiers (server/client)
+    useId,
+
     // Add reactive styles
     css,
 
@@ -235,6 +238,25 @@ reset();
 > [!CAUTION]
 >
 > The `reset` method is a powerful tool that should be used judiciously. It clears all effects and cleanups, potentially affecting the web component's behavior. Ensure that its usage aligns with the desired functionality and doesn't compromise the integrity of the web component.
+
+## `useId`
+
+`useId(): string`
+
+The `useId` method generates a unique identifier for the web component. It is useful for creating unique keys for elements in lists or for other purposes that require unique identifiers. The generated ID is unique across all web components and the generation is the same on the server and client.
+
+Example:
+
+```tsx
+const passwordHintId = useId();
+
+return (
+  <>
+    <input type="password" aria-describedby={passwordHintId} />
+    <p id={passwordHintId}>
+  </>
+)
+```
 
 ## `css`
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "validate-urls": "bun run scripts/validate-urls.ts",
     "www:build": "bun run --cwd packages/www build",
     "www:dev": "bun run --cwd packages/www dev",
-    "www:deploy": "bun run docs:build && vercel --prod",
+    "www:deploy": "bun run build && bun run www:build && vercel --prod",
     "prepare": "husky"
   },
   "packageManager": "bun@1.1.28",

--- a/packages/brisa/src/types/index.d.ts
+++ b/packages/brisa/src/types/index.d.ts
@@ -559,6 +559,18 @@ export interface BaseWebContext {
   /**
    * Description:
    *
+   * The `useId` method will generate a unique identifier for each invocation and guarantees that
+   * these will be consistent when rendering both on the server and the client.
+   *
+   * A common use case for consistent IDs are forms, where <label>-elements use the for attribute
+   * to associate them with a specific <input>-element. The useId hook isn't tied to just forms
+   * though and can be used whenever you need a unique ID.
+   */
+  useId(): string;
+
+  /**
+   * Description:
+   *
    * The `css` method is used to inject reactive CSS into the DOM.
    *
    * Example:

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -201,6 +201,7 @@ export default function brisaElement(
       const fnToExecuteAfterMount: (() => void)[] = [];
       const cssStyles: CSSStyles = [];
       const sheet = new CSSStyleSheet();
+      let idCount = 0;
 
       // Add global CSS to apply to the shadowRoot
       const css: string[] = [];
@@ -410,6 +411,9 @@ export default function brisaElement(
           ...renderSignals,
           onMount(cb: () => void) {
             fnToExecuteAfterMount.push(cb);
+          },
+          useId() {
+            return self.dataset[`id-${++idCount}`] ?? crypto.randomUUID();
           },
           // Context
           useContext<T>(context: BrisaContext<T>) {

--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 3072;
 const brisaSize = 5743; // TODO: Reduce this size :/
 const webComponents = 1144;
 const unsuspenseSize = 217;
-const rpcSize = 2468; // TODO: Reduce this size
+const rpcSize = 2467; // TODO: Reduce this size
 const lazyRPCSize = 4171; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/ssr-web-component/index.test.tsx
+++ b/packages/brisa/src/utils/ssr-web-component/index.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, afterEach } from 'bun:test';
+import { describe, expect, it, afterEach, spyOn } from 'bun:test';
 import { join } from 'node:path';
 import SSRWebComponent, { AVOID_DECLARATIVE_SHADOW_DOM_SYMBOL } from '.';
 import type {
@@ -875,6 +875,43 @@ describe('utils', () => {
 
       expect(output[2][0][2][2][1]).toEqual({
         html: `<style>@import '/foo.css';@import '/bar.css'</style>`,
+      });
+    });
+
+    it('should useId add the data-id-num to the web component with an id', async () => {
+      spyOn(crypto, 'randomUUID').mockImplementationOnce(
+        () => '91d4295f-a12c-4807-a213-389e9262c422',
+      );
+      spyOn(crypto, 'randomUUID').mockImplementationOnce(
+        () => 'd519f3a3-c53a-43fe-853a-50dd799194b3',
+      );
+      const WebComponent = ({}, { useId }: WebContext) => {
+        const id1 = useId();
+        const id2 = useId();
+        return (
+          <>
+            <input id={id1} />
+            <input id={id2} />
+          </>
+        );
+      };
+
+      const selector = 'web-component';
+
+      const output = (await SSRWebComponent(
+        {
+          'ssr-Component': WebComponent,
+          'ssr-selector': selector,
+        },
+        requestContext,
+      )) as any;
+
+      expect(output[0]).toBe(selector);
+      expect(output[1]).toEqual({
+        __isWebComponent: true,
+        'data-id-1': '91d4295f-a12c-4807-a213-389e9262c422',
+        'data-id-2': 'd519f3a3-c53a-43fe-853a-50dd799194b3',
+        key: undefined,
       });
     });
   });

--- a/packages/brisa/src/utils/ssr-web-component/index.tsx
+++ b/packages/brisa/src/utils/ssr-web-component/index.tsx
@@ -37,6 +37,11 @@ export default async function SSRWebComponent(
   const self = { shadowRoot: {}, attachInternals: voidFn } as any;
   let style = '';
   const Selector = selector;
+  const ids = {} as Record<
+    string,
+    `${string}-${string}-${string}-${string}-${string}`
+  >;
+  let idCount = 0;
 
   // Note: For renderOn="build" we need to import the component inside
   // to execute the SSRWebComponent in a macro with serialized props.
@@ -52,6 +57,7 @@ export default async function SSRWebComponent(
     store,
     self,
     state: (value: unknown) => ({ value }),
+    useId: () => (ids[`data-id-${++idCount}`] = crypto.randomUUID()),
     effect: voidFn,
     onMount: voidFn,
     reset: voidFn,
@@ -107,7 +113,7 @@ export default async function SSRWebComponent(
 
   return (
     // @ts-ignore
-    <Selector key={__key} {...props} __isWebComponent>
+    <Selector key={__key} {...props} {...ids} __isWebComponent>
       {showContent && (
         <template
           shadowrootmode="open"


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/506
Fixes https://github.com/brisa-build/brisa/issues/357

`useId(): string`

The `useId` method generates a unique identifier for the web component. It is useful for creating unique keys for elements in lists or for other purposes that require unique identifiers. The generated ID is unique across all web components and the generation is the same on the server and client.

Example:

```tsx
const passwordHintId = useId();

return (
  <>
    <input type="password" aria-describedby={passwordHintId} />
    <p id={passwordHintId}>
  </>
)
```