### PR TITLE
fix: transform hard to soft redirect when it comes from SPA

### DIFF
--- a/docs/building-your-application/routing/middleware.md
+++ b/docs/building-your-application/routing/middleware.md
@@ -148,10 +148,23 @@ export default async function middleware(request) {
     // Continue processing the request
     return;
   }
+
+  // ... Manage other routes
 }
 ```
 
 When the user visits `/old`, the request will be rewritten to `/new`.
+
+> [!CAUTION]
+>
+> If after the rewrite you return a `Response` object, the rewrite will be ignored. So, if you want to rewrite properly, you should ensure to continue processing the request by returning nothing.
+>
+> ```ts
+> // ❌ Rewrite is ignored
+> request.finalURL = new URL("/new", request.finalURL).toString();
+> // ✅ Response is processed
+> return new Response("Hello World!");
+> ```
 
 ## Cookies & Headers
 

--- a/packages/brisa/src/cli/serve/index.tsx
+++ b/packages/brisa/src/cli/serve/index.tsx
@@ -99,7 +99,7 @@ const serveOptions = await getServeOptions();
 if (!serveOptions) process.exit(1);
 
 if (!process.env.USE_HANDLER) {
-  init(serveOptions);
+  init(serveOptions as ServeOptions);
 }
 
 // This is necesary for some adapters after build this

--- a/packages/brisa/src/cli/serve/node-serve/handler.ts
+++ b/packages/brisa/src/cli/serve/node-serve/handler.ts
@@ -23,7 +23,7 @@ export default async function handler(
     bunServer,
   );
 
-  await setResponse(res, response);
+  await setResponse(res, response!);
 }
 
 /*

--- a/packages/brisa/src/cli/serve/serve-options.test.tsx
+++ b/packages/brisa/src/cli/serve/serve-options.test.tsx
@@ -1824,6 +1824,118 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     ).toBeFalse();
   });
 
+  it('should return a soft redirect from an action', async () => {
+    globalThis.mockConstants = {
+      ...globalThis.mockConstants,
+      I18N_CONFIG: undefined,
+    };
+
+    const res = await testRequest(
+      new Request(
+        `http://localhost:1234${basePath}/somepage?_aid=2&redirect=/`,
+        {
+          method: 'POST',
+          headers: {
+            'x-action': 'a1_1',
+          },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-navigate')).toBe('/');
+  });
+
+  it('should return a soft redirect from an action with i18n resolving the correct locale', async () => {
+    const res = await testRequest(
+      new Request(
+        `http://localhost:1234${basePath}/en/somepage?_aid=2&redirect=/`,
+        {
+          method: 'POST',
+          headers: {
+            'x-action': 'a1_1',
+          },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-navigate')).toBe('/en');
+  });
+
+  it('should return a soft redirect from an SPA navigation', async () => {
+    globalThis.mockConstants = {
+      ...globalThis.mockConstants,
+      I18N_CONFIG: undefined,
+    };
+
+    const res = await testRequest(
+      new Request(`http://localhost:1234${basePath}/somepage?redirect=/`, {
+        method: 'POST',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-navigate')).toBe('/');
+  });
+
+  it('should return a soft redirect from an SPA Navigation with i18n resolving the correct locale', async () => {
+    const res = await testRequest(
+      new Request(`http://localhost:1234${basePath}/en/somepage?redirect=/`, {
+        method: 'POST',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-navigate')).toBe('/en');
+  });
+
+  it('should return a HARD redirect from an API endpoint', async () => {
+    globalThis.mockConstants = {
+      ...globalThis.mockConstants,
+      I18N_CONFIG: undefined,
+    };
+
+    const res = await testRequest(
+      new Request(`http://localhost:1234${basePath}/api/example?redirect=/`),
+    );
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('/');
+  });
+
+  it('should return a HARD redirect from an API endpoint with i18n resolving the correct locale', async () => {
+    const res = await testRequest(
+      new Request(`http://localhost:1234${basePath}/en/api/example?redirect=/`),
+    );
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('/en');
+  });
+
+  it('should return a HARD redirect from an initial render', async () => {
+    globalThis.mockConstants = {
+      ...globalThis.mockConstants,
+      I18N_CONFIG: undefined,
+    };
+
+    const res = await testRequest(
+      new Request(`http://localhost:1234${basePath}/somepage?redirect=/`),
+    );
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('/');
+  });
+
+  it('should return a HARD redirect from an initial render with i18n resolving the correct locale', async () => {
+    const res = await testRequest(
+      new Request(`http://localhost:1234${basePath}/en/somepage?redirect=/`),
+    );
+
+    expect(res.status).toBe(301);
+    expect(res.headers.get('location')).toBe('/en');
+  });
+
   it('should avoid declarative shadow DOM on server actions', async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 

--- a/packages/brisa/src/utils/generate-static-export/index.ts
+++ b/packages/brisa/src/utils/generate-static-export/index.ts
@@ -79,7 +79,7 @@ export default async function generateStaticExport(): Promise<
         fakeServer,
       );
 
-      const html = await response.text();
+      const html = await response!.text();
       const relativePath = (route?.filePath ?? '').replace(BUILD_DIR, '');
       let htmlPath: string;
 

--- a/packages/brisa/src/utils/hard-to-soft-redirect/index.test.ts
+++ b/packages/brisa/src/utils/hard-to-soft-redirect/index.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'bun:test';
+import extendRequestContext from '../extend-request-context';
+import hardToSoftRedirect, { handleSPARedirects } from '.';
+
+const req = extendRequestContext({
+  originalRequest: new Request('https://test.com'),
+});
+
+describe('utils', () => {
+  describe('hardToSoftRedirect', () => {
+    it('should return a response with the navigate header', () => {
+      const location = '/some-location';
+      const response = hardToSoftRedirect({ req, location });
+
+      expect(response.headers.get('X-Navigate')).toBe(location);
+      expect(response.headers.has('X-Mode')).toBeFalse();
+    });
+
+    it('should return a response with the navigate header and the mode reactivity', () => {
+      const location = '/some-location';
+      const mode = 'reactivity';
+      const response = hardToSoftRedirect({ req, location, mode });
+
+      expect(response.headers.get('X-Navigate')).toBe(location);
+      expect(response.headers.get('X-Mode')).toBe(mode);
+    });
+
+    it('should transfer the request store', async () => {
+      const reqWithStore = extendRequestContext({ originalRequest: req });
+      reqWithStore.store.set('foo', 'bar');
+      reqWithStore.store.transferToClient(['foo']);
+      const response = hardToSoftRedirect({
+        req: reqWithStore,
+        location: '/some-location',
+      });
+
+      expect(await response.json()).toEqual([['foo', 'bar']]);
+    });
+  });
+
+  describe('handleSPARedirects', () => {
+    it('should return the response as is when is not a hard redirect', () => {
+      const res = new Response(null, { status: 200 });
+      const response = handleSPARedirects(req, res);
+
+      expect(response).toBe(res);
+    });
+
+    it('should return the response as is when is a hard redirect with INITIAL_REQUEST initiator', () => {
+      const location = '/some-location';
+      const res = new Response(null, {
+        status: 302,
+        headers: { Location: location },
+      });
+      req.initiator = 'INITIAL_REQUEST';
+      const response = handleSPARedirects(req, res);
+
+      expect(response).toBe(res);
+    });
+
+    it('should return the response as is when is a hard redirect with API_REQUEST initiator', () => {
+      const location = '/some-location';
+      const res = new Response(null, {
+        status: 302,
+        headers: { Location: location },
+      });
+      req.initiator = 'API_REQUEST';
+      const response = handleSPARedirects(req, res);
+
+      expect(response).toBe(res);
+    });
+
+    it('should return a soft redirect response when a SPA soft redirect (initiator SPA_NAVIGATION)', () => {
+      const location = '/some-location';
+      const res = new Response(null, {
+        status: 302,
+        headers: { Location: location },
+      });
+      req.initiator = 'SPA_NAVIGATION';
+      const response = handleSPARedirects(req, res);
+
+      expect(response.headers.get('X-Navigate')).toBe(location);
+    });
+
+    it('should return a soft redirect response when a SPA soft redirect (initiator SERVER_ACTION)', () => {
+      const location = '/some-location';
+      const res = new Response(null, {
+        status: 302,
+        headers: { Location: location },
+      });
+      req.initiator = 'SERVER_ACTION';
+      const response = handleSPARedirects(req, res);
+
+      expect(response.headers.get('X-Navigate')).toBe(location);
+    });
+  });
+});

--- a/packages/brisa/src/utils/hard-to-soft-redirect/index.ts
+++ b/packages/brisa/src/utils/hard-to-soft-redirect/index.ts
@@ -1,0 +1,40 @@
+import type { RenderMode, RequestContext } from '@/types';
+import { resolveStore } from '../transfer-store-service';
+import type { InitiatorType } from '@/types/server';
+
+type HardToSoftRedirectParams = {
+  req: RequestContext;
+  location: string;
+  mode?: RenderMode;
+};
+
+const SPA_INITIATORS = new Set<keyof InitiatorType>([
+  'SPA_NAVIGATION',
+  'SERVER_ACTION',
+]);
+
+export default function hardToSoftRedirect({
+  req,
+  location,
+  mode,
+}: HardToSoftRedirectParams) {
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    'X-Navigate': location,
+  });
+
+  if (mode) headers.set('X-Mode', mode);
+
+  return new Response(resolveStore(req), { status: 200, headers });
+}
+
+export function handleSPARedirects(req: RequestContext, res: Response) {
+  const isSPASoftRedirect =
+    SPA_INITIATORS.has(req?.initiator) &&
+    res?.status >= 300 &&
+    res?.status < 400;
+
+  return isSPASoftRedirect
+    ? hardToSoftRedirect({ req, location: res.headers.get('Location')! })
+    : res;
+}

--- a/packages/brisa/src/utils/navigate/utils.ts
+++ b/packages/brisa/src/utils/navigate/utils.ts
@@ -1,3 +1,5 @@
+import type { RenderMode } from '@/types';
+
 const NAVIGATE_PREFIX = 'navigate:';
 
 export function isNavigateThrowable(error: unknown) {
@@ -5,5 +7,5 @@ export function isNavigateThrowable(error: unknown) {
 }
 
 export function getNavigateMode(error: Error) {
-  return error.name.replace(NAVIGATE_PREFIX, '');
+  return error.name.replace(NAVIGATE_PREFIX, '') as RenderMode;
 }

--- a/packages/brisa/src/utils/response-action/index.ts
+++ b/packages/brisa/src/utils/response-action/index.ts
@@ -3,7 +3,7 @@ import { getConstants } from '@/constants';
 import type { RequestContext } from '@/types';
 import { deserialize } from '@/utils/serialization';
 import transferStoreService from '@/utils/transfer-store-service';
-import { resolveStore } from '@/utils/resolve-action';
+import { resolveStore } from '@/utils/transfer-store-service';
 import { logError } from '@/utils/log/log-build';
 import { pathToFileURLWhenNeeded } from '../get-importable-filepath';
 

--- a/packages/brisa/src/utils/transfer-store-service/index.ts
+++ b/packages/brisa/src/utils/transfer-store-service/index.ts
@@ -75,3 +75,7 @@ export function getTransferedServerStoreToClient(request: RequestContext) {
 
   return store;
 }
+
+export function resolveStore(req: RequestContext) {
+  return JSON.stringify([...getTransferedServerStoreToClient(req)]);
+}


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/577

Now from the middleware, if you send `Response` with redirects and you are in the middle of a SPA navigation or a Server Action, the RPC Client knows how to manage it using a soft redirect and keeping the store.

@AlbertSabate I have clarified in the Middleware `rewrite` documentation with the proposals you made to me in the previous [PR](https://github.com/brisa-build/brisa/pull/586).
