### PR TITLE
fix: fix composed extensions in `fileSystemRouter`

### DIFF
--- a/packages/brisa/src/utils/file-system-router/index.test.ts
+++ b/packages/brisa/src/utils/file-system-router/index.test.ts
@@ -188,6 +188,17 @@ describe('utils', () => {
       ]);
     });
 
+    it('should work with composed fileExtension', () => {
+      const router = fileSystemRouter({
+        dir,
+        fileExtensions: ['-us.tsx'],
+      });
+
+      expect(router.routes).toEqual([
+        ['/about', path.join(dir, 'about-us.tsx')],
+      ]);
+    })
+
     it('should resolve only the tsx files', () => {
       const router = fileSystemRouter({
         dir,

--- a/packages/brisa/src/utils/file-system-router/index.ts
+++ b/packages/brisa/src/utils/file-system-router/index.ts
@@ -140,9 +140,9 @@ function resolveRoutes({
   for (const file of files) {
     if (file.isDirectory() || isTestFile(file.name, true)) continue;
 
-    const ext = path.extname(file.name);
+    const ext = fileExtensions.find((ext) => file.name.endsWith(ext));
 
-    if (!fileExtensions.includes(ext)) continue;
+    if (!ext) continue;
 
     const filePath = path.resolve(file.parentPath, file.name);
     let route = filePath


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/551

Allows `fileSystemRouter` to support compound extensions, such as `.d.ts`.