### PR TITLE
fix(reactivity): solve disconnected nodes on recursion with fragments

### DIFF
--- a/packages/brisa/src/utils/brisa-element/index.test.ts
+++ b/packages/brisa/src/utils/brisa-element/index.test.ts
@@ -3300,6 +3300,34 @@ describe('utils', () => {
       },
     );
 
+    it('should work reactivity in a nested ternary in first level (arrow fn component)', () => {
+      const times = 10;
+
+      const Component = ({}, { store, derived }: WebContext) => {
+        let count = 0;
+        const show = derived(() => store.get('show'));
+
+        const foo = (num: number): any =>
+          num < times ? foo(num + 1) : show.value && 'last number = ' + num;
+
+        return [null, {}, () => foo(++count)];
+      };
+
+      customElements.define('test-component', brisaElement(Component));
+
+      document.body.innerHTML = '<test-component />';
+      const testComponent = document.querySelector(
+        'test-component',
+      ) as HTMLElement;
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBeEmpty();
+
+      // Update the store
+      window._s.set('show', true);
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
+    });
+
     it('should work reactivity in a nested ternary in a div', () => {
       const times = 10;
       const Component = ({}, { store, derived }: WebContext) => {

--- a/packages/brisa/src/utils/brisa-element/index.test.ts
+++ b/packages/brisa/src/utils/brisa-element/index.test.ts
@@ -49,6 +49,7 @@ describe('utils', () => {
       window.__USE_LOCALE__ = false;
       window.__USE_PAGE_TRANSLATION__ = false;
       window.fPath = undefined;
+      window._s.Map.clear();
       GlobalRegistrator.unregister();
     });
     it('should work props and state with a counter', () => {
@@ -3212,7 +3213,7 @@ describe('utils', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('<div>test</div>');
     });
 
-    it.todo('should work reactivity in a nested way', () => {
+    it.todo('should work reactivity in a nested fragment', () => {
       const times = 10;
       const Component = ({}, { store, derived }: WebContext) => {
         let count = 0;
@@ -3247,7 +3248,222 @@ describe('utils', () => {
       window._s.set('show', true);
 
       expect(testComponent?.shadowRoot?.innerHTML).toBe(
-        `<div><div><div><div><div><div><div><div><div><div></div>show10</div>show9</div>show8</div>show7</div>show6</div>show5</div>show4</div>show3</div>show2</div>show1</div>show0</div>`,
+        `<div><div><div><div><div><div><div><div><div><div></div>show10</div>show9</div>show8</div>show7</div>show6</div>show5</div>show4</div>show3</div>show2</div>show1`,
+      );
+    });
+
+    it.todo(
+      'should work reactivity in a nested ternary in a nested fragment',
+      () => {
+        const times = 10;
+        const Component = ({}, { store, derived }: WebContext) => {
+          let count = 0;
+          const show = derived(() => store.get('show'));
+
+          const foo = (num: number) => {
+            return [
+              null,
+              {},
+              [
+                [
+                  null,
+                  {},
+                  [
+                    null,
+                    {},
+                    () =>
+                      num < times
+                        ? foo(num + 1)
+                        : show.value && 'last number = ' + num,
+                  ],
+                ],
+              ],
+            ];
+          };
+
+          return foo(++count);
+        };
+
+        customElements.define('test-component', brisaElement(Component));
+
+        document.body.innerHTML = '<test-component />';
+        const testComponent = document.querySelector(
+          'test-component',
+        ) as HTMLElement;
+
+        expect(testComponent?.shadowRoot?.innerHTML).toBeEmpty();
+
+        // Update the store
+        window._s.set('show', true);
+
+        expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
+      },
+    );
+
+    it('should work reactivity in a nested ternary in a div', () => {
+      const times = 10;
+      const Component = ({}, { store, derived }: WebContext) => {
+        let count = 0;
+        const show = derived(() => store.get('show'));
+
+        const foo = (num: number) => {
+          return [
+            null,
+            {},
+            [
+              [
+                'div',
+                {},
+                [
+                  null,
+                  {},
+                  () =>
+                    num < times
+                      ? foo(num + 1)
+                      : show.value && 'last number = ' + num,
+                ],
+              ],
+            ],
+          ];
+        };
+
+        return foo(++count);
+      };
+
+      customElements.define('test-component', brisaElement(Component));
+
+      document.body.innerHTML = '<test-component />';
+      const testComponent = document.querySelector(
+        'test-component',
+      ) as HTMLElement;
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        '<div>'.repeat(times) + '</div>'.repeat(times),
+      );
+
+      // Update the store
+      window._s.set('show', true);
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        `<div><div><div><div><div><div><div><div><div><div>last number = 10</div></div></div></div></div></div></div></div></div></div>`,
+      );
+    });
+
+    it('should work reactivity in a nested fragment with signal at fist level', () => {
+      const times = 10;
+      const Component = ({}, { store, derived }: WebContext) => {
+        let count = 0;
+        const show = derived(() => store.get('show'));
+
+        const foo = (num: number) => {
+          return [
+            null,
+            {},
+            [
+              ['div', {}, [null, {}, () => (num < times ? foo(num + 1) : '')]],
+              [null, {}, () => show.value && 'show' + num],
+              show.value && '🔥',
+            ],
+          ];
+        };
+
+        return foo(++count);
+      };
+
+      customElements.define('test-component', brisaElement(Component));
+
+      document.body.innerHTML = '<test-component />';
+      const testComponent = document.querySelector(
+        'test-component',
+      ) as HTMLElement;
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        '<div>'.repeat(times) + '</div>'.repeat(times),
+      );
+
+      // Update the store
+      window._s.set('show', true);
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        `<div><div><div><div><div><div><div><div><div><div></div>show10🔥</div>show9🔥</div>show8🔥</div>show7🔥</div>show6🔥</div>show5🔥</div>show4🔥</div>show3🔥</div>show2🔥</div>show1`,
+      );
+    });
+
+    it('should work reactivity in a nested div', () => {
+      const times = 10;
+      const Component = ({}, { store, derived }: WebContext) => {
+        let count = 0;
+        const show = derived(() => store.get('show'));
+
+        const foo = (num: number) => {
+          return [
+            'div',
+            {},
+            [
+              ['div', {}, [null, {}, () => (num < times ? foo(num + 1) : '')]],
+              [null, {}, () => show.value && 'show' + num],
+            ],
+          ];
+        };
+
+        return foo(++count);
+      };
+
+      customElements.define('test-component', brisaElement(Component));
+
+      document.body.innerHTML = '<test-component />';
+      const testComponent = document.querySelector(
+        'test-component',
+      ) as HTMLElement;
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        '<div>'.repeat(times * 2) + '</div>'.repeat(times * 2),
+      );
+
+      // Update the store
+      window._s.set('show', true);
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        `${'<div>'.repeat(times * 2)}</div>show10</div></div>show9</div></div>show8</div></div>show7</div></div>show6</div></div>show5</div></div>show4</div></div>show3</div></div>show2</div></div>show1</div>`,
+      );
+    });
+
+    it('should work reactivity in a nested inner div', () => {
+      const times = 10;
+      const Component = ({}, { store, derived }: WebContext) => {
+        let count = 0;
+        const show = derived(() => store.get('show'));
+
+        const foo = (num: number) => {
+          return [
+            null,
+            {},
+            [
+              ['div', {}, [null, {}, () => (num < times ? foo(num + 1) : '')]],
+              ['div', {}, () => show.value && 'show' + num],
+            ],
+          ];
+        };
+
+        return foo(++count);
+      };
+
+      customElements.define('test-component', brisaElement(Component));
+
+      document.body.innerHTML = '<test-component />';
+      const testComponent = document.querySelector(
+        'test-component',
+      ) as HTMLElement;
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        '<div>'.repeat(times) + '</div><div></div>'.repeat(times) + '',
+      );
+
+      // Update the store
+      window._s.set('show', true);
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        `${'<div>'.repeat(times)}</div><div>show10</div></div><div>show9</div></div><div>show8</div></div><div>show7</div></div><div>show6</div></div><div>show5</div></div><div>show4</div></div><div>show3</div></div><div>show2</div></div><div>show1</div>`,
       );
     });
 

--- a/packages/brisa/src/utils/brisa-element/index.test.ts
+++ b/packages/brisa/src/utils/brisa-element/index.test.ts
@@ -3213,7 +3213,7 @@ describe('utils', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('<div>test</div>');
     });
 
