### PR TITLE
fix: not log _Fragment (swc of playground)

### DIFF
--- a/packages/brisa/src/utils/client-build-plugin/transform-to-reactive-arrays/index.ts
+++ b/packages/brisa/src/utils/client-build-plugin/transform-to-reactive-arrays/index.ts
@@ -6,6 +6,7 @@ import { logError, logWarning } from '@/utils/log/log-build';
 import { JSX_NAME } from '@/utils/ast/constants';
 import { BOOLEANS_IN_HTML } from '@/public-constants';
 
+const fragmentNames = new Set(['Fragment', '_Fragment']);
 export const logsPerFile = new Set<string | undefined>();
 
 export default function transformToReactiveArrays(
@@ -42,7 +43,7 @@ export default function transformToReactiveArrays(
 
     if (
       value.arguments[0].type === 'Identifier' &&
-      value.arguments[0].name !== 'Fragment'
+      !fragmentNames.has(value.arguments[0].name)
     ) {
       const errorMessages = [
         `You can't use "${value.arguments[0].name}" variable as a tag name.`,


### PR DESCRIPTION
SWC modifies the name of the fragment, this is why this log was not skipped. With this change it fixes

Fixes https://github.com/brisa-build/brisa/issues/541