### PR TITLE
fix(actions): publish commits via pkg-pr-new

### DIFF
--- a/.github/workflows/publish-commits.yml
+++ b/.github/workflows/publish-commits.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Publish Any Commit
 
 on:
   push:
@@ -7,11 +7,8 @@ on:
     branches: [canary]
 
 jobs:
-  bun-tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+  build:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -26,27 +23,5 @@ jobs:
         run: bun install
       - name: Build project
         run: bun run build && bun run create-brisa:build
-      - name: Run Bun tests
-        run: bun test
-
-  node-tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '22'
-      - name: Setup Bun.js
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: 1.1.30
-      - name: Install dependencies
-        run: bun install
-      - name: Build project
-        run: bun run build && bun run create-brisa:build
-      - name: Run Node.js tests
-        run: bun run test:node
+      - name: Publish commits
+        run: bunx pkg-pr-new publish './packages/*'


### PR DESCRIPTION
Fixes GH Actions to publish Packages via pkg-pr-new on every PR.