### PR TITLE
fix: skip set attribute when value is `undefined`

### DIFF
--- a/packages/brisa/src/utils/brisa-element/index.test.ts
+++ b/packages/brisa/src/utils/brisa-element/index.test.ts
@@ -4054,5 +4054,19 @@ describe('utils', () => {
         '1234-543-4234-5425-1231111-222-333-444-555',
       );
     });
+
+    it('should not add attribute as undefined', () => {
+      const Component = () => {
+        return ['div', { id: undefined }, ''];
+      };
+
+      customElements.define('id-component', brisaElement(Component));
+
+      document.body.innerHTML = '<id-component />';
+
+      const idComponent = document.querySelector('id-component') as HTMLElement;
+
+      expect(idComponent?.shadowRoot?.innerHTML).toBe('<div></div>');
+    });
   });
 });

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -126,6 +126,8 @@ export default function brisaElement(
       ? stylePropsToString(value as unknown as JSX.CSSProperties)
       : serialize(value);
 
+    if (serializedValue === undefined) return;
+
     const isWithNamespace =
       el.namespaceURI === SVG_NAMESPACE &&
       (key.startsWith('xlink:') || key === 'href');


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/539