### PR TITLE
fix(serve): fix prerender home page

### DIFF
--- a/packages/brisa/src/utils/response-rendered-page/index.test.ts
+++ b/packages/brisa/src/utils/response-rendered-page/index.test.ts
@@ -7,19 +7,6 @@ import responseRenderedPage, { routeToPrerenderedPagePath } from '.';
 import { getConstants } from '@/constants';
 import { Initiator } from '@/public-constants';
 
-/*
-export function routeToPrerenderedPagePath(route: MatchedBrisaRoute) {
-  const { BUILD_DIR, CONFIG } = getConstants();
-  const { pathname } = new URL(route.pathname, 'http://localhost');
-  return path.join(
-    BUILD_DIR,
-    'prerendered-pages',
-    CONFIG.trailingSlash
-      ? `${pathname}${path.sep}index.html`
-      : `${pathname}.html`,
-  );
-  */
-
 const BUILD_DIR = path.join(import.meta.dir, '..', '..', '__fixtures__');
 const PAGES_DIR = path.join(BUILD_DIR, 'pages');
 const ASSETS_DIR = path.join(BUILD_DIR, 'public');

--- a/packages/brisa/src/utils/response-rendered-page/index.test.ts
+++ b/packages/brisa/src/utils/response-rendered-page/index.test.ts
@@ -3,35 +3,48 @@ import path from 'node:path';
 
 import type { MatchedBrisaRoute, Translate } from '@/types';
 import extendRequestContext from '@/utils/extend-request-context';
-import responseRenderedPage from '.';
+import responseRenderedPage, { routeToPrerenderedPagePath } from '.';
 import { getConstants } from '@/constants';
 import { Initiator } from '@/public-constants';
+
+/*
+export function routeToPrerenderedPagePath(route: MatchedBrisaRoute) {
+  const { BUILD_DIR, CONFIG } = getConstants();
+  const { pathname } = new URL(route.pathname, 'http://localhost');
+  return path.join(
+    BUILD_DIR,
+    'prerendered-pages',
+    CONFIG.trailingSlash
+      ? `${pathname}${path.sep}index.html`
+      : `${pathname}.html`,
+  );
+  */
 
 const BUILD_DIR = path.join(import.meta.dir, '..', '..', '__fixtures__');
 const PAGES_DIR = path.join(BUILD_DIR, 'pages');
 const ASSETS_DIR = path.join(BUILD_DIR, 'public');
 
 describe('utils', () => {
+  beforeEach(async () => {
+    globalThis.mockConstants = {
+      ...(getConstants() ?? {}),
+      PAGES_DIR,
+      BUILD_DIR,
+      SRC_DIR: BUILD_DIR,
+      ASSETS_DIR,
+      LOCALES_SET: new Set(['en', 'es']),
+      I18N_CONFIG: {
+        locales: ['en', 'es'],
+        defaultLocale: 'es',
+      },
+    };
+  });
+
+  afterEach(() => {
+    globalThis.mockConstants = undefined;
+  });
+
   describe('response-rendered-page', () => {
-    beforeEach(async () => {
-      globalThis.mockConstants = {
-        ...(getConstants() ?? {}),
-        PAGES_DIR,
-        BUILD_DIR,
-        SRC_DIR: BUILD_DIR,
-        ASSETS_DIR,
-        LOCALES_SET: new Set(['en', 'es']),
-        I18N_CONFIG: {
-          locales: ['en', 'es'],
-          defaultLocale: 'es',
-        },
-      };
-    });
-
-    afterEach(() => {
-      globalThis.mockConstants = undefined;
-    });
-
     it('should return 200 page with client page code', async () => {
       const req = extendRequestContext({
         originalRequest: new Request(
@@ -268,6 +281,64 @@ describe('utils', () => {
 
       expect(await response.text()).not.toContain(
         'window._S=[["key","value"]]',
+      );
+    });
+  });
+
+  describe('routeToPrerenderedPagePath', () => {
+    it('should work for the home', () => {
+      const route = {
+        pathname: '/',
+      } as MatchedBrisaRoute;
+      const pagePath = routeToPrerenderedPagePath(route);
+
+      expect(pagePath).toBe(
+        path.join(BUILD_DIR, 'prerendered-pages', 'index.html'),
+      );
+    });
+
+    it('should work for the home with trailingSlash', () => {
+      globalThis.mockConstants = {
+        ...globalThis.mockConstants,
+        CONFIG: {
+          trailingSlash: true,
+        },
+      };
+      const route = {
+        pathname: '/',
+      } as MatchedBrisaRoute;
+      const pagePath = routeToPrerenderedPagePath(route);
+
+      expect(pagePath).toBe(
+        path.join(BUILD_DIR, 'prerendered-pages', 'index.html'),
+      );
+    });
+
+    it('should return the path to the prerendered page', () => {
+      const route = {
+        pathname: '/foo',
+      } as MatchedBrisaRoute;
+      const pagePath = routeToPrerenderedPagePath(route);
+
+      expect(pagePath).toBe(
+        path.join(BUILD_DIR, 'prerendered-pages', 'foo.html'),
+      );
+    });
+
+    it('should return the path to the prerendered page with trailingSlash', () => {
+      globalThis.mockConstants = {
+        ...globalThis.mockConstants,
+        CONFIG: {
+          trailingSlash: true,
+        },
+      };
+      const route = {
+        pathname: '/foo/',
+      } as MatchedBrisaRoute;
+      const pagePath = routeToPrerenderedPagePath(route);
+
+      expect(pagePath).toBe(
+        path.join(BUILD_DIR, 'prerendered-pages', 'foo', 'index.html'),
       );
     });
   });

--- a/packages/brisa/src/utils/response-rendered-page/index.ts
+++ b/packages/brisa/src/utils/response-rendered-page/index.ts
@@ -37,7 +37,9 @@ export default async function responseRenderedPage({
     transferClientStoreToServer();
   }
 
-  const fileStream = getPrerenderedPage(route);
+  const fileStream = getReadableStreamFromPath(
+    routeToPrerenderedPagePath(route),
+  );
   const htmlStream =
     fileStream ??
     renderToReadableStream(PageComponent(), {
@@ -53,16 +55,15 @@ export default async function responseRenderedPage({
   return new Response(htmlStream, responseOptions);
 }
 
-function getPrerenderedPage(route: MatchedBrisaRoute) {
+export function routeToPrerenderedPagePath(route: MatchedBrisaRoute) {
   const { BUILD_DIR, CONFIG } = getConstants();
   const { pathname } = new URL(route.pathname, 'http://localhost');
-  const filePath = path.join(
+  const isHome = pathname === '/';
+  return path.join(
     BUILD_DIR,
     'prerendered-pages',
     CONFIG.trailingSlash
       ? `${pathname}${path.sep}index.html`
-      : `${pathname}.html`,
+      : `${isHome ? 'index' : pathname}.html`,
   );
-
-  return getReadableStreamFromPath(filePath);
 }


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/601

The home was rendering again instead of loading the pretender file when `prerender = true`