### PR TITLE
fix(dx): improve error feedback on CLI build

### DIFF
--- a/examples/with-tailwindcss/brisa.config.ts
+++ b/examples/with-tailwindcss/brisa.config.ts
@@ -2,6 +2,5 @@ import type { Configuration } from 'brisa';
 import tailwindcss from 'brisa-tailwindcss';
 
 export default {
-  output: 'static',
   integrations: [tailwindcss()],
 } satisfies Configuration;

--- a/packages/brisa/src/utils/log/log-build.test.ts
+++ b/packages/brisa/src/utils/log/log-build.test.ts
@@ -10,6 +10,19 @@ describe('utils', () => {
       mock.restore();
     });
 
+    it('should log an error when table data is empty', () => {
+      const mockLog = mock((f, s) => (s ? `${f} ${s}` : f));
+
+      spyOn(console, 'log').mockImplementation((f, s) => mockLog(f, s));
+
+      logTable([]);
+
+      expect(mockLog.mock.results).toHaveLength(4);
+      expect(mockLog.mock.calls.join()).toContain(
+        'An error trying to log a table with the generated files',
+      );
+    });
+
     it('should log a table', () => {
       const mockLog = mock((f, s) => (s ? `${f} ${s}` : f));
 

--- a/packages/brisa/src/utils/log/log-build.ts
+++ b/packages/brisa/src/utils/log/log-build.ts
@@ -6,7 +6,16 @@ const BRISA_ERRORS = '__BRISA_ERRORS__';
 
 export function logTable(data: { [key: string]: string }[]) {
   const { LOG_PREFIX } = getConstants();
-  const headers = Object.keys(data[0]);
+  const headersContent = data?.[0];
+
+  if (!headersContent) {
+    logError({
+      messages: ['An error trying to log a table with the generated files'],
+    });
+    return;
+  }
+
+  const headers = Object.keys(headersContent);
   const maxLengths = headers.map((header) =>
     data.reduce(
       (max, item) => Math.max(max, item[header].length),


### PR DESCRIPTION
To have better feedback when the file log fails for something (what is happening now in Windows). The Windows bug is still to be fixed, but I take advantage of it and improve the error feedback. 