### PR TITLE
fix(file-sytem-router): fix regex to work on windows

### DIFF
--- a/packages/brisa/src/utils/file-system-router/index.test.ts
+++ b/packages/brisa/src/utils/file-system-router/index.test.ts
@@ -1,5 +1,5 @@
 import type { MatchedBrisaRoute } from '@/types';
-import { fileSystemRouter } from '@/utils/file-system-router';
+import { fileSystemRouter, normalizeRoute } from '@/utils/file-system-router';
 import { describe, it, expect } from 'bun:test';
 import path from 'node:path';
 
@@ -813,6 +813,58 @@ describe('utils', () => {
         const output = router.match(filePath);
 
         expect(output).toEqual(expected);
+      },
+    );
+  });
+
+  describe('fileSystemRouter > normalizeRoute', () => {
+    const BATTERY_OF_TESTS = [
+      [
+        'C:\\Users\\Test\\my-app\\src\\about\\index.js',
+        { dir: 'C:\\Users\\Test\\my-app\\src', ext: '.js', result: '/about' },
+      ],
+      [
+        '/Users/Test/my-app/src/about/index.js',
+        { dir: '/Users/Test/my-app/src', ext: '.js', result: '/about' },
+      ],
+      [
+        'C:\\Users\\Test\\my-app\\src\\about\\/\\/\\/\\\\/index.js',
+        { dir: 'C:\\Users\\Test\\my-app\\src', ext: '.js', result: '/about' },
+      ],
+      [
+        '/Users/Test/my-app/src/about//\\//\\//\\\\//index.js',
+        { dir: '/Users/Test/my-app/src', ext: '.js', result: '/about' },
+      ],
+      [
+        '///Users///Test///my-app///src/about///index.tsx',
+        {
+          dir: '///Users///Test///my-app///src',
+          ext: '.tsx',
+          result: '/about',
+        },
+      ],
+      [
+        '/\\Users/\\Test/\\my-app/\\src/about/\\index.tsx',
+        {
+          dir: '/\\Users/\\Test/\\my-app/\\src',
+          ext: '.tsx',
+          result: '/about',
+        },
+      ],
+      [
+        '//\\Users//\\Test//\\my-app//\\src/about//\\index.js',
+        {
+          dir: '//\\Users//\\Test//\\my-app//\\src',
+          ext: '.js',
+          result: '/about',
+        },
+      ],
+    ] as [string, { dir: string; ext: string; result: string }][];
+
+    it.each(BATTERY_OF_TESTS)(
+      'should normalize the route %s',
+      (filePath, { dir, ext, result }) => {
+        expect(normalizeRoute(filePath, dir, ext)).toBe(result);
       },
     );
   });

--- a/packages/brisa/src/utils/file-system-router/index.ts
+++ b/packages/brisa/src/utils/file-system-router/index.ts
@@ -4,7 +4,7 @@ import type { MatchedBrisaRoute } from '@/types';
 import type { FileSystemRouterOptions } from '@/types/server';
 import isTestFile from '@/utils/is-test-file';
 
-const ENDS_WITH_SLASH_INDEX_REGEX = new RegExp(`${path.sep}index$`);
+const ENDS_WITH_SLASH_INDEX_REGEX = /[\\|/]+index$/;
 const DEFAULT_EXTENSIONS = ['.tsx', '.jsx', '.ts', '.mjs', '.cjs', '.js'];
 const MULTI_SLASH_REGEX = /(?<!:)\/{2,}/g;
 const TRAILING_SLASH_REGEX = /\/$/;
@@ -98,6 +98,14 @@ export function fileSystemRouter(options: FileSystemRouterOptions) {
   return { routes, match };
 }
 
+export function normalizeRoute(filePath: string, dir: string, ext: string) {
+  return filePath
+    .replace(ext, '')
+    .replace(dir, '')
+    .replace(ENDS_WITH_SLASH_INDEX_REGEX, '')
+    .replace(WINDOWS_PATH_REGEX, '/');
+}
+
 function getRouteKind(route: string): MatchedBrisaRoute['kind'] {
   if (route.includes('[[...')) return 'optional-catch-all';
   if (route.includes('[...')) return 'catch-all';
@@ -145,11 +153,7 @@ function resolveRoutes({
     if (!ext) continue;
 
     const filePath = path.resolve(file.parentPath, file.name);
-    let route = filePath
-      .replace(ext, '')
-      .replace(dir, '')
-      .replace(ENDS_WITH_SLASH_INDEX_REGEX, '')
-      .replace(WINDOWS_PATH_REGEX, '/');
+    let route = normalizeRoute(filePath, dir, ext);
 
     if (route === '') route = '/';
 


### PR DESCRIPTION
Related to https://github.com/brisa-build/brisa/issues/538

When normalizing the path in the `fileSystemRouter` of Brisa it was using a Regex using the `path.sep`, however, in Windows it was getting the duplicate separator `\\\\`, I have improved this regex and added the failing tests so that this does not happen anymore. After this fix, you should be able to navigate to  `localhost:3000/about` (`/about/index.tsx`) and correctly resolve the route.