### PR TITLE
docs: explain Brisa clustering vs PM2

### DIFF
--- a/docs/building-your-application/configuring/clustering.md
+++ b/docs/building-your-application/configuring/clustering.md
@@ -30,6 +30,14 @@ export default {
 
 To make it possible, Brisa uses [`node:cluster`](https://nodejs.org/api/cluster.html) to handle the clustering. This Node API also works in Bun.
 
+## Why should I turn off clustering?
+
+If you are using a popular process manager like [PM2](https://pm2.keymetrics.io/), make sense to use `clustering: false` in Brisa to avoid conflicts between the process manager and Brisa.
+
+> [!TIP]
+>
+> PM2 work by default for Node.js applications, and it will handle the clustering for you. However, you can use [PM2 with Bun.js](https://bun.sh/guides/ecosystem/pm2) as well.
+
 > [!CAUTION]
 >
 > If you need to use a [Custom Server](/building-your-application/configuring/custom-server), this configuration does not apply, and you need to handle the clustering yourself.


### PR DESCRIPTION
I just added an explanation about PM2 with Bun inside the clustering documentation