### PR TITLE
fix(hot-reload): use cache only in prod

### DIFF
--- a/packages/brisa/src/utils/process-page-route/index.tsx
+++ b/packages/brisa/src/utils/process-page-route/index.tsx
@@ -13,13 +13,14 @@ export default async function processPageRoute(
   route: MatchedBrisaRoute,
   error?: Error,
 ) {
+  const { BUILD_DIR, IS_PRODUCTION } = getConstants();
+
   // This cache improves the req/sec 575%
   // https://github.com/brisa-build/brisa/pull/604
-  if (cache.has(route.filePath)) {
+  if (IS_PRODUCTION && cache.has(route.filePath)) {
     return cache.get(route.filePath);
   }
 
-  const { BUILD_DIR } = getConstants();
   const module = (await import(
     pathToFileURLWhenNeeded(route.filePath)
   )) as PageModule;


### PR DESCRIPTION
Regression after adding a cache to improve performance, then hot-reload was not updating correctly