### PR TITLE
fix: fix WC regex for Windows

### DIFF
--- a/packages/brisa/src/utils/server-component-plugin/index.test.ts
+++ b/packages/brisa/src/utils/server-component-plugin/index.test.ts
@@ -61,6 +61,26 @@ describe('utils', () => {
       expect(out.dependencies).toBeEmpty();
     });
 
+    it('should not add the action if is a web-component with Window separator', () => {
+      const wcPath = `${FIXTURES}\\web-components\\web-component.tsx`;
+      const code = `
+        export default function WebComponent() {
+          return <button onClick={() => console.log('clicked')}>click</button>;
+        }
+      `;
+      const allWebComponents = {
+        'web-component': wcPath,
+      };
+
+      const out = serverComponentPlugin(code, {
+        allWebComponents,
+        fileID: 'a1',
+        path: wcPath,
+      });
+      expect(out.hasActions).toBeFalse();
+      expect(out.dependencies).toBeEmpty();
+    });
+
     it('should wrap the web-component to SSR wrapper when selectorToWrapDeclarativeShadowDom is true', () => {
       const code = `
         export default function WebComponent() {

--- a/packages/brisa/src/utils/server-component-plugin/index.ts
+++ b/packages/brisa/src/utils/server-component-plugin/index.ts
@@ -16,7 +16,7 @@ type ServerComponentPluginOptions = {
 const { parseCodeToAST, generateCodeFromAST } = AST('tsx');
 const JSX_NAME = new Set(['jsx', 'jsxDEV', 'jsxs']);
 const SERVER_OUPUTS = new Set(['bun', 'node']);
-const WEB_COMPONENT_REGEX = /.*\/web-components\/.*/;
+const WEB_COMPONENT_REGEX = /.*[\/\\]web-components[\/\\].*/;
 const FN_EXPRESSIONS = new Set([
   'ArrowFunctionExpression',
   'FunctionExpression',


### PR DESCRIPTION
Related https://github.com/brisa-build/brisa/issues/538

This was causing an useless warning in Windows:

```sh
[ warn ]   Ops! Warning:
[ warn ]   --------------------------
[ warn ]   Actions are not supported with the "output": "static" option.
[ warn ]
[ warn ]   The warn arises in: J:\brisa\packages\www\src\web-components\custom-counter.tsx
[ warn ]
[ warn ]   This limitation is due to the requirement of a server infrastructure for the proper functioning
[ warn ]   of server actions.
[ warn ]
[ warn ]   To resolve this, ensure that the "output" option is set to "bun" or "node" when using server actions.
[ warn ]
[ warn ]   Feel free to reach out if you have any further questions or encounter challenges during this process.
[ warn ]
[ warn ]   Documentation: https://brisa.build/building-your-application/data-management/server-actions#server-actions
```