-    it.todo('should work reactivity in a nested fragment', () => {
+    it('should work reactivity in a nested fragment', () => {
       const times = 10;
       const Component = ({}, { store, derived }: WebContext) => {
         let count = 0;
@@ -3252,53 +3252,50 @@ describe('utils', () => {
       );
     });
 
-    it.todo(
-      'should work reactivity in a nested ternary in a nested fragment',
-      () => {
-        const times = 10;
-        const Component = ({}, { store, derived }: WebContext) => {
-          let count = 0;
-          const show = derived(() => store.get('show'));
+    it('should work reactivity in a nested ternary in a nested fragment', () => {
+      const times = 10;
+      const Component = ({}, { store, derived }: WebContext) => {
+        let count = 0;
+        const show = derived(() => store.get('show'));
 
-          const foo = (num: number) => {
-            return [
-              null,
-              {},
+        const foo = (num: number) => {
+          return [
+            null,
+            {},
+            [
               [
+                null,
+                {},
                 [
                   null,
                   {},
-                  [
-                    null,
-                    {},
-                    () =>
-                      num < times
-                        ? foo(num + 1)
-                        : show.value && 'last number = ' + num,
-                  ],
+                  () =>
+                    num < times
+                      ? foo(num + 1)
+                      : show.value && 'last number = ' + num,
                 ],
               ],
-            ];
-          };
-
-          return foo(++count);
+            ],
+          ];
         };
 
-        customElements.define('test-component', brisaElement(Component));
+        return foo(++count);
+      };
 
-        document.body.innerHTML = '<test-component />';
-        const testComponent = document.querySelector(
-          'test-component',
-        ) as HTMLElement;
+      customElements.define('test-component', brisaElement(Component));
 
-        expect(testComponent?.shadowRoot?.innerHTML).toBeEmpty();
+      document.body.innerHTML = '<test-component />';
+      const testComponent = document.querySelector(
+        'test-component',
+      ) as HTMLElement;
 
-        // Update the store
-        window._s.set('show', true);
+      expect(testComponent?.shadowRoot?.innerHTML).toBeEmpty();
 
-        expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
-      },
-    );
+      // Update the store
+      window._s.set('show', true);
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
+    });
 
     it('should work reactivity in a nested ternary in first level (arrow fn component)', () => {
       const times = 10;

--- a/packages/brisa/src/utils/brisa-element/index.test.ts
+++ b/packages/brisa/src/utils/brisa-element/index.test.ts
@@ -3213,7 +3213,7 @@ describe('utils', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('<div>test</div>');
     });
 
-    it('should work reactivity in a nested fragment', () => {
+    it('should work reactivity in a nested fragment #618', () => {
       const times = 10;
       const Component = ({}, { store, derived }: WebContext) => {
         let count = 0;
@@ -3252,7 +3252,7 @@ describe('utils', () => {
       );
     });
 
-    it('should work reactivity in a nested ternary in a nested fragment', () => {
+    it('should work reactivity in a nested ternary in a nested fragment #618', () => {
       const times = 10;
       const Component = ({}, { store, derived }: WebContext) => {
         let count = 0;
@@ -3297,7 +3297,7 @@ describe('utils', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
     });
 
-    it('should work reactivity in a nested ternary in first level (arrow fn component)', () => {
+    it('should work reactivity in a nested ternary in first level (arrow fn component) #618', () => {
       const times = 10;
 
       const Component = ({}, { store, derived }: WebContext) => {
@@ -3325,7 +3325,7 @@ describe('utils', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
     });
 
-    it('should work reactivity in a nested ternary in a div', () => {
+    it('should work reactivity in a nested ternary in a div #618', () => {
       const times = 10;
       const Component = ({}, { store, derived }: WebContext) => {
         let count = 0;
@@ -3374,7 +3374,7 @@ describe('utils', () => {
       );
     });
 
-    it('should work reactivity in a nested fragment with signal at fist level', () => {
+    it('should work reactivity in a nested fragment with signal at fist level #618', () => {
       const times = 10;
       const Component = ({}, { store, derived }: WebContext) => {
         let count = 0;
@@ -3414,7 +3414,7 @@ describe('utils', () => {
       );
     });
 
-    it('should work reactivity in a nested div', () => {
+    it('should work reactivity in a nested div #618', () => {
       const times = 10;
       const Component = ({}, { store, derived }: WebContext) => {
         let count = 0;
@@ -3453,7 +3453,7 @@ describe('utils', () => {
       );
     });
 
-    it('should work reactivity in a nested inner div', () => {
+    it('should work reactivity in a nested inner div #618', () => {
       const times = 10;
       const Component = ({}, { store, derived }: WebContext) => {
         let count = 0;

--- a/packages/brisa/src/utils/brisa-element/index.test.ts
+++ b/packages/brisa/src/utils/brisa-element/index.test.ts
@@ -3212,51 +3212,44 @@ describe('utils', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('<div>test</div>');
     });
 
-    it.todo(
-      'should work a fragment with one div and also a signal with another div when is true',
-      () => {
-        const times = 10;
-        const Component = ({}, { store, derived }: WebContext) => {
-          let count = 0;
-          const show = derived(() => store.get('show'));
+    it.todo('should work reactivity in a nested way', () => {
+      const times = 10;
+      const Component = ({}, { store, derived }: WebContext) => {
+        let count = 0;
+        const show = derived(() => store.get('show'));
 
-          const foo = (num: number) => {
-            return [
-              null,
-              {},
-              [
-                [
-                  'div',
-                  {},
-                  [null, {}, () => (num < times ? foo(num + 1) : '')],
-                ],
-                [null, {}, () => show.value && 'show' + num],
-              ],
-            ];
-          };
-
-          return foo(++count);
+        const foo = (num: number) => {
+          return [
+            null,
+            {},
+            [
+              ['div', {}, [null, {}, () => (num < times ? foo(num + 1) : '')]],
+              [null, {}, () => show.value && 'show' + num],
+            ],
+          ];
         };
 
-        customElements.define('test-component', brisaElement(Component));
+        return foo(++count);
+      };
 
-        document.body.innerHTML = '<test-component />';
-        const testComponent = document.querySelector(
-          'test-component',
-        ) as HTMLElement;
+      customElements.define('test-component', brisaElement(Component));
 
-        expect(testComponent?.shadowRoot?.innerHTML).toBe(
-          '<div>'.repeat(times) + '</div>'.repeat(times),
-        );
+      document.body.innerHTML = '<test-component />';
+      const testComponent = document.querySelector(
+        'test-component',
+      ) as HTMLElement;
 
-        // Update the store
-        window._s.set('show', true);
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        '<div>'.repeat(times) + '</div>'.repeat(times),
+      );
 
-        expect(testComponent?.shadowRoot?.innerHTML).toBe(
-          `<div><div><div><div><div><div><div><div><div><div></div>show10</div>show9</div>show8</div>show7</div>show6</div>show5</div>show4</div>show3</div>show2</div>show1</div>show0</div>`,
-        );
-      },
-    );
+      // Update the store
+      window._s.set('show', true);
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        `<div><div><div><div><div><div><div><div><div><div></div>show10</div>show9</div>show8</div>show7</div>show6</div>show5</div>show4</div>show3</div>show2</div>show1</div>show0</div>`,
+      );
+    });
 
     it('should be possible to execute different onMount callbacks', async () => {
       const mockFirstCallback = mock((s: string) => {});

--- a/packages/brisa/src/utils/brisa-element/index.test.ts
+++ b/packages/brisa/src/utils/brisa-element/index.test.ts
@@ -3212,6 +3212,52 @@ describe('utils', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('<div>test</div>');
     });
 
+    it.todo(
+      'should work a fragment with one div and also a signal with another div when is true',
+      () => {
+        const times = 10;
+        const Component = ({}, { store, derived }: WebContext) => {
+          let count = 0;
+          const show = derived(() => store.get('show'));
+
+          const foo = (num: number) => {
+            return [
+              null,
+              {},
+              [
+                [
+                  'div',
+                  {},
+                  [null, {}, () => (num < times ? foo(num + 1) : '')],
+                ],
+                [null, {}, () => show.value && 'show' + num],
+              ],
+            ];
+          };
+
+          return foo(++count);
+        };
+
+        customElements.define('test-component', brisaElement(Component));
+
+        document.body.innerHTML = '<test-component />';
+        const testComponent = document.querySelector(
+          'test-component',
+        ) as HTMLElement;
+
+        expect(testComponent?.shadowRoot?.innerHTML).toBe(
+          '<div>'.repeat(times) + '</div>'.repeat(times),
+        );
+
+        // Update the store
+        window._s.set('show', true);
+
+        expect(testComponent?.shadowRoot?.innerHTML).toBe(
+          `<div><div><div><div><div><div><div><div><div><div></div>show10</div>show9</div>show8</div>show7</div>show6</div>show5</div>show4</div>show3</div>show2</div>show1</div>show0</div>`,
+        );
+      },
+    );
+
     it('should be possible to execute different onMount callbacks', async () => {
       const mockFirstCallback = mock((s: string) => {});
       const mockSecondCallback = mock((s: string) => {});

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -324,7 +324,7 @@ export default function brisaElement(
 
           const insertOrUpdate = (nodes: ChildNode[]) => {
             if (lastNodes && el.contains(lastNodes[0])) {
-              for (const node of nodes) el.insertBefore(node, lastNodes[0]);
+              lastNodes[0].before(...nodes);
               for (const node of lastNodes) node?.remove();
             } else {
               el.append(...nodes);
@@ -341,7 +341,7 @@ export default function brisaElement(
                 const isDangerHTML = (child as any)?.[0] === HTML;
 
                 if (isDangerHTML || isReactiveArray(child)) {
-                  const tempContainer = createElement('p') as any;
+                  const tempContainer = createElement(CONTEXT) as any;
 
                   // Reactive injected danger HTML via dangerHTML() helper
                   if (isDangerHTML) {

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -323,11 +323,13 @@ export default function brisaElement(
           let lastNodes: ChildNode[] | undefined;
 
           const insertOrUpdate = (nodes: ChildNode[]) => {
-            if (lastNodes && el.contains(lastNodes[0])) {
+            const element = lastNodes && !el.isConnected ? shadowRoot : el;
+
+            if (lastNodes && element.contains(lastNodes[0])) {
               lastNodes[0].before(...nodes);
               for (const node of lastNodes) node?.remove();
             } else {
-              el.append(...nodes);
+              element.append(...nodes);
             }
           };
 
@@ -341,7 +343,9 @@ export default function brisaElement(
                 const isDangerHTML = (child as any)?.[0] === HTML;
 
                 if (isDangerHTML || isReactiveArray(child)) {
-                  const tempContainer = createElement(CONTEXT) as any;
+                  const tempContainer = el.isConnected
+                    ? (createElement(CONTEXT) as any)
+                    : el;
 
                   // Reactive injected danger HTML via dangerHTML() helper
                   if (isDangerHTML) {

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -6253,7 +6253,7 @@ describe('integration', () => {
       );
     });
 
-    it.todo('should work reactivity in a nested ternary in a fragment', () => {
+    it('should work reactivity in a nested ternary in a fragment', () => {
       const code = `
         const times = 10;
 
@@ -6286,10 +6286,8 @@ describe('integration', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
     });
 
-    it.todo(
-      'should work reactivity in a nested ternary in multi fragment levels',
-      () => {
-        const code = `
+    it('should work reactivity in a nested ternary in multi fragment levels', () => {
+      const code = `
         const times = 10;
 
         export default function Component ({}, { store, derived }) {
@@ -6313,21 +6311,18 @@ describe('integration', () => {
         }
         `;
 
-        defineBrisaWebComponent(code, 'src/web-components/wc-ternary.tsx');
+      defineBrisaWebComponent(code, 'src/web-components/wc-ternary.tsx');
 
-        document.body.innerHTML = '<wc-ternary />';
-        const testComponent = document.querySelector(
-          'wc-ternary',
-        ) as HTMLElement;
+      document.body.innerHTML = '<wc-ternary />';
+      const testComponent = document.querySelector('wc-ternary') as HTMLElement;
 
-        expect(testComponent?.shadowRoot?.innerHTML).toBe('');
+      expect(testComponent?.shadowRoot?.innerHTML).toBe('');
 
-        // Update the store
-        window._s.set('show', true);
+      // Update the store
+      window._s.set('show', true);
 
-        expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
-      },
-    );
+      expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
+    });
 
     // TODO: This test should work after this happydom feat about ElementInternals
     // https://github.com/capricorn86/happy-dom/issues/1419

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -56,6 +56,7 @@ describe('integration', () => {
       window.createContext = createContext;
     });
     afterEach(async () => {
+      window._s.Map.clear();
       if (typeof window !== 'undefined') GlobalRegistrator.unregister();
     });
     it('should work returning a text node', () => {
@@ -6185,6 +6186,78 @@ describe('integration', () => {
 
       expect(div.textContent).toBe('0');
     });
+
+    it('should work reactivity in a nested ternary in first level', () => {
+      const code = `
+        const times = 10;
+
+        export default function Component ({}, { store, derived }) {
+          let count = 0;
+          const show = derived(() => store.get('show'));
+
+          const foo = (num: number) => {
+            return num < times ? foo(num + 1) : show.value && 'last number = ' + num
+          };
+
+          return <>{foo(++count)}</>;
+        }
+        `;
+
+      defineBrisaWebComponent(code, 'src/web-components/wc-ternary.tsx');
+
+      document.body.innerHTML = '<wc-ternary />';
+      const testComponent = document.querySelector('wc-ternary') as HTMLElement;
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe('');
+
+      // Update the store
+      window._s.set('show', true);
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
+    });
+
+    it.todo(
+      'should work reactivity in a nested ternary in multi fragment levels',
+      () => {
+        const code = `
+        const times = 10;
+
+        export default function Component ({}, { store, derived }) {
+          let count = 0;
+          const show = derived(() => store.get('show'));
+
+          const foo = (num: number) => {
+            return (
+              <>
+                <>
+                  <>
+                    {num < times ? foo(num + 1) : show.value && 'last number = ' + num}
+                  </>
+                </>
+                <></>
+              </>
+              )
+          };
+
+          return <>{foo(++count)}</>;
+        }
+        `;
+
+        defineBrisaWebComponent(code, 'src/web-components/wc-ternary.tsx');
+
+        document.body.innerHTML = '<wc-ternary />';
+        const testComponent = document.querySelector(
+          'wc-ternary',
+        ) as HTMLElement;
+
+        expect(testComponent?.shadowRoot?.innerHTML).toBe('');
+
+        // Update the store
+        window._s.set('show', true);
+
+        expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
+      },
+    );
 
     // TODO: This test should work after this happydom feat about ElementInternals
     // https://github.com/capricorn86/happy-dom/issues/1419

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -6216,6 +6216,76 @@ describe('integration', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
     });
 
+    it('should work reactivity in a nested ternary in a div', () => {
+      const code = `
+        const times = 10;
+
+        export default function Component ({}, { store, derived }) {
+          let count = 0;
+          const show = derived(() => store.get('show'));
+
+          const foo = (num: number) => {
+            return (
+              <div>
+                {num < times ? foo(num + 1) : show.value && 'last number = ' + num}
+              </div>
+              )
+          };
+
+          return <>{foo(++count)}</>;
+        }
+        `;
+
+      defineBrisaWebComponent(code, 'src/web-components/wc-ternary.tsx');
+
+      document.body.innerHTML = '<wc-ternary />';
+      const testComponent = document.querySelector('wc-ternary') as HTMLElement;
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        '<div>'.repeat(10) + '</div>'.repeat(10),
+      );
+
+      // Update the store
+      window._s.set('show', true);
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe(
+        '<div>'.repeat(10) + 'last number = 10' + '</div>'.repeat(10),
+      );
+    });
+
+    it.todo('should work reactivity in a nested ternary in a fragment', () => {
+      const code = `
+        const times = 10;
+
+        export default function Component ({}, { store, derived }) {
+          let count = 0;
+          const show = derived(() => store.get('show'));
+
+          const foo = (num: number) => {
+            return (
+              <>
+                {num < times ? foo(num + 1) : show.value && 'last number = ' + num}
+              </>
+              )
+          };
+
+          return <>{foo(++count)}</>;
+        }
+        `;
+
+      defineBrisaWebComponent(code, 'src/web-components/wc-ternary.tsx');
+
+      document.body.innerHTML = '<wc-ternary />';
+      const testComponent = document.querySelector('wc-ternary') as HTMLElement;
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe('');
+
+      // Update the store
+      window._s.set('show', true);
+
+      expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
+    });
+
     it.todo(
       'should work reactivity in a nested ternary in multi fragment levels',
       () => {

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -6187,7 +6187,7 @@ describe('integration', () => {
       expect(div.textContent).toBe('0');
     });
 
-    it('should work reactivity in a nested ternary in first level', () => {
+    it('should work reactivity in a nested ternary in first level #618', () => {
       const code = `
         const times = 10;
 
@@ -6216,7 +6216,7 @@ describe('integration', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
     });
 
-    it('should work reactivity in a nested ternary in a div', () => {
+    it('should work reactivity in a nested ternary in a div #618', () => {
       const code = `
         const times = 10;
 
@@ -6253,7 +6253,7 @@ describe('integration', () => {
       );
     });
 
-    it('should work reactivity in a nested ternary in a fragment', () => {
+    it('should work reactivity in a nested ternary in a fragment #618', () => {
       const code = `
         const times = 10;
 
@@ -6286,7 +6286,7 @@ describe('integration', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
     });
 
-    it('should work reactivity in a nested ternary in multi fragment levels', () => {
+    it('should work reactivity in a nested ternary in multi fragment levels #618', () => {
       const code = `
         const times = 10;
 


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/618

In the end, it was a rendering problem. The set of fragments and temporary containers sometimes had disconnected nodes. They were reactive, but they were not part of the DOM. 

When this happens, it is always the `shadowRoot`. This change fixed all the failing tests while keeping the others passing fine.