### PR TITLE
fix: fix bug on select-option render

### DIFF
--- a/packages/brisa/src/utils/brisa-element/index.test.ts
+++ b/packages/brisa/src/utils/brisa-element/index.test.ts
@@ -4370,6 +4370,37 @@ describe('utils', () => {
       expect(idComponent?.shadowRoot?.innerHTML).toBe('1234-543-4234-5425-123');
     });
 
+    it.only('should not select the last option by default when using appendChild in a loop', async () => {
+      const options = ['Option 1', 'Option 2', 'Option 3'];
+
+      const Component = () => {
+        return [
+          'select',
+          {},
+          () => options.map((option) => ['option', { value: option }, option]),
+        ];
+      };
+
+      customElements.define('select-component', brisaElement(Component));
+      document.body.innerHTML = '<select-component />';
+
+      const selectComponent = document.querySelector(
+        'select-component',
+      ) as HTMLElement;
+      const select = selectComponent.shadowRoot?.querySelector(
+        'select',
+      ) as HTMLSelectElement;
+      const optionsElements = Array.from(select.options);
+
+      expect(optionsElements[0].textContent).toBe('Option 1');
+      expect(optionsElements[1].textContent).toBe('Option 2');
+      expect(optionsElements[2].textContent).toBe('Option 3');
+
+      expect(optionsElements[0].selected).toBeTrue();
+      expect(optionsElements[1].selected).toBeFalse();
+      expect(optionsElements[2].selected).toBeFalse();
+    });
+
     it('should be generate multi useId when data-id does not exists', () => {
       spyOn(crypto, 'randomUUID').mockImplementationOnce(
         () => '1234-543-4234-5425-123',

--- a/packages/brisa/src/utils/brisa-element/index.test.ts
+++ b/packages/brisa/src/utils/brisa-element/index.test.ts
@@ -4370,7 +4370,7 @@ describe('utils', () => {
       expect(idComponent?.shadowRoot?.innerHTML).toBe('1234-543-4234-5425-123');
     });
 
-    it.only('should not select the last option by default when using appendChild in a loop', async () => {
+    it('should not select the last option by default when using appendChild in a loop', async () => {
       const options = ['Option 1', 'Option 2', 'Option 3'];
 
       const Component = () => {

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -343,9 +343,7 @@ export default function brisaElement(
                 const isDangerHTML = (child as any)?.[0] === HTML;
 
                 if (isDangerHTML || isReactiveArray(child)) {
-                  const tempContainer = el.isConnected
-                    ? (createElement(CONTEXT) as any)
-                    : el;
+                  const tempContainer = createElement(CONTEXT) as any;
 
                   // Reactive injected danger HTML via dangerHTML() helper
                   if (isDangerHTML) {

--- a/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
+++ b/packages/brisa/src/utils/get-client-code-in-page/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 2799;
 const brisaSize = 5720; // TODO: Reduce this size :/
 const webComponents = 1107;
 const unsuspenseSize = 213;
-const rpcSize = 2500; // TODO: Reduce this size
+const rpcSize = 2509; // TODO: Reduce this size
 const lazyRPCSize = 4105; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/632

The problem was that when the modifications were made directly in the select, the last modification was kept and interpreted as "selected". After this PR change, when we render an array of elements, it always does it in a temporary node to add all the modifications at once. When making the change all the tests pass, this was not what solved the disconnected nodes, so we can safely return this to its previous state. What really fixed the disconnected nodes is this line here:

https://github.com/brisa-build/brisa/blob/bbcf2021a62a070e73fccc37a4abf36c11d136ff/packages/brisa/src/utils/brisa-element/index.ts#L326