### PR TITLE
fix(playground): fix back navigation on playground

### DIFF
--- a/packages/brisa/src/utils/replace-ast-imports-to-absolute/index.test.ts
+++ b/packages/brisa/src/utils/replace-ast-imports-to-absolute/index.test.ts
@@ -134,7 +134,7 @@ describe('utils', () => {
         'Error resolving import path:',
       );
       expect(mockLogError.mock.calls.toString()).toContain(
-        `Cannot find module "@/foo/unknown" from "file://${utilsDir}/replace-ast-imports-to-absolute`,
+        `Cannot find module '@/foo/unknown' from 'file://${utilsDir}/replace-ast-imports-to-absolute`,
       );
       expect(result).toEqual(expected);
       mockLogError.mockRestore();

--- a/packages/www/src/pages/playground/index.tsx
+++ b/packages/www/src/pages/playground/index.tsx
@@ -93,6 +93,13 @@ export default function Playground() {
 
               window._xm = "native";
               window.changeTheme = monaco.editor.setTheme.bind(monaco.editor);
+              function nav(e) {
+                window._xm = "native";
+                window.location.reload();
+                e.preventDefault();
+                window.navigation?.removeEventListener("navigatesuccess", nav);
+              }
+              window.navigation?.addEventListener("navigatesuccess", nav);
             `)}
           </script>
         </div>


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/591

In the playground, in order not to break the Monaco editor, we are avoiding the SPA navigation once we are inside the playground. In doing so, when navigating to another page it works with the native navigation, and everything ok, but instead, if you press the Chrome back button, it tries to load the old SPA page and it doesn't work. This PR fix this.

