### PR TITLE
feat: add filterRuntimeDevErrors config property

### DIFF
--- a/docs/building-your-application/configuring/brisa-config-js.md
+++ b/docs/building-your-application/configuring/brisa-config-js.md
@@ -74,6 +74,12 @@ const config: Configuration = {
    * Default: undefined (no integrations added)
    */
   integrations: [brisaTailwindCSS()],
+
+  /**
+   * `filterRuntimeDevErrors` configuration
+   * Default: () => true (no errors are filtered)
+   */
+  filterRuntimeDevErrors?(error: ErrorEvent): boolean;
 };
 
 // Export the configuration as the default export
@@ -136,3 +142,6 @@ The `external` option allows you to define external dependencies that should not
 
 The `integrations` option allows you to integrate third-party libraries with the Brisa internals. This is useful when you want to automatically handle the integration of libraries like TailwindCSS.
 
+## [`filterRuntimeDevErrors`](/building-your-application/configuring/filter-runtime-dev-errors)
+
+The `filterRuntimeDevErrors` option allows you to filter runtime development errors. This is useful for filtering out errors that are not relevant to your application.

--- a/docs/building-your-application/configuring/filter-runtime-dev-errors.md
+++ b/docs/building-your-application/configuring/filter-runtime-dev-errors.md
@@ -1,0 +1,34 @@
+---
+description: Learn how to filter runtime development errors.
+---
+
+# Filter Runtime Development Errors
+
+The `filterRuntimeDevErrors` configuration property in `brisa.config.ts` allows you to filter runtime development errors. This is useful for filtering out errors that are not relevant to your application.
+
+## Example
+
+In the next example, we are filtering out the `TypeError` error. This means that the error will not be logged to the console.
+
+```ts 4
+import type { Configuration } from "brisa";
+
+export default {
+  filterRuntimeDevErrors(error: ErrorEvent) {
+    return !(error.error instanceof TypeError);
+  },
+} satisfies Configuration;
+```
+
+> [!IMPORTANT]
+>
+> This config property is stringified and passed to the client code only during development, so it should not have any side effects.
+
+## Types
+
+```ts
+export type Configuration = {
+  // ...
+  filterRuntimeDevErrors?(error: ErrorEvent): boolean;
+};
+```

--- a/docs/building-your-application/configuring/filter-runtime-dev-errors.md
+++ b/docs/building-your-application/configuring/filter-runtime-dev-errors.md
@@ -10,6 +10,8 @@ The `filterRuntimeDevErrors` configuration property in `brisa.config.ts` allows 
 
 In the next example, we are filtering out the `TypeError` error. This means that the error will not be logged to the console.
 
