### PR TITLE
fix(i18n): use `interpolation` and `format` inside Web Components

### DIFF
--- a/docs/building-your-application/routing/internationalization.md
+++ b/docs/building-your-application/routing/internationalization.md
@@ -681,6 +681,26 @@ Returns:
 - In English: `The number is 33.5`
 - In Spanish: `El número es 33,5`
 
+> [!CAUTION]
+>
+> The `format` function is serialized to the client using `.toString()`. This means it cannot reference any external variables or functions outside of `format` itself. If you want to avoid sending unnecessary formatters that are only used on the server to the client, follow this approach:
+>
+> Example:
+>
+> ```ts
+> function format(value: number, format: string, lang: string) {
+>   if (typeof window !== 'undefined') {
+>     if (format === "uppercase") return value.toUpperCase();
+>     return value;
+>   }
+>   
+>   // Only runs on the server
+>   return serverFormat(value, format, lang);
+> }
+> ```
+>
+> By using the external identifier `serverFormat`, the code for `serverFormat` will not be included in the client-side bundle.
+
 ### Nested messages
 
 It's possible to use nested messages in the JSONs:

--- a/packages/brisa/src/utils/client-build-plugin/add-i18n-bridge/index.test.ts
+++ b/packages/brisa/src/utils/client-build-plugin/add-i18n-bridge/index.test.ts
@@ -436,6 +436,48 @@ describe('utils', () => {
           },
         });
       });
+
+      it('should add interpolation.format function on the client-side', () => {
+        mock.module('@/constants', () => ({
+          default: {
+            I18N_CONFIG: {
+              ...I18N_CONFIG,
+              interpolation: {
+                format: (value, formatName, lang) => {
+                  if (formatName === 'uppercase') {
+                    return (value as string).toUpperCase();
+                  }
+                  if (formatName === 'lang') return lang;
+                  return value;
+                },
+              },
+            } as I18nConfig,
+          },
+        }));
+
+        const ast = addI18nBridge(emptyAst, {
+          usei18nKeysLogic: true,
+          i18nAdded: false,
+          isTranslateCoreAdded: false,
+        });
+
+        const output = generateCodeFromAST(ast);
+        expect(normalizeHTML(output)).toContain(
+          normalizeHTML(`return translateCore(this.locale, {
+        ...i18nConfig,
+          messages: this.messages,
+            interpolation: {
+              ...i18nConfig.interpolation,
+                format: (value, formatName, lang) => {
+                  if (formatName === "uppercase") return value.toUpperCase();
+                      if (formatName === "lang") return lang;
+                      return value;
+                  }      
+                }    
+            }
+        );`),
+        );
+      });
     });
   });
 });

--- a/packages/brisa/src/utils/client-build-plugin/add-i18n-bridge/index.ts
+++ b/packages/brisa/src/utils/client-build-plugin/add-i18n-bridge/index.ts
@@ -12,9 +12,15 @@ type I18nBridgeConfig = {
   i18nAdded: boolean;
 };
 
-const i18nKeysLogic = (configText = 'i18nConfig') => `
+const i18nKeysLogic = (configText = 'i18nConfig') => {
+  const formatters =
+    typeof constants.I18N_CONFIG.interpolation?.format === 'function'
+      ? `interpolation: {...i18nConfig.interpolation, format:${constants.I18N_CONFIG.interpolation?.format.toString()}},`
+      : '';
+
+  return `
   get t() {
-    return translateCore(this.locale, { ...${configText}, messages: this.messages })
+    return translateCore(this.locale, { ...${configText}, messages: this.messages, ${formatters} });
   },
   get messages() { return {[this.locale]: window.i18nMessages } },
   overrideMessages(callback) {
@@ -23,6 +29,7 @@ const i18nKeysLogic = (configText = 'i18nConfig') => `
     return p.then?.(a) ?? a(p);
   }
 `;
+};
 
 export default function addI18nBridge(
   ast: ESTree.Program,

--- a/packages/brisa/src/utils/client-build-plugin/add-i18n-bridge/index.ts
+++ b/packages/brisa/src/utils/client-build-plugin/add-i18n-bridge/index.ts
@@ -14,7 +14,7 @@ type I18nBridgeConfig = {
 
 const i18nKeysLogic = (configText = 'i18nConfig') => {
   const formatters =
-    typeof constants.I18N_CONFIG.interpolation?.format === 'function'
+    typeof constants.I18N_CONFIG?.interpolation?.format === 'function'
       ? `interpolation: {...i18nConfig.interpolation, format:${constants.I18N_CONFIG.interpolation?.format.toString()}},`
       : '';
 

--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 3072;
 const brisaSize = 5820; // TODO: Reduce this size :/
 const webComponents = 1145;
 const unsuspenseSize = 217;
-const rpcSize = 2467; // TODO: Reduce this size
+const rpcSize = 2468; // TODO: Reduce this size
 const lazyRPCSize = 4171; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/545

The formatters of i18n ([`interpolation.format`](https://brisa.build/building-your-application/routing/internationalization#formatters)) are not being taken to the client, therefore the **whole interpolation** part cannot be used inside the web components right now, it is only being applied in the server components and during the SSR of the Web Components.

