### PR TITLE
chore(packages): set npm/yarn/pnpm versions

### DIFF
--- a/.github/workflows/publish-commits.yml
+++ b/.github/workflows/publish-commits.yml
@@ -21,6 +21,8 @@ jobs:
           bun-version: 1.1.30
       - name: Install dependencies
         run: bun install
+      - name: Install Brisa globally
+        run: bun i -g brisa
       - name: Build project
         run: bun run build:all
       - name: Publish commits

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Bun.js
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.31
+          bun-version: 1.1.32
       - name: Install dependencies
         run: bun install
       - name: Build project
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Bun.js
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.1.31
+          bun-version: 1.1.32
       - name: Install dependencies
         run: bun install
       - name: Build project

--- a/docs/building-your-application/deploying/docker.md
+++ b/docs/building-your-application/deploying/docker.md
@@ -14,7 +14,7 @@ To _containerize_ our application, we define a `Dockerfile`. This file contains 
 
 ```dockerfile
 # Adjust BUN_VERSION as desired
-ARG BUN_VERSION=1.1.31
+ARG BUN_VERSION=1.1.32
 FROM oven/bun:${BUN_VERSION}-slim AS base
 
 # Brisa app lives here

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -11,7 +11,7 @@ related:
 
 ### System Requirements
 
-- Bun [<w-badge type="tip" text="1.1.31" />](https://bun.sh/) or later
+- Bun [<w-badge type="tip" text="1.1.32" />](https://bun.sh/) or later
 - macOS, Windows (including WSL), and Linux are supported.
 
 ### Automatic Installation

--- a/package.json
+++ b/package.json
@@ -46,9 +46,9 @@
     "www:deploy": "bun run build && bun run www:build && vercel --prod",
     "prepare": "husky"
   },
-  "packageManager": "bun@1.1.31",
+  "packageManager": "bun@1.1.32",
   "engines": {
-    "bun": ">= 1.1.31",
+    "bun": ">= 1.1.32",
     "npm": ">= 10.0.0",
     "yarn": ">= 3.0.0",
     "pnpm": ">= 9.8.0"

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
   "packageManager": "bun@1.1.31",
   "engines": {
     "bun": ">= 1.1.31",
-    "npm": "please-use-bun",
-    "yarn": "please-use-bun",
-    "pnpm": "please-use-bun"
+    "npm": ">= 10.0.0",
+    "yarn": ">= 3.0.0",
+    "pnpm": ">= 9.8.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.2",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -18,13 +18,15 @@
     "url": "git+https://github.com/brisa-build/brisa.git",
     "directory": "packages/adapter-vercel"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "brisa": "workspace:*"
   },
-  "packageManager": "bun@1.1.31",
+  "packageManager": "bun@1.1.32",
   "engines": {
-    "bun": ">= 1.1.31",
+    "bun": ">= 1.1.32",
     "npm": ">= 10.0.0",
     "yarn": ">= 3.0.0",
     "pnpm": ">= 9.8.0"

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -25,9 +25,9 @@
   "packageManager": "bun@1.1.31",
   "engines": {
     "bun": ">= 1.1.31",
-    "npm": "please-use-bun",
-    "yarn": "please-use-bun",
-    "pnpm": "please-use-bun"
+    "npm": ">= 10.0.0",
+    "yarn": ">= 3.0.0",
+    "pnpm": ">= 9.8.0"
   },
   "description": "A Brisa adapter that creates a Vercel app.",
   "bugs": {

--- a/packages/brisa-pandacss/package.json
+++ b/packages/brisa-pandacss/package.json
@@ -23,9 +23,9 @@
   "packageManager": "bun@1.1.31",
   "engines": {
     "bun": ">= 1.1.31",
-    "npm": "please-use-bun",
-    "yarn": "please-use-bun",
-    "pnpm": "please-use-bun"
+    "npm": ">= 10.0.0",
+    "yarn": ">= 3.0.0",
+    "pnpm": ">= 9.8.0"
   },
   "description": "A Brisa integration with Panda CSS.",
   "bugs": {

--- a/packages/brisa-pandacss/package.json
+++ b/packages/brisa-pandacss/package.json
@@ -15,14 +15,17 @@
     "url": "git+https://github.com/brisa-build/brisa.git",
     "directory": "packages/brisa-pandacss"
   },
-  "files": ["index.ts", "index.d.ts"],
+  "files": [
+    "index.ts",
+    "index.d.ts"
+  ],
   "dependencies": {
     "@pandacss/dev": "0.46.1",
     "postcss": "8.4.47"
   },
-  "packageManager": "bun@1.1.31",
+  "packageManager": "bun@1.1.32",
   "engines": {
-    "bun": ">= 1.1.31",
+    "bun": ">= 1.1.32",
     "npm": ">= 10.0.0",
     "yarn": ">= 3.0.0",
     "pnpm": ">= 9.8.0"

--- a/packages/brisa-tailwindcss/package.json
+++ b/packages/brisa-tailwindcss/package.json
@@ -24,9 +24,9 @@
   "packageManager": "bun@1.1.31",
   "engines": {
     "bun": ">= 1.1.31",
-    "npm": "please-use-bun",
-    "yarn": "please-use-bun",
-    "pnpm": "please-use-bun"
+    "npm": ">= 10.0.0",
+    "yarn": ">= 3.0.0",
+    "pnpm": ">= 9.8.0"
   },
   "description": "A Brisa integration with Tailwind CSS.",
   "bugs": {

--- a/packages/brisa-tailwindcss/package.json
+++ b/packages/brisa-tailwindcss/package.json
@@ -15,15 +15,18 @@
     "url": "git+https://github.com/brisa-build/brisa.git",
     "directory": "packages/brisa-tailwindcss"
   },
-  "files": ["index.ts", "index.d.ts"],
+  "files": [
+    "index.ts",
+    "index.d.ts"
+  ],
   "dependencies": {
     "@tailwindcss/postcss": "4.0.0-alpha.25",
     "postcss": "8.4.47",
     "tailwindcss": "4.0.0-alpha.25"
   },
-  "packageManager": "bun@1.1.31",
+  "packageManager": "bun@1.1.32",
   "engines": {
-    "bun": ">= 1.1.31",
+    "bun": ">= 1.1.32",
     "npm": ">= 10.0.0",
     "yarn": ">= 3.0.0",
     "pnpm": ">= 9.8.0"

--- a/packages/brisa/package.json
+++ b/packages/brisa/package.json
@@ -100,7 +100,9 @@
     "test",
     "cli.js"
   ],
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "build": "bun run clean && bun run build:jsx-runtime && bun run build:jsx-dev-runtime && bun run build:core && bun run build:core-client && bun run build:core-server && bun run build:core-macros && bun run build:core-test && bun run build:core-compiler",
     "build:cli": "bun build --minify --target=bun --outdir=./ cli.ts && bun run build:cli-utils",
@@ -138,9 +140,9 @@
     "brisa-tailwindcss": "workspace:*",
     "brisa-pandacss": "workspace:*"
   },
-  "packageManager": "bun@1.1.31",
+  "packageManager": "bun@1.1.32",
   "engines": {
-    "bun": ">= 1.1.31",
+    "bun": ">= 1.1.32",
     "npm": ">= 10.0.0",
     "yarn": ">= 3.0.0",
     "pnpm": ">= 9.8.0"

--- a/packages/brisa/package.json
+++ b/packages/brisa/package.json
@@ -141,8 +141,8 @@
   "packageManager": "bun@1.1.31",
   "engines": {
     "bun": ">= 1.1.31",
-    "npm": "please-use-bun",
-    "yarn": "please-use-bun",
-    "pnpm": "please-use-bun"
+    "npm": ">= 10.0.0",
+    "yarn": ">= 3.0.0",
+    "pnpm": ">= 9.8.0"
   }
 }

--- a/packages/create-brisa/package.json
+++ b/packages/create-brisa/package.json
@@ -24,9 +24,9 @@
   "packageManager": "bun@1.1.31",
   "engines": {
     "bun": ">= 1.1.31",
-    "npm": "please-use-bun",
-    "yarn": "please-use-bun",
-    "pnpm": "please-use-bun"
+    "npm": ">= 10.0.0",
+    "yarn": ">= 3.0.0",
+    "pnpm": ">= 9.8.0"
   },
   "devDependencies": {
     "brisa": "latest"

--- a/packages/create-brisa/package.json
+++ b/packages/create-brisa/package.json
@@ -17,13 +17,17 @@
     "url": "https://github.com/brisa-build/brisa.git",
     "directory": "packages/create-brisa"
   },
-  "files": ["create-brisa.cjs", "basic-template", "examples"],
+  "files": [
+    "create-brisa.cjs",
+    "basic-template",
+    "examples"
+  ],
   "bin": {
     "create-brisa": "./create-brisa.cjs"
   },
-  "packageManager": "bun@1.1.31",
+  "packageManager": "bun@1.1.32",
   "engines": {
-    "bun": ">= 1.1.31",
+    "bun": ">= 1.1.32",
     "npm": ">= 10.0.0",
     "yarn": ">= 3.0.0",
     "pnpm": ">= 9.8.0"

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -36,9 +36,9 @@
     "@types/jsdom": "21.1.7",
     "sharp": "0.33.5"
   },
-  "packageManager": "bun@1.1.31",
+  "packageManager": "bun@1.1.32",
   "engines": {
-    "bun": ">= 1.1.31",
+    "bun": ">= 1.1.32",
     "npm": ">= 10.0.0",
     "yarn": ">= 3.0.0",
     "pnpm": ">= 9.8.0"

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -39,8 +39,8 @@
   "packageManager": "bun@1.1.31",
   "engines": {
     "bun": ">= 1.1.31",
-    "npm": "please-use-bun",
-    "yarn": "please-use-bun",
-    "pnpm": "please-use-bun"
+    "npm": ">= 10.0.0",
+    "yarn": ">= 3.0.0",
+    "pnpm": ">= 9.8.0"
   }
 }

--- a/scripts/upgrade-bun.ts
+++ b/scripts/upgrade-bun.ts
@@ -31,15 +31,15 @@ packageJSON.engines =
   brisaTailwindCSSPackageJSON.engines =
     {
       bun: `>= ${version}`,
-      npm: 'please-use-bun',
-      yarn: 'please-use-bun',
-      pnpm: 'please-use-bun',
+      npm: ">= 10.0.0",
+      yarn: ">= 3.0.0",
+      pnpm: ">= 9.8.0"
     };
 brisaPandaCSSPackageJSON.engines = {
   bun: `>= ${version}`,
-  npm: 'please-use-bun',
-  yarn: 'please-use-bun',
-  pnpm: 'please-use-bun',
+  npm: ">= 10.0.0",
+  yarn: ">= 3.0.0",
+  pnpm: ">= 9.8.0"
 };
 // Update all the package.json files
 fs.writeFileSync(


### PR DESCRIPTION
It sets the engine versions for all packages, to be able to install it in environments like StackBlitz:

![image](https://github.com/user-attachments/assets/94383817-dd82-4088-9b54-b325bec04d42)
