### PR TITLE
fix(build): fix standalone var env

### DIFF
--- a/packages/brisa/src/utils/compile-serve-internals-into-build/index.test.ts
+++ b/packages/brisa/src/utils/compile-serve-internals-into-build/index.test.ts
@@ -51,14 +51,21 @@ describe('utils/compileServeInternalsIntoBuild', () => {
     expect(fs.existsSync(path.join(BUILD_DIR, 'brisa.config.js'))).toBeFalse();
   });
 
-  it('should compile the server with defined IS_PRODUCTION, IS_SERVE_PROCESS and IS_STANDALONE_SERVER', async () => {
+  it('should compile the server with defined env vars', async () => {
     await compileBrisaInternalsToDoBuildPortable();
     const server = fs.readFileSync(path.join(BUILD_DIR, 'server.js'), 'utf-8');
 
-    // doesn't exist in the code anymore, now is defined in the build process
-    expect(server).not.toContain('process.env.IS_STANDALONE_SERVER');
-    expect(server).not.toContain('process.env.IS_SERVE_PROCESS');
-    expect(server).not.toContain('process.env.IS_PROD');
+    expect(server).toContain('process.env.IS_SERVE_PROCESS ??= true;');
+    expect(server).toContain('process.env.IS_PROD ??= true;');
+    expect(server).toContain(
+      'process.env.BRISA_SRC_DIR ??= import.meta.dirname;',
+    );
+    expect(server).toContain(
+      'process.env.BRISA_BUILD_FOLDER ??= import.meta.dirname;',
+    );
+    expect(server).toContain(
+      'process.env.BRISA_ROOT_DIR ??= import.meta.dirname;',
+    );
     expect(mockLog.mock.calls.flat().join()).toContain(
       'Node.js Server compiled into build folder',
     );
@@ -69,10 +76,17 @@ describe('utils/compileServeInternalsIntoBuild', () => {
     await compileBrisaInternalsToDoBuildPortable();
     const server = fs.readFileSync(path.join(BUILD_DIR, 'server.js'), 'utf-8');
 
-    // doesn't exist in the code anymore, now is defined in the build process
-    expect(server).not.toContain('process.env.IS_STANDALONE_SERVER');
-    expect(server).not.toContain('process.env.IS_SERVE_PROCESS');
-    expect(server).not.toContain('process.env.IS_PROD');
+    expect(server).toContain('process.env.IS_SERVE_PROCESS ??= true;');
+    expect(server).toContain('process.env.IS_PROD ??= true;');
+    expect(server).toContain(
+      'process.env.BRISA_SRC_DIR ??= import.meta.dirname;',
+    );
+    expect(server).toContain(
+      'process.env.BRISA_BUILD_FOLDER ??= import.meta.dirname;',
+    );
+    expect(server).toContain(
+      'process.env.BRISA_ROOT_DIR ??= import.meta.dirname;',
+    );
     expect(mockLog.mock.calls.flat().join()).toContain(
       'Bun.js Server compiled into build folder',
     );

--- a/packages/brisa/src/utils/compile-serve-internals-into-build/index.ts
+++ b/packages/brisa/src/utils/compile-serve-internals-into-build/index.ts
@@ -68,11 +68,13 @@ export default async function compileServeInternalsIntoBuild() {
     },
     external: CONFIG.external,
     target: isNode ? 'node' : 'bun',
-    define: {
-      'process.env.IS_SERVE_PROCESS': 'true',
-      'process.env.IS_PROD': 'true',
-      'process.env.IS_STANDALONE_SERVER': 'true',
-    },
+    banner: [
+      'process.env.IS_SERVE_PROCESS ??= true;',
+      'process.env.IS_PROD ??= true;',
+      'process.env.BRISA_SRC_DIR ??= import.meta.dirname;',
+      'process.env.BRISA_BUILD_FOLDER ??= import.meta.dirname;',
+      'process.env.BRISA_ROOT_DIR ??= import.meta.dirname;',
+    ].join('\n'),
   });
 
   if (!output.success) {

--- a/packages/brisa/src/utils/load-constants/index.ts
+++ b/packages/brisa/src/utils/load-constants/index.ts
@@ -39,25 +39,23 @@ export function internalConstants(): InternalConstants {
     Boolean(process.env.IS_SERVE_PROCESS) ||
     Boolean(currentScript.endsWith(path.join(CLI_DIR, 'serve', 'index.js')));
 
-  const isStandaloneServer = Boolean(process.env.IS_STANDALONE_SERVER);
-  const ROOT_DIR = isStandaloneServer ? import.meta.dirname : process.cwd();
+  const ROOT_DIR = process.env.BRISA_ROOT_DIR ?? process.cwd();
 
   const IS_BUILD_PROCESS = Boolean(
     currentScript.endsWith(path.join(CLI_DIR, 'build.js')),
   );
 
-  const BRISA_DIR = currentScript.replace(
-    new RegExp(`${CLI_DIR.replace(WIN32_SEP_REGEX, '\\\\')}.*`),
-    'brisa',
-  );
+  const BRISA_DIR =
+    process.env.BRISA_DIR ??
+    currentScript.replace(
+      new RegExp(`${CLI_DIR.replace(WIN32_SEP_REGEX, '\\\\')}.*`),
+      'brisa',
+    );
 
-  const SRC_DIR: string = isStandaloneServer
-    ? import.meta.dirname
-    : path.resolve(ROOT_DIR, 'src');
-
-  const BUILD_DIR: string = isStandaloneServer
-    ? import.meta.dirname
-    : (process.env.BRISA_BUILD_FOLDER ?? path.resolve(ROOT_DIR, 'build'));
+  const SRC_DIR: string =
+    process.env.BRISA_SRC_DIR ?? path.resolve(ROOT_DIR, 'src');
+  const BUILD_DIR: string =
+    process.env.BRISA_BUILD_FOLDER ?? path.resolve(ROOT_DIR, 'build');
 
   const WORKSPACE = IS_BUILD_PROCESS ? SRC_DIR : BUILD_DIR;
 


### PR DESCRIPTION
Related https://github.com/brisa-build/brisa/issues/622

By setting the env variables to “banner” instead of “define”, all files will already have the correct environment variables and therefore the constants will always be loaded correctly.