### PR TITLE
fix: improve multi-save hot-reload time

### DIFF
--- a/packages/brisa/src/cli/dev-live-reload.test.tsx
+++ b/packages/brisa/src/cli/dev-live-reload.test.tsx
@@ -1,5 +1,15 @@
-import { describe, it, expect } from 'bun:test';
-import { LiveReloadScript } from './dev-live-reload';
+import {
+  describe,
+  it,
+  expect,
+  mock,
+  afterEach,
+  beforeEach,
+  spyOn,
+} from 'bun:test';
+import { LiveReloadScript, activateHotReload } from './dev-live-reload';
+import fs from 'node:fs';
+import cp from 'node:child_process';
 
 describe('dev-live-reload', () => {
   it('should return live reload script for port 3000', () => {
@@ -22,5 +32,72 @@ describe('dev-live-reload', () => {
     const output = LiveReloadScript({ port: 4000, children: null }) as any;
 
     expect(output[2][0][2][1].html).toContain('window._xm = "native";');
+  });
+});
+
+describe('activateHotReload', () => {
+  let mockWatch: ReturnType<typeof spyOn>;
+  let mockKillProcess: ReturnType<typeof mock>;
+  let mockSpawn: ReturnType<typeof spyOn>;
+  let mockExistsSync: ReturnType<typeof mock>;
+  let mockStatSync: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    mockKillProcess = mock();
+    mockWatch = spyOn(fs, 'watch').mockImplementation(
+      () =>
+        ({
+          close: mock(),
+        }) as any,
+    );
+    mockExistsSync = spyOn(fs, 'existsSync').mockReturnValue(true);
+    mockStatSync = spyOn(fs, 'statSync').mockReturnValue({ size: 1 } as any);
+    mockSpawn = spyOn(cp, 'spawn');
+    mockSpawn.mockImplementation(() => ({
+      kill: mockKillProcess,
+      on: mock(),
+    }));
+  });
+
+  afterEach(() => {
+    mockWatch.mockRestore();
+    mockKillProcess.mockRestore();
+    mockSpawn.mockRestore();
+    mockExistsSync.mockRestore();
+    mockStatSync.mockRestore();
+  });
+
+  it('should initialize the watcher', async () => {
+    await activateHotReload();
+    expect(mockWatch).toHaveBeenCalledWith(
+      expect.any(String),
+      { recursive: true },
+      expect.any(Function),
+    );
+  });
+
+  it('should NOT kill the current process on the first process', async () => {
+    const recompile = await activateHotReload();
+    await recompile('test-file.js');
+
+    expect(mockKillProcess).not.toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+
+  it('should kill the current process and spawn a new one on file change', async () => {
+    const recompile = await activateHotReload();
+    await recompile('test-file.js');
+    await recompile('test-file.js');
+
+    expect(mockKillProcess).toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.any(Object),
+    );
   });
 });

--- a/packages/brisa/src/cli/dev-live-reload.tsx
+++ b/packages/brisa/src/cli/dev-live-reload.tsx
@@ -1,56 +1,54 @@
-import { watch, existsSync, statSync } from 'node:fs';
-import path from 'node:path';
-import process from 'node:process';
-import { spawnSync } from 'node:child_process';
-import constants, { reinitConstants } from '@/constants';
-import dangerHTML from '@/utils/danger-html';
-import { toInline } from '@/helpers';
-import { logError } from '@/utils/log/log-build';
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import cp from "node:child_process";
+import constants, { reinitConstants } from "@/constants";
+import dangerHTML from "@/utils/danger-html";
+import { toInline } from "@/helpers";
+import { logError } from "@/utils/log/log-build";
 
 const { LOG_PREFIX, SRC_DIR, IS_DEVELOPMENT, IS_SERVE_PROCESS } = constants;
-const LIVE_RELOAD_WEBSOCKET_PATH = '__brisa_live_reload__';
-const LIVE_RELOAD_COMMAND = 'reload';
+const LIVE_RELOAD_WEBSOCKET_PATH = "__brisa_live_reload__";
+const LIVE_RELOAD_COMMAND = "reload";
 
 // Similar than Bun.nanoseconds, but also working with Node.js
 function nanoseconds() {
   return Number(process.hrtime.bigint());
 }
 
-async function activateHotReload() {
-  let semaphore = false;
-  let waitFilename = '';
+export async function activateHotReload() {
+  let currentProcess: ReturnType<typeof cp.spawn> | null = null;
 
   async function watchSourceListener(event: any, filename: any) {
     try {
       // Compile assets only once (there are some issues with variable fonts)
       // - https://github.com/brisa-build/brisa/issues/227
       // - https://github.com/brisa-build/brisa/issues/228
-      if (filename.split(path.sep)[0] === 'public') return;
+      if (filename.split(path.sep)[0] === "public") return;
 
       const filePath = path.join(SRC_DIR, filename);
 
-      if (!existsSync(filePath)) return;
-      if (event !== 'change' && statSync(filePath).size !== 0) return;
+      if (!fs.existsSync(filePath)) return;
+      if (event !== "change" && fs.statSync(filePath).size !== 0) return;
 
       console.log(LOG_PREFIX.WAIT, `recompiling ${filename}...`);
-      if (semaphore) waitFilename = filename as string;
-      else recompile(filename as string);
+      recompile(filename as string);
     } catch (e: any) {
       logError({
         messages: [e.message, `Error while trying to recompile ${filename}`],
         stack: e.stack,
         docTitle: `Please, file a GitHub issue to Brisa's team`,
-        docLink: 'https://github.com/brisa-build/brisa/issues/new',
+        docLink: "https://github.com/brisa-build/brisa/issues/new",
       });
     }
   }
 
   async function recompile(filename: string) {
-    semaphore = true;
-
-    if (typeof Bun !== 'undefined') {
+    if (typeof Bun !== "undefined") {
       globalThis.Loader.registry.clear();
     }
+
+    currentProcess?.kill?.();
 
     const nsStart = nanoseconds();
 
@@ -59,55 +57,55 @@ async function activateHotReload() {
     // different runtimes, like Node.js or Bun, however, the build process is always
     // executed in Bun.
     // https://github.com/brisa-build/brisa/issues/404
-    const { error } = spawnSync(
+    currentProcess = cp.spawn(
       process.execPath,
-      [path.join(process.argv[1], '..', '..', 'build.js')],
+      [path.join(process.argv[1], "..", "..", "build.js")],
       {
-        env: Object.assign(process.env, { QUIET_MODE: 'true' }),
-        stdio: ['inherit', 'inherit', 'pipe'],
+        env: Object.assign(process.env, { QUIET_MODE: "true" }),
+        stdio: ["inherit", "inherit", "pipe"],
       },
     );
 
     const nsEnd = nanoseconds();
     const ms = ((nsEnd - nsStart) / 1000000).toFixed(2);
 
-    if (error) {
+    currentProcess.on("error", (error: any) => {
       console.log(
         LOG_PREFIX.ERROR,
         `failed to recompile ${filename}`,
         error.toString(),
       );
-      semaphore = false;
-      return;
-    }
+    });
 
-    console.log(LOG_PREFIX.READY, `hot reloaded successfully in ${ms}ms`);
+    currentProcess.on("exit", async (code: number) => {
+      if (code !== 0) return;
 
-    if (!globalThis.brisaServer) return;
+      console.log(LOG_PREFIX.READY, `recompiled ${filename} in ${ms}ms`);
+      if (!globalThis.brisaServer) return;
 
-    await reinitConstants();
-    globalThis.brisaServer.publish('hot-reload', LIVE_RELOAD_COMMAND);
-
-    if (waitFilename) {
-      const popFilename = waitFilename;
-      waitFilename = '';
-      await recompile(popFilename);
-    }
-    semaphore = false;
+      await reinitConstants();
+      globalThis.brisaServer.publish("hot-reload", LIVE_RELOAD_COMMAND);
+    });
   }
 
   if (globalThis.watcher) {
     globalThis.watcher.close();
   } else {
-    console.log(LOG_PREFIX.INFO, 'hot reloading enabled');
+    console.log(LOG_PREFIX.INFO, "hot reloading enabled");
   }
 
-  globalThis.watcher = watch(SRC_DIR, { recursive: true }, watchSourceListener);
+  globalThis.watcher = fs.watch(
+    SRC_DIR,
+    { recursive: true },
+    watchSourceListener,
+  );
 
-  process.on('SIGINT', () => {
+  process.on("SIGINT", () => {
     globalThis.watcher?.close();
     process.exit(0);
   });
+
+  return recompile;
 }
 
 // Checking IS_SERVE_PROCESS is totally necessary because this component is

--- a/packages/brisa/src/cli/dev-live-reload.tsx
+++ b/packages/brisa/src/cli/dev-live-reload.tsx
@@ -1,15 +1,15 @@
-import fs from "node:fs";
-import path from "node:path";
-import process from "node:process";
-import cp from "node:child_process";
-import constants, { reinitConstants } from "@/constants";
-import dangerHTML from "@/utils/danger-html";
-import { toInline } from "@/helpers";
-import { logError } from "@/utils/log/log-build";
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import cp from 'node:child_process';
+import constants, { reinitConstants } from '@/constants';
+import dangerHTML from '@/utils/danger-html';
+import { toInline } from '@/helpers';
+import { logError } from '@/utils/log/log-build';
 
 const { LOG_PREFIX, SRC_DIR, IS_DEVELOPMENT, IS_SERVE_PROCESS } = constants;
-const LIVE_RELOAD_WEBSOCKET_PATH = "__brisa_live_reload__";
-const LIVE_RELOAD_COMMAND = "reload";
+const LIVE_RELOAD_WEBSOCKET_PATH = '__brisa_live_reload__';
+const LIVE_RELOAD_COMMAND = 'reload';
 
 // Similar than Bun.nanoseconds, but also working with Node.js
 function nanoseconds() {
@@ -24,12 +24,12 @@ export async function activateHotReload() {
       // Compile assets only once (there are some issues with variable fonts)
       // - https://github.com/brisa-build/brisa/issues/227
       // - https://github.com/brisa-build/brisa/issues/228
-      if (filename.split(path.sep)[0] === "public") return;
+      if (filename.split(path.sep)[0] === 'public') return;
 
       const filePath = path.join(SRC_DIR, filename);
 
       if (!fs.existsSync(filePath)) return;
-      if (event !== "change" && fs.statSync(filePath).size !== 0) return;
+      if (event !== 'change' && fs.statSync(filePath).size !== 0) return;
 
       console.log(LOG_PREFIX.WAIT, `recompiling ${filename}...`);
       recompile(filename as string);
@@ -38,13 +38,13 @@ export async function activateHotReload() {
         messages: [e.message, `Error while trying to recompile ${filename}`],
         stack: e.stack,
         docTitle: `Please, file a GitHub issue to Brisa's team`,
-        docLink: "https://github.com/brisa-build/brisa/issues/new",
+        docLink: 'https://github.com/brisa-build/brisa/issues/new',
       });
     }
   }
 
   async function recompile(filename: string) {
-    if (typeof Bun !== "undefined") {
+    if (typeof Bun !== 'undefined') {
       globalThis.Loader.registry.clear();
     }
 
@@ -59,17 +59,17 @@ export async function activateHotReload() {
     // https://github.com/brisa-build/brisa/issues/404
     currentProcess = cp.spawn(
       process.execPath,
-      [path.join(process.argv[1], "..", "..", "build.js")],
+      [path.join(process.argv[1], '..', '..', 'build.js')],
       {
-        env: Object.assign(process.env, { QUIET_MODE: "true" }),
-        stdio: ["inherit", "inherit", "pipe"],
+        env: Object.assign(process.env, { QUIET_MODE: 'true' }),
+        stdio: ['inherit', 'inherit', 'pipe'],
       },
     );
 
     const nsEnd = nanoseconds();
     const ms = ((nsEnd - nsStart) / 1000000).toFixed(2);
 
-    currentProcess.on("error", (error: any) => {
+    currentProcess.on('error', (error: any) => {
       console.log(
         LOG_PREFIX.ERROR,
         `failed to recompile ${filename}`,
@@ -77,21 +77,21 @@ export async function activateHotReload() {
       );
     });
 
-    currentProcess.on("exit", async (code: number) => {
+    currentProcess.on('exit', async (code: number) => {
       if (code !== 0) return;
 
       console.log(LOG_PREFIX.READY, `recompiled ${filename} in ${ms}ms`);
       if (!globalThis.brisaServer) return;
 
       await reinitConstants();
-      globalThis.brisaServer.publish("hot-reload", LIVE_RELOAD_COMMAND);
+      globalThis.brisaServer.publish('hot-reload', LIVE_RELOAD_COMMAND);
     });
   }
 
   if (globalThis.watcher) {
     globalThis.watcher.close();
   } else {
-    console.log(LOG_PREFIX.INFO, "hot reloading enabled");
+    console.log(LOG_PREFIX.INFO, 'hot reloading enabled');
   }
 
   globalThis.watcher = fs.watch(
@@ -100,7 +100,7 @@ export async function activateHotReload() {
     watchSourceListener,
   );
 
-  process.on("SIGINT", () => {
+  process.on('SIGINT', () => {
     globalThis.watcher?.close();
     process.exit(0);
   });


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/640

This PR improves the time when saving many times in a row during hot-reload. 

Before:

A semaphore flag was waiting for the previous process to finish before starting the new one. This might make sense when we improve it so that instead of recompiling the whole app, it is done only for the specific file. Now, it does not make sense.

Now:

When a new process enters, it kills the previous one. 