### PR TITLE
fix: "Upgrade Bun" message prompts the user to install their current version

### DIFF
--- a/packages/brisa/cli.ts
+++ b/packages/brisa/cli.ts
@@ -64,8 +64,8 @@ async function main({
   if (!Bun.semver.satisfies(currentBunVersion, '>=' + SUPPORTED_BUN_VERSION)) {
     const isWindows = process.platform === 'win32';
     const command = isWindows
-      ? `iex "& {$(irm https://bun.sh/install.ps1)} -Version ${currentBunVersion}"`
-      : `curl -fsSL https://bun.sh/install | bash -s "bun-v${currentBunVersion}"`;
+      ? `iex "& {$(irm https://bun.sh/install.ps1)} -Version ${SUPPORTED_BUN_VERSION}"`
+      : `curl -fsSL https://bun.sh/install | bash -s "bun-v${SUPPORTED_BUN_VERSION}"`;
 
     console.log(
       yellowLog(


### PR DESCRIPTION
"Upgrade Bun" message prompts the user to install their current version.

![Screenshot 2024-10-13 at 22 01 18](https://github.com/user-attachments/assets/389efbf1-35b4-403f-923e-9d585990805f)

Following this message leads to the same error.

We want the user to install `SUPPORTED_BUN_VERSION` instead.
