### PR TITLE
feat(www playground): add Eruda for devtools panel

### DIFF
--- a/packages/www/src/pages/playground/preview.tsx
+++ b/packages/www/src/pages/playground/preview.tsx
@@ -1,3 +1,64 @@
+import { dangerHTML as esm } from 'brisa'
+
 export default function Playground() {
-  return <play-ground-preview skipSSR />;
+  const erudaCode = `import eruda from 'https://esm.sh/eruda'
+
+function __setupEruda() {
+  const container = document.getElementById('eruda-container')
+  
+  if (!container) {
+    return
+  }
+  
+  eruda.init({
+    container,
+    tool: ['console', 'elements'],
+    autoScale: true,
+    useShadowDom: false,
+    defaults: {
+      displaySize: 100,
+      transparency: 100,
+    },
+  })
+  
+  const erudaContainer = document.querySelector('.eruda-container')
+  if (erudaContainer) {
+    erudaContainer.style.position = 'absolute'
+  }
+  
+  const erudaDevTools = document.querySelector('.eruda-dev-tools')
+  if (erudaDevTools) {
+    erudaDevTools.style.height = '100%'
+  }
+
+  const erudaEntryButton = document.querySelector('.eruda-entry-btn')
+  if (erudaEntryButton) {
+    erudaEntryButton.style.display = 'none'
+  }
+  
+  eruda.show()
+  
+  __setupErudaTheme()
+}
+
+function __setupErudaTheme() {
+  const erudaConfig = eruda?.get('')?.config
+  erudaConfig?.set('theme', document.body.classList.contains('dark') ? 'Dark' : 'Light')
+}
+
+__setupEruda()`
+
+  return <div style="display: flex; flex: 1; flex-direction: column; width: 100%; height: 100vh;">
+    <script type="module">
+      {esm(erudaCode)}
+    </script>
+
+    <div id="preview-container" style="height: 50%; padding: 0.5rem;">
+      <play-ground-preview skipSSR/>
+    </div>
+    <div id="console-container" style="height: 50%; position: relative;">
+      <div id="eruda-container">
+      </div>
+    </div>
+  </div>
 }

--- a/packages/www/src/web-components/play-ground.tsx
+++ b/packages/www/src/web-components/play-ground.tsx
@@ -80,15 +80,6 @@ export default async function PlayGround(
       }
     }
 
-    #tab-wc {
-      padding: 0.5rem
-    }
-    #tab-wc iframe {
-      display: flex;
-      flex-grow: 1;
-      border: none;
-    }
-
     #tab-compiled {
       padding: 0.5rem;
     }


### PR DESCRIPTION
Adds Eruda as DevTools for Playground.

By default, Eruda is displayed with a `fixed` position (and can therefore overlap the WC element). To prevent this, it is placed inside an `eruda-container` and given an `absolute` position, inside a `relative` element, so it cannot overlap the WC element. This also makes it possible to position it inside a SplitView component, allowing the size to be adjusted by the User (inspired by [Solid Playground](https://playground.solidjs.com/)).

TODO:

- Inside `iframe`, the `body` element does not have `dark` class, so I didn't find a way to access to Root Body from Iframe context.
- Add an SplitView component, to allows change size and even hide the DevTools.
- Define design considerations. For example, in my custom editor, I decreased the Tabs height; hid the "log type" sub-tabs; and hid the Settings tab:
![image](https://github.com/user-attachments/assets/53eb3691-e377-42d4-9a18-72cd019b181a)
