### PR TITLE
fix(regression): solve indicator to work server action without js

### DIFF
--- a/packages/brisa/src/utils/get-initiator/index.test.ts
+++ b/packages/brisa/src/utils/get-initiator/index.test.ts
@@ -2,18 +2,7 @@ import { describe, it, expect } from 'bun:test';
 
 import { Initiator } from '@/public-constants';
 import type { RequestContext } from '@/types';
-
-export default function getInitiator(req: RequestContext) {
-  const firstPathnamePart = new URL(req.finalURL).pathname.split('/')[
-    req.i18n?.locale ? 2 : 1
-  ];
-
-  if (firstPathnamePart === 'api') return Initiator.API_REQUEST;
-  if (req.method !== 'POST') return Initiator.INITIAL_REQUEST;
-  if (req.headers.has('x-action')) return Initiator.SERVER_ACTION;
-
-  return Initiator.SPA_NAVIGATION;
-}
+import getInitiator from '.';
 
 describe('utils / getInitiator', () => {
   it('should return API_REQUEST when the first pathname part is "api" with i18n + GET', () => {
@@ -73,6 +62,16 @@ describe('utils / getInitiator', () => {
       finalURL: 'https://example.com/foo/bar',
       method: 'POST',
       headers: new Headers([['x-action', 'foo']]),
+    } as RequestContext;
+
+    expect(getInitiator(req)).toBe(Initiator.SERVER_ACTION);
+  });
+
+  it('should return SERVER_ACTION when the ?_aid param in a POST method is present', () => {
+    const req = {
+      finalURL: 'https://example.com/foo/bar?_aid=a1_1',
+      method: 'POST',
+      headers: new Headers(),
     } as RequestContext;
 
     expect(getInitiator(req)).toBe(Initiator.SERVER_ACTION);

--- a/packages/brisa/src/utils/get-initiator/index.ts
+++ b/packages/brisa/src/utils/get-initiator/index.ts
@@ -2,13 +2,14 @@ import { Initiator } from '@/public-constants';
 import type { RequestContext } from '@/types';
 
 export default function getInitiator(req: RequestContext) {
-  const firstPathnamePart = new URL(req.finalURL).pathname.split('/')[
-    req.i18n.locale ? 2 : 1
-  ];
+  const url = new URL(req.finalURL);
+  const firstPathnamePart = url.pathname.split('/')[req.i18n?.locale ? 2 : 1];
 
   if (firstPathnamePart === 'api') return Initiator.API_REQUEST;
   if (req.method !== 'POST') return Initiator.INITIAL_REQUEST;
-  if (req.headers.has('x-action')) return Initiator.SERVER_ACTION;
+  if (req.headers.has('x-action') || url.searchParams.has('_aid')) {
+    return Initiator.SERVER_ACTION;
+  }
 
   return Initiator.SPA_NAVIGATION;
 }


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/595

I noticed this bug while preparing the demo at BarcelonaJS, we could not show it because it stopped working after [this PR](https://github.com/brisa-build/brisa/pull/585). 

After this fix, Form server actions work again even if the user has JavaScript disabled.