### PR TITLE
fix(cli)): fix brisa start to load correct brisa.config

### DIFF
--- a/packages/brisa/src/bin/index.test.ts
+++ b/packages/brisa/src/bin/index.test.ts
@@ -40,6 +40,7 @@ const TAILWINDCSS_PATH = path.join(
 const PANDACSS_PATH = path.join(INTEGRATIONS_PATH, 'pandacss', 'index.js');
 const BUILD_PATH = path.join(OUT_PATH, 'cli', 'build.js');
 const SERVE_PATH = path.join(OUT_PATH, 'cli', 'serve', 'index.js');
+const SERVE_PATH_PROD = path.join(process.cwd(), 'build', 'server.js');
 
 let originalArgv: string[];
 let mockSpawnSync: Mock<typeof cp.spawnSync>;
@@ -1172,7 +1173,7 @@ describe('Brisa CLI', () => {
     ]);
     expect(mockSpawnSync.mock.calls[1]).toEqual([
       'bun',
-      [SERVE_PATH, '3000', 'PROD'],
+      [SERVE_PATH_PROD, '3000', 'PROD'],
       prodOptions,
     ]);
   });
@@ -1196,7 +1197,7 @@ describe('Brisa CLI', () => {
 
     expect(mockSpawnSync.mock.calls[1]).toEqual([
       'bun',
-      [SERVE_PATH, '3005', 'PROD'],
+      [SERVE_PATH_PROD, '3005', 'PROD'],
       newProdOptions,
     ]);
   });
@@ -1214,7 +1215,7 @@ describe('Brisa CLI', () => {
 
     expect(mockSpawnSync.mock.calls[1]).toEqual([
       'node',
-      [SERVE_PATH, '3000', 'PROD'],
+      [SERVE_PATH_PROD, '3000', 'PROD'],
       prodOptions,
     ]);
   });
@@ -1237,7 +1238,8 @@ describe('Brisa CLI', () => {
         '--allow-net',
         '--allow-read',
         '--allow-env',
-        SERVE_PATH,
+        '--allow-sys',
+        SERVE_PATH_PROD,
         '3000',
         'PROD',
       ],
@@ -1274,7 +1276,7 @@ describe('Brisa CLI', () => {
     ]);
     expect(mockSpawnSync.mock.calls[1]).toEqual([
       'bun',
-      [SERVE_PATH, '5000', 'PROD'],
+      [SERVE_PATH_PROD, '5000', 'PROD'],
       prodOptions,
     ]);
   });
@@ -1301,7 +1303,7 @@ describe('Brisa CLI', () => {
     );
     expect(mockSpawnSync.mock.calls[1]).toEqual([
       path.join(process.env.HOME!, '.bun', 'bin', 'bun'),
-      [SERVE_PATH, '3000', 'PROD'],
+      [SERVE_PATH_PROD, '3000', 'PROD'],
       prodOptions,
     ]);
   });

--- a/packages/brisa/src/bin/index.ts
+++ b/packages/brisa/src/bin/index.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env bun
 
-const { blueLog, yellowLog, redLog } = require('@/utils/log/log-color');
+const { yellowLog, redLog } = require('@/utils/log/log-color');
 const cp = require('child_process');
 const path = require('node:path');
 const fs = require('node:fs');
 const crypto = require('node:crypto');
 const process = require('node:process');
-const { version, packageManager } = require('@/../package.json');
+const { packageManager } = require('@/../package.json');
 const outPath = path
   .join(import.meta.dir, 'out')
   // There are some cases where the CLI is executed from the node_modules/.bin folder
@@ -42,6 +42,7 @@ const buildStandaloneFilePath = path.join(
   'index.js',
 );
 const serveFilepath = path.join(outPath, 'cli', 'serve', 'index.js');
+const serveFilepathProd = path.resolve(process.cwd(), 'build', 'server.js');
 const MOBILE_OUTPUTS = new Set(['android', 'ios']);
 const TAURI_OUTPUTS = new Set(['android', 'ios', 'desktop']);
 
@@ -319,11 +320,18 @@ async function main({
 
       const runtimeStartCmd = {
         node: ['node'],
-        deno: ['deno', 'run', '--allow-net', '--allow-read', '--allow-env'],
+        deno: [
+          'deno',
+          'run',
+          '--allow-net',
+          '--allow-read',
+          '--allow-env',
+          '--allow-sys',
+        ],
       }[OUTPUT] ?? [BUN_EXEC];
 
       const cmd = runtimeStartCmd[0];
-      const options = [serveFilepath, PORT.toString(), 'PROD'];
+      const options = [serveFilepathProd, PORT.toString(), 'PROD'];
       const rest =
         runtimeStartCmd.length > 1
           ? [...runtimeStartCmd.slice(1), ...options]

--- a/packages/brisa/src/cli/build.test.ts
+++ b/packages/brisa/src/cli/build.test.ts
@@ -65,6 +65,7 @@ describe('cli', () => {
       mockLog.mockRestore();
       mock.restore();
       globalThis.mockConstants = undefined;
+      process.env.QUIET_MODE = undefined;
     });
 
     it('should remove the content of build directory if it exists (except _brisa)', async () => {

--- a/packages/brisa/src/cli/serve/index.tsx
+++ b/packages/brisa/src/cli/serve/index.tsx
@@ -23,11 +23,11 @@ async function init(options: ServeOptions) {
       cluster.fork();
     }
 
-    let messageDisplayed = false;
+    let workerId: number;
 
     cluster.on('message', (worker, message) => {
-      if (messageDisplayed) return;
-      messageDisplayed = true;
+      if (workerId && worker.id !== workerId) return;
+      workerId = worker.id;
       console.log(LOG_PREFIX.INFO, message);
     });
 

--- a/packages/brisa/src/utils/client-build/layout-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/layout-build/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 3653;
 const brisaSize = 5638; // TODO: Reduce this size :/
 const webComponents = 1118;
 const unsuspenseSize = 213;
-const rpcSize = 2500; // TODO: Reduce this size
+const rpcSize = 2509; // TODO: Reduce this size
 const lazyRPCSize = 4105; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/compile-files/index.test.ts
+++ b/packages/brisa/src/utils/compile-files/index.test.ts
@@ -51,6 +51,7 @@ describe('utils', () => {
       const constants = getConstants();
       const mockExtendPlugins = mock();
 
+      process.env.QUIET_MODE = undefined;
       globalThis.mockConstants = {
         ...constants,
         PAGES_DIR: DEV_PAGES_DIR,
@@ -952,6 +953,7 @@ describe('utils', () => {
         ASSETS_DIR: path.join(SRC_DIR, 'out', 'public'),
       };
 
+      process.env.QUIET_MODE = undefined;
       mockConsoleLog.mockImplementation(() => {});
       mock.module('brisa/server', () => ({
         SSRWebComponent,

--- a/packages/brisa/src/utils/handle-css-files/index.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { getConstants } from '@/constants';
-import { log, logError } from '../log/log-build';
+import { logError } from '../log/log-build';
 import { gzipSync } from 'bun';
 import { brotliCompressSync } from 'node:zlib';
 
@@ -26,7 +26,10 @@ export default async function handleCSSFiles() {
         const startTime = Date.now();
 
         if (IS_BUILD_PROCESS) {
-          log(LOG_PREFIX.WAIT, `transpiling CSS with ${integration.name}...`);
+          console.log(
+            LOG_PREFIX.WAIT,
+            `transpiling CSS with ${integration.name}...`,
+          );
         }
 
         let useDefault = true;


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/661

after this PR the `brisa start` calls the standalone server and loads the constants correctly in the same way.