### PR TITLE
perf(optimization): improve req/sec 575%

### DIFF
--- a/packages/brisa/src/utils/get-page-component-with-headers/index.ts
+++ b/packages/brisa/src/utils/get-page-component-with-headers/index.ts
@@ -11,6 +11,9 @@ type Params = {
   headers?: Record<string, string>;
 };
 
+const { HEADERS, BUILD_DIR } = getConstants();
+const middlewareModule = await importFileIfExists('middleware', BUILD_DIR);
+
 export default async function getPageComponentWithHeaders({
   req,
   route,
@@ -18,8 +21,6 @@ export default async function getPageComponentWithHeaders({
   status = 200,
   headers,
 }: Params) {
-  const { HEADERS, BUILD_DIR } = getConstants();
-  const middlewareModule = await importFileIfExists('middleware', BUILD_DIR);
   const { Page, module, layoutModule } = await processPageRoute(route, error);
   const middlewareResponseHeaders =
     middlewareModule?.responseHeaders?.(req, status) ?? {};

--- a/packages/brisa/src/utils/process-page-route/index.test.tsx
+++ b/packages/brisa/src/utils/process-page-route/index.test.tsx
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { getConstants } from '@/constants';
 import renderToReadableStream from '@/utils/render-to-readable-stream';
 import extendRequestContext from '@/utils/extend-request-context';
-import processPageRoute from '.';
+import processPageRoute, { cache } from '.';
 import { toInline } from '@/helpers';
 import translateCore from '@/utils/translate-core';
 import type { MatchedBrisaRoute, RequestContext } from '@/types';
@@ -33,6 +33,7 @@ const routeHomepage = { filePath: HOMEPAGE } as unknown as MatchedBrisaRoute;
 
 describe('utils', () => {
   beforeEach(() => {
+    cache.clear();
     globalThis.mockConstants = getConstants() ?? {};
   });
 

--- a/packages/brisa/src/utils/process-page-route/index.tsx
+++ b/packages/brisa/src/utils/process-page-route/index.tsx
@@ -1,11 +1,11 @@
-import { getConstants } from "@/constants";
-import dangerHTML from "@/utils/danger-html";
-import { LiveReloadScript } from "@/cli/dev-live-reload";
-import LoadLayout from "@/utils/load-layout";
-import type { MatchedBrisaRoute, PageModule } from "@/types";
+import { getConstants } from '@/constants';
+import dangerHTML from '@/utils/danger-html';
+import { LiveReloadScript } from '@/cli/dev-live-reload';
+import LoadLayout from '@/utils/load-layout';
+import type { MatchedBrisaRoute, PageModule } from '@/types';
 import getImportableFilepath, {
   pathToFileURLWhenNeeded,
-} from "@/utils/get-importable-filepath";
+} from '@/utils/get-importable-filepath';
 
 export const cache = new Map<string, any>();
 
@@ -23,13 +23,13 @@ export default async function processPageRoute(
   const module = (await import(
     pathToFileURLWhenNeeded(route.filePath)
   )) as PageModule;
-  const layoutPath = getImportableFilepath("layout", BUILD_DIR);
+  const layoutPath = getImportableFilepath('layout', BUILD_DIR);
   const layoutModule = layoutPath ? await import(layoutPath) : undefined;
   const PageComponent = module.default;
 
   const Page = () => (
     <>
-      {dangerHTML("<!DOCTYPE html>")}
+      {dangerHTML('<!DOCTYPE html>')}
       <PageLayout layoutModule={layoutModule}>
         <PageComponent error={error} />
       </PageLayout>

--- a/packages/brisa/src/utils/process-page-route/index.tsx
+++ b/packages/brisa/src/utils/process-page-route/index.tsx
@@ -7,10 +7,16 @@ import getImportableFilepath, {
   pathToFileURLWhenNeeded,
 } from '@/utils/get-importable-filepath';
 
+export const cache = new Map<string, any>();
+
 export default async function processPageRoute(
   route: MatchedBrisaRoute,
   error?: Error,
 ) {
+  if (cache.has(route.filePath)) {
+    return cache.get(route.filePath);
+  }
+
   const { BUILD_DIR } = getConstants();
   const module = (await import(
     pathToFileURLWhenNeeded(route.filePath)
@@ -28,7 +34,11 @@ export default async function processPageRoute(
     </>
   );
 
-  return { Page, module, layoutModule } as const;
+  const res = { Page, module, layoutModule } as const;
+
+  cache.set(route.filePath, res);
+
+  return res;
 }
 
 function PageLayout({

--- a/packages/brisa/src/utils/process-page-route/index.tsx
+++ b/packages/brisa/src/utils/process-page-route/index.tsx
@@ -1,11 +1,11 @@
-import { getConstants } from '@/constants';
-import dangerHTML from '@/utils/danger-html';
-import { LiveReloadScript } from '@/cli/dev-live-reload';
-import LoadLayout from '@/utils/load-layout';
-import type { MatchedBrisaRoute, PageModule } from '@/types';
+import { getConstants } from "@/constants";
+import dangerHTML from "@/utils/danger-html";
+import { LiveReloadScript } from "@/cli/dev-live-reload";
+import LoadLayout from "@/utils/load-layout";
+import type { MatchedBrisaRoute, PageModule } from "@/types";
 import getImportableFilepath, {
   pathToFileURLWhenNeeded,
-} from '@/utils/get-importable-filepath';
+} from "@/utils/get-importable-filepath";
 
 export const cache = new Map<string, any>();
 
@@ -13,6 +13,8 @@ export default async function processPageRoute(
   route: MatchedBrisaRoute,
   error?: Error,
 ) {
+  // This cache improves the req/sec 575%
+  // https://github.com/brisa-build/brisa/pull/604
   if (cache.has(route.filePath)) {
     return cache.get(route.filePath);
   }
@@ -21,13 +23,13 @@ export default async function processPageRoute(
   const module = (await import(
     pathToFileURLWhenNeeded(route.filePath)
   )) as PageModule;
-  const layoutPath = getImportableFilepath('layout', BUILD_DIR);
+  const layoutPath = getImportableFilepath("layout", BUILD_DIR);
   const layoutModule = layoutPath ? await import(layoutPath) : undefined;
   const PageComponent = module.default;
 
   const Page = () => (
     <>
-      {dangerHTML('<!DOCTYPE html>')}
+      {dangerHTML("<!DOCTYPE html>")}
       <PageLayout layoutModule={layoutModule}>
         <PageComponent error={error} />
       </PageLayout>


### PR DESCRIPTION
It was only at ~4000 req/sec because many dynamic imports were executed in runtime. 

This PR moves some dynamic exports to global variables + adds cache, and improves 575% the req/sec, to ~27.000 req/sec.

There are still many dynamic imports and many optimizations that could bring it close to **100,000 req/sec**. But this is a first step, since for 0.1 the target was the route map and the primary features, the optimization is now coming as a target for the 1.0 route map.

## Before 

```sh
> wrk -t12 -c400 -d30s http://localhost:3000
Running 30s test @ http://localhost:3000
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   100.81ms   11.35ms 199.92ms   88.45%
    Req/Sec   328.18     28.23   510.00     89.02%
  117868 requests in 30.09s, 47.89MB read
Requests/sec:   3917.06
Transfer/sec:      1.59MB
```

## Now

```sh
> wrk -t12 -c400 -d30s http://localhost:3000
Running 30s test @ http://localhost:3000
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    14.82ms    4.45ms  59.72ms   95.47%
    Req/Sec     2.28k   210.97     2.58k    86.69%
  816361 requests in 30.02s, 331.66MB read
Requests/sec:  27198.12
Transfer/sec:     11.05MB
```