### PR TITLE
fix: init store only once when no web-components

### DIFF
--- a/packages/brisa/src/utils/extend-stream-controller/index.test.ts
+++ b/packages/brisa/src/utils/extend-stream-controller/index.test.ts
@@ -296,7 +296,7 @@ describe('extendStreamController', () => {
     controller.transferStoreToClient();
 
     expect(mockController.enqueue.mock.calls).toEqual([
-      [`<script>window._S=[["test","test"]]</script>`],
+      [`<script id="init-S">window._S=[["test","test"]]</script>`],
     ]);
   });
 
@@ -317,7 +317,7 @@ describe('extendStreamController', () => {
     controller.transferStoreToClient();
 
     expect(mockController.enqueue.mock.calls).toEqual([
-      [`<script>window._S=[["test","test"]]</script>`],
+      [`<script id="init-S">window._S=[["test","test"]]</script>`],
     ]);
   });
 
@@ -406,7 +406,7 @@ describe('extendStreamController', () => {
     controller.transferStoreToClient();
 
     expect(mockController.enqueue.mock.calls).toEqual([
-      [`<script>window._S=[["some","foo"]]</script>`],
+      [`<script id="init-S">window._S=[["some","foo"]]</script>`],
       [`<script>for(let e of [["another","bar"]]) _S.push(e)</script>`],
     ]);
   });
@@ -432,7 +432,7 @@ describe('extendStreamController', () => {
     controller.transferStoreToClient();
 
     expect(mockController.enqueue.mock.calls).toEqual([
-      [`<script>window._S=[["some","foo"]]</script>`],
+      [`<script id="init-S">window._S=[["some","foo"]]</script>`],
       [
         `<script>for(let [k, v] of [["another","bar"]]){ _s?.set?.(k, v); _S.push([k, v])}</script>`,
       ],

--- a/packages/brisa/src/utils/extend-stream-controller/index.ts
+++ b/packages/brisa/src/utils/extend-stream-controller/index.ts
@@ -122,7 +122,7 @@ export default function extendStreamController({
       } else if (storeTransfered && !areSignalsInjected) {
         script = `<script>for(let e of ${serializedStore}) _S.push(e)</script>`;
       } else {
-        script = `<script>window._S=${serializedStore}</script>`;
+        script = `<script id="init-S">window._S=${serializedStore}</script>`;
       }
 
       this.enqueue(script, suspenseId);


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/644

Adding an `id` fixes multi-executions of the same script during SPA, solving the store updates. This bug only happened in a page without any web component, with only the RPC code for the server actions.

Before:

https://github.com/user-attachments/assets/efced3d3-31d5-49b2-88c8-dbe2a3d94730


Now:

https://github.com/user-attachments/assets/428f0081-c6eb-4c50-81cd-988e4b539ba1


