### PR TITLE
fix: fix userEvent.select and deselect to work in new versions of happy-dom

### DIFF
--- a/packages/brisa/src/core/test/api/index.ts
+++ b/packages/brisa/src/core/test/api/index.ts
@@ -241,17 +241,15 @@ export const userEvent = {
   },
   select: (select: HTMLSelectElement, value: string) => {
     select.value = value;
-    // Note: Dispatching 'input' event is also dispatching 'change' event
-    // in Happy-DOM, so we don't need to dispatch 'change' event separately
     select.dispatchEvent(new Event('input', { bubbles: true }));
+    select.dispatchEvent(new Event('change', { bubbles: true }));
   },
-  deselect: (selecgt: HTMLSelectElement, value: string) => {
-    if (value === selecgt.value) {
-      selecgt.value = '';
+  deselect: (select: HTMLSelectElement, value: string) => {
+    if (value === select.value) {
+      select.value = '';
     }
-    // Note: Dispatching 'input' event is also dispatching 'change' event
-    // in Happy-DOM, so we don't need to dispatch 'change' event separately
-    selecgt.dispatchEvent(new Event('input', { bubbles: true }));
+    select.dispatchEvent(new Event('input', { bubbles: true }));
+    select.dispatchEvent(new Event('change', { bubbles: true }));
   },
   upload: (input: HTMLInputElement, file: File) => {
     // @ts-ignore


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/680

In the new versions of happy-dom the tests of Brisa on `userEvent.select` and `userEvent.deselect` crash, with this change they are fixed and it works again. 