+**brisa.config.ts**:
+
 ```ts 4
 import type { Configuration } from "brisa";
 

--- a/packages/brisa/src/constants.ts
+++ b/packages/brisa/src/constants.ts
@@ -195,6 +195,7 @@ declare global {
   var __USE_LOCALE__: boolean;
   var __IS_STATIC__: boolean;
   var __USE_PAGE_TRANSLATION__: boolean;
+  var __FILTER_DEV_RUNTIME_ERRORS__: string;
 }
 
 export default constants;

--- a/packages/brisa/src/test-setup.ts
+++ b/packages/brisa/src/test-setup.ts
@@ -8,6 +8,7 @@ const dec = new TextDecoder();
 Bun.env.__CRYPTO_KEY__ = crypto.randomBytes(32).toString('hex');
 Bun.env.__CRYPTO_IV__ = crypto.randomBytes(8).toString('hex');
 globalThis.__BASE_PATH__ = '';
+globalThis.__FILTER_DEV_RUNTIME_ERRORS__ = '() => true';
 
 // All tests about this diff dom streaming algorithm are inside the library
 mock.module('diff-dom-streaming', () => ({

--- a/packages/brisa/src/types/index.d.ts
+++ b/packages/brisa/src/types/index.d.ts
@@ -1244,6 +1244,33 @@ export type Configuration = {
    *
    */
   integrations?: Integration[];
+
+  /**
+   * Description:
+   *
+   * The `filterRuntimeDevErrors` config property is used to filter the runtime errors in development.
+   * There are some cases where you want to ignore some errors, for example, when you are using
+   * a third-party library that throws an error that you know is not a problem.
+   *
+   * The default value is `true`.
+   *
+   * Example:
+   *
+   * ```ts
+   * filterRuntimeDevErrors: (error) => error.message !== 'Some error message'
+   * ```
+   *
+   * To ignore all errors, you can use the following code:
+   *
+   * ```ts
+   * filterRuntimeDevErrors: () => false
+   * ```
+   *
+   * Docs:
+   *
+   * - [How to use `filterRuntimeDevErrors`](https://brisa.build/building-your-application/configuring/filter-runtime-dev-errors)
+   */
+  filterRuntimeDevErrors?(error: ErrorEvent): boolean;
 };
 
 export type Integration = {

--- a/packages/brisa/src/utils/brisa-error-dialog/inject-code.test.ts
+++ b/packages/brisa/src/utils/brisa-error-dialog/inject-code.test.ts
@@ -1,0 +1,43 @@
+import { getConstants } from '@/constants';
+import { describe, it, expect, afterEach, spyOn } from 'bun:test';
+import { getFilterDevRuntimeErrors } from './inject-code';
+
+const mockLog = spyOn(console, 'log');
+
+describe('utils - brisa-error-dialog - getFilterDevRuntimeErrors', () => {
+  afterEach(() => {
+    globalThis.mockConstants = undefined;
+    mockLog.mockClear();
+  });
+  it('should return a function if CONFIG.filterRuntimeDevErrors is a function', () => {
+    globalThis.mockConstants = {
+      ...getConstants(),
+      CONFIG: { filterRuntimeDevErrors: () => false },
+    };
+
+    expect(getFilterDevRuntimeErrors()).toBe('() => !1');
+    expect(mockLog).toBeCalledTimes(0);
+  });
+
+  it('should throws an error when CONFIG.filterRuntimeDevErrors is not a function', () => {
+    globalThis.mockConstants = {
+      ...getConstants(),
+      CONFIG: { filterRuntimeDevErrors: false },
+    } as any;
+
+    expect(getFilterDevRuntimeErrors()).toBe('() => true');
+    expect(mockLog.mock.calls.toString()).toContain(
+      'CONFIG.filterRuntimeDevErrors should be a function',
+    );
+  });
+
+  it('should return a function that always return true when CONFIG.filterRuntimeDevErrors is undefined', () => {
+    globalThis.mockConstants = {
+      ...getConstants(),
+      CONFIG: { filterRuntimeDevErrors: undefined },
+    };
+
+    expect(getFilterDevRuntimeErrors()).toBe('() => true');
+    expect(mockLog).toBeCalledTimes(0);
+  });
+});

--- a/packages/brisa/src/utils/brisa-error-dialog/inject-code.ts
+++ b/packages/brisa/src/utils/brisa-error-dialog/inject-code.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import clientBuildPlugin from '@/utils/client-build-plugin';
-import { logBuildError, logWarning } from '@/utils/log/log-build';
-import { getConstants } from '@/constants';
+import { logBuildError } from '@/utils/log/log-build';
 
 // Should be used via macro
 export async function injectBrisaDialogErrorCode() {
@@ -17,7 +16,7 @@ export async function injectBrisaDialogErrorCode() {
     target: 'browser',
     external: ['brisa'],
     define: {
-      __FILTER_DEV_RUNTIME_ERRORS__: getFilterDevRuntimeErrors(),
+      __FILTER_DEV_RUNTIME_ERRORS__: '__FILTER_DEV_RUNTIME_ERRORS__',
     },
     plugins: [
       {
@@ -42,22 +41,4 @@ export async function injectBrisaDialogErrorCode() {
   }
 
   return (await outputs?.[0]?.text?.()) ?? '';
-}
-
-export function getFilterDevRuntimeErrors() {
-  const { CONFIG } = getConstants();
-  const filterType = typeof CONFIG.filterRuntimeDevErrors;
-
-  if (filterType === 'function') {
-    return CONFIG.filterRuntimeDevErrors!.toString();
-  }
-
-  if (filterType !== 'undefined') {
-    logWarning(
-      ['CONFIG.filterRuntimeDevErrors should be a function'],
-      'Docs: https://brisa.build/building-your-application/configuring/filter-runtime-dev-errors',
-    );
-  }
-
-  return '() => true';
 }

--- a/packages/brisa/src/utils/brisa-error-dialog/utils.test.ts
+++ b/packages/brisa/src/utils/brisa-error-dialog/utils.test.ts
@@ -1,6 +1,6 @@
 import { getConstants } from '@/constants';
 import { describe, it, expect, afterEach, spyOn } from 'bun:test';
-import { getFilterDevRuntimeErrors } from './inject-code';
+import { getFilterDevRuntimeErrors } from './utils';
 
 const mockLog = spyOn(console, 'log');
 

--- a/packages/brisa/src/utils/brisa-error-dialog/utils.ts
+++ b/packages/brisa/src/utils/brisa-error-dialog/utils.ts
@@ -1,0 +1,20 @@
+import { getConstants } from '@/constants';
+import { logWarning } from '../log/log-build';
+
+export function getFilterDevRuntimeErrors() {
+  const { CONFIG } = getConstants();
+  const filterType = typeof CONFIG.filterRuntimeDevErrors;
+
+  if (filterType === 'function') {
+    return CONFIG.filterRuntimeDevErrors!.toString();
+  }
+
+  if (filterType !== 'undefined') {
+    logWarning(
+      ['CONFIG.filterRuntimeDevErrors should be a function'],
+      'Docs: https://brisa.build/building-your-application/configuring/filter-runtime-dev-errors',
+    );
+  }
+
+  return '() => true';
+}

--- a/packages/brisa/src/utils/brisa-error-dialog/web-components/brisa-error-dialog.tsx
+++ b/packages/brisa/src/utils/brisa-error-dialog/web-components/brisa-error-dialog.tsx
@@ -22,6 +22,10 @@ export default function ErrorDialog(
   const errors = derived(() => store.get<Error[]>(ERROR_STORE_KEY) ?? []);
   const numErrors = derived(() => errors.value?.length ?? 0);
   const currentIndex = state(0);
+  const filterDevRuntimeErrors = new Function(
+    'e',
+    `const cb = ${__FILTER_DEV_RUNTIME_ERRORS__}; return cb(e);`,
+  );
 
   effect(() => {
     self!.shadowRoot!.adoptedStyleSheets = [];
@@ -76,10 +80,11 @@ export default function ErrorDialog(
 
   effect(() => {
     window.addEventListener('error', (e) => {
-      if (isNavigateThrowable(e.error)) return;
+      if (!filterDevRuntimeErrors(e) || isNavigateThrowable(e.error)) return;
+
       displayDialog.value = true;
-      store.set('__BRISA_ERRORS__', [
-        ...(store.get<Error[]>('__BRISA_ERRORS__') ?? []),
+      store.set(ERROR_STORE_KEY, [
+        ...(store.get<Error[]>(ERROR_STORE_KEY) ?? []),
         {
           title: 'Uncaught Error',
           details: [e.error?.message ?? e.message ?? 'Unknown error'],

--- a/packages/brisa/src/utils/brisa-error-dialog/web-components/brisa-error-dialog.tsx
+++ b/packages/brisa/src/utils/brisa-error-dialog/web-components/brisa-error-dialog.tsx
@@ -22,7 +22,7 @@ export default function ErrorDialog(
   const errors = derived(() => store.get<Error[]>(ERROR_STORE_KEY) ?? []);
   const numErrors = derived(() => errors.value?.length ?? 0);
   const currentIndex = state(0);
-  const filterDevRuntimeErrors = new Function(
+  const filterRuntimeDevErrors = new Function(
     'e',
     `const cb = ${__FILTER_DEV_RUNTIME_ERRORS__}; return cb(e);`,
   );
@@ -80,7 +80,7 @@ export default function ErrorDialog(
 
   effect(() => {
     window.addEventListener('error', (e) => {
-      if (!filterDevRuntimeErrors(e) || isNavigateThrowable(e.error)) return;
+      if (!filterRuntimeDevErrors(e) || isNavigateThrowable(e.error)) return;
 
       displayDialog.value = true;
       store.set(ERROR_STORE_KEY, [

--- a/packages/brisa/src/utils/get-client-code-in-page/index.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.ts
@@ -17,6 +17,7 @@ import { injectClientContextProviderCode } from '@/utils/context-provider/inject
 import { injectBrisaDialogErrorCode } from '@/utils/brisa-error-dialog/inject-code' with {
   type: 'macro',
 };
+import { getFilterDevRuntimeErrors } from '@/utils/brisa-error-dialog/utils';
 import clientBuildPlugin from '@/utils/client-build-plugin';
 import createContextPlugin from '@/utils/create-context/create-context-plugin';
 import snakeToCamelCase from '@/utils/snake-to-camelcase';
@@ -205,8 +206,10 @@ export async function transformToWebComponents({
 
   // IS_DEVELOPMENT to avoid PROD and TEST environments
   if (IS_DEVELOPMENT) {
-    const brisaDialogErrorCode =
-      injectBrisaDialogErrorCode() as unknown as string;
+    const brisaDialogErrorCode = (await injectBrisaDialogErrorCode()).replace(
+      '__FILTER_DEV_RUNTIME_ERRORS__',
+      getFilterDevRuntimeErrors(),
+    );
     code += brisaDialogErrorCode;
   }
 

--- a/packages/www/brisa.config.ts
+++ b/packages/www/brisa.config.ts
@@ -4,4 +4,7 @@ import vercel from 'brisa-adapter-vercel';
 export default {
   output: 'static',
   outputAdapter: vercel(),
+  filterRuntimeDevErrors: (e) => {
+    return !e.message?.startsWith?.('ResizeObserver') ?? true;
+  },
 } satisfies Configuration;

--- a/packages/www/src/components/side-bar.tsx
+++ b/packages/www/src/components/side-bar.tsx
@@ -47,7 +47,7 @@ function generateList(name: string | undefined, pathname: string) {
 
 function isSummaryOpened(item: Item, pathname: string) {
   return (
-    (pathname.startsWith('/getting-started') && item.collapse === false) ||
+    (pathname.startsWith('/getting-started') && item.collapsed === false) ||
     Boolean(pathname?.startsWith?.(item.id ?? item.link ?? '-'))
   );
 }

--- a/packages/www/src/config.ts
+++ b/packages/www/src/config.ts
@@ -5,7 +5,7 @@ export default {
     {
       text: '🚀 Getting started',
       id: '/getting-started',
-      collapse: false,
+      collapsed: false,
       items: [
         {
           text: 'What is Brisa?',
@@ -24,11 +24,11 @@ export default {
     {
       text: '🛠️ Building your application',
       id: '/building-your-application',
-      collapse: false,
+      collapsed: false,
       items: [
         {
           text: '🛣️ Routing',
-          collapse: false,
+          collapsed: false,
           id: '/building-your-application/routing',
           items: [
             {

--- a/packages/www/src/config.ts
+++ b/packages/www/src/config.ts
@@ -218,6 +218,10 @@ export default {
               link: '/building-your-application/configuring/clustering',
             },
             {
+              text: 'Filter runtime dev errors',
+              link: '/building-your-application/configuring/filter-runtime-dev-errors',
+            },
+            {
               text: 'Content Security Policy',
               link: '/building-your-application/configuring/content-security-policy',
             },

--- a/packages/www/src/public/content.json
+++ b/packages/www/src/public/content.json
@@ -2937,7 +2937,7 @@
   {
     "id": "/building-your-application/configuring/brisa-config-js#brisaconfigts-options",
     "title": "brisa.config.ts options",
-    "text": "The brisa.config.(js|ts|jsx|tsx) file is the main configuration file for an application using the Brisa framework. This file should export by default an object that satisfies the Configuration type structure. Below is a detailed explanation of how to define this configuration file and a unified example with comments on default values and how to configure them. import brisaTailwindCSS from \"brisa-tailwindcss\";\nimport type { Configuration } from \"brisa\";\n\nconst config: Configuration = {\n  /**\n   * `trailingSlash` configuration\n   * Default: undefined (trailing slash is not modified)\n   */\n  trailingSlash: true, // Adds trailing slash to URLs\n\n  /**\n   * `assetPrefix` configuration\n   * Default: undefined (no prefix added to assets)\n   */\n  assetPrefix: \"https://cdn.example.com\", // Prefix for assets\n\n  /**\n   * `extendPlugins` configuration\n   * Default: undefined (no additional plugins added)\n   */\n  extendPlugins: (plugins, { dev, isServer }) => [\n    ...plugins,\n    {\n      name: \"my-plugin\",\n      setup(build) {\n        build.onLoad({ filter: /\\.txt$/ }, async (args) => {\n          return {\n            contents: \"export default \" + JSON.stringify(args.path) + \";\",\n            loader: \"js\",\n          };\n        });\n      },\n    },\n  ],\n\n  /**\n   * `basePath` configuration\n   * Default: undefined (no base path added)\n   */\n  basePath: \"/my-app\", // Base path for the application\n\n  /**\n   * `tls` configuration\n   * Default: undefined (HTTPS is not enabled)\n   */\n  tls: {\n    cert: Bun.file(\"cert.pem\"),\n    key: Bun.file(\"key.pem\"),\n  }, // Enable HTTPS\n\n  /**\n   * `output` configuration\n   * Default: 'bun'\n   */\n  output: \"static\", // Output type of the application\n\n  /**\n   * `external` configuration\n   * Default: undefined (no external dependencies)\n   */\n  external: [\"lightningcss\"],\n\n  /**\n   * `integrations` configuration\n   * Default: undefined (no integrations added)\n   */\n  integrations: [brisaTailwindCSS()],\n};\n\n// Export the configuration as the default export\nexport default config satisfies Configuration;",
+    "text": "The brisa.config.(js|ts|jsx|tsx) file is the main configuration file for an application using the Brisa framework. This file should export by default an object that satisfies the Configuration type structure. Below is a detailed explanation of how to define this configuration file and a unified example with comments on default values and how to configure them. import brisaTailwindCSS from \"brisa-tailwindcss\";\nimport type { Configuration } from \"brisa\";\n\nconst config: Configuration = {\n  /**\n   * `trailingSlash` configuration\n   * Default: undefined (trailing slash is not modified)\n   */\n  trailingSlash: true, // Adds trailing slash to URLs\n\n  /**\n   * `assetPrefix` configuration\n   * Default: undefined (no prefix added to assets)\n   */\n  assetPrefix: \"https://cdn.example.com\", // Prefix for assets\n\n  /**\n   * `extendPlugins` configuration\n   * Default: undefined (no additional plugins added)\n   */\n  extendPlugins: (plugins, { dev, isServer }) => [\n    ...plugins,\n    {\n      name: \"my-plugin\",\n      setup(build) {\n        build.onLoad({ filter: /\\.txt$/ }, async (args) => {\n          return {\n            contents: \"export default \" + JSON.stringify(args.path) + \";\",\n            loader: \"js\",\n          };\n        });\n      },\n    },\n  ],\n\n  /**\n   * `basePath` configuration\n   * Default: undefined (no base path added)\n   */\n  basePath: \"/my-app\", // Base path for the application\n\n  /**\n   * `tls` configuration\n   * Default: undefined (HTTPS is not enabled)\n   */\n  tls: {\n    cert: Bun.file(\"cert.pem\"),\n    key: Bun.file(\"key.pem\"),\n  }, // Enable HTTPS\n\n  /**\n   * `output` configuration\n   * Default: 'bun'\n   */\n  output: \"static\", // Output type of the application\n\n  /**\n   * `external` configuration\n   * Default: undefined (no external dependencies)\n   */\n  external: [\"lightningcss\"],\n\n  /**\n   * `integrations` configuration\n   * Default: undefined (no integrations added)\n   */\n  integrations: [brisaTailwindCSS()],\n\n  /**\n   * `filterRuntimeDevErrors` configuration\n   * Default: () => true (no errors are filtered)\n   */\n  filterRuntimeDevErrors?(error: ErrorEvent): boolean;\n};\n\n// Export the configuration as the default export\nexport default config satisfies Configuration;",
     "titles": []
   },
   {
@@ -3000,6 +3000,14 @@
     "id": "/building-your-application/configuring/brisa-config-js#integrationsbuilding-your-applicationconfiguringintegrations",
     "title": "integrations",
     "text": "The integrations option allows you to integrate third-party libraries with the Brisa internals. This is useful when you want to automatically handle the integration of libraries like TailwindCSS.",
+    "titles": [
+      "brisa.config.ts options"
+    ]
+  },
+  {
+    "id": "/building-your-application/configuring/brisa-config-js#filterruntimedeverrorsbuilding-your-applicationconfiguringfilter-runtime-dev-errors",
+    "title": "filterRuntimeDevErrors",
+    "text": "The filterRuntimeDevErrors option allows you to filter runtime development errors. This is useful for filtering out errors that are not relevant to your application.",
     "titles": [
       "brisa.config.ts options"
     ]
@@ -3232,6 +3240,28 @@
     "text": "export type Configuration = {\n  // ...\n  external?: string[];\n};",
     "titles": [
       "External Dependencies"
+    ]
+  },
+  {
+    "id": "/building-your-application/configuring/filter-runtime-dev-errors#filter-runtime-development-errors",
+    "title": "Filter Runtime Development Errors",
+    "text": "The filterRuntimeDevErrors configuration property in brisa.config.ts allows you to filter runtime development errors. This is useful for filtering out errors that are not relevant to your application.",
+    "titles": []
+  },
+  {
+    "id": "/building-your-application/configuring/filter-runtime-dev-errors#example",
+    "title": "Example",
+    "text": "In the next example, we are filtering out the TypeError error. This means that the error will not be logged to the console. import type { Configuration } from \"brisa\";\n\nexport default {\n  filterRuntimeDevErrors(error: ErrorEvent) {\n    return !(error.error instanceof TypeError);\n  },\n} satisfies Configuration; This config property is stringified and passed to the client code only during development, so it should not have any side effects.",
+    "titles": [
+      "Filter Runtime Development Errors"
+    ]
+  },
+  {
+    "id": "/building-your-application/configuring/filter-runtime-dev-errors#types",
+    "title": "Types",
+    "text": "export type Configuration = {\n  // ...\n  filterRuntimeDevErrors?(error: ErrorEvent): boolean;\n};",
+    "titles": [
+      "Filter Runtime Development Errors"
     ]
   },
   {

--- a/packages/www/src/types.ts
+++ b/packages/www/src/types.ts
@@ -7,6 +7,5 @@ export type Item = {
 };
 
 export type Config = {
-  dir: string;
   sidebar: Item[];
 };


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/515

Proposal by @enzonotario , already applied to the `www` project to ignore the Monaco Editor error about `ResizeError`

# Filter Runtime Development Errors

The `filterRuntimeDevErrors` configuration property in `brisa.config.ts` allows you to filter runtime development errors. This is useful for filtering out errors that are not relevant to your application.

## Example

In the next example, we are filtering out the `TypeError` error. This means that the error will not be logged to the console.

**brisa.config.ts**:

```ts 4
import type { Configuration } from "brisa";

export default {
  filterRuntimeDevErrors(error: ErrorEvent) {
    return !(error.error instanceof TypeError);
  },
} satisfies Configuration;
```

> [!IMPORTANT]
>
> This config property is stringified and passed to the client code only during development, so it should not have any side effects.

## Types

```ts
export type Configuration = {
  // ...
  filterRuntimeDevErrors?(error: ErrorEvent): boolean;
};
```

