### PR TITLE
Fixes query when have duplicated keys

### DIFF
--- a/packages/brisa/src/utils/file-system-router/index.test.ts
+++ b/packages/brisa/src/utils/file-system-router/index.test.ts
@@ -376,6 +376,7 @@ describe('utils', () => {
       // With query:
       '/?test=1',
       '/user/john?test=1',
+      '/user/john?test=1&test=2',
       '/foo/bar?test=1',
       '/rest/a/b/c?test=1',
       '/rest2/a/b/c?test=1',

--- a/packages/brisa/src/utils/file-system-router/index.ts
+++ b/packages/brisa/src/utils/file-system-router/index.ts
@@ -131,6 +131,12 @@ function getParamsAndQuery(route: string, pathname: string, url: URL) {
   );
 
   const query = { ...params, ...Object.fromEntries(url.searchParams) };
+  for (const key of url.searchParams.keys()) {
+    query[key] = url.searchParams.getAll(key);
+    if (query[key].length === 1) {
+      query[key] = query[key][0];
+    }
+  }
 
   return { params, query };
 }

--- a/packages/brisa/src/utils/file-system-router/index.ts
+++ b/packages/brisa/src/utils/file-system-router/index.ts
@@ -113,6 +113,19 @@ function getRouteKind(route: string): MatchedBrisaRoute['kind'] {
   return 'exact';
 }
 
+function getURLParams(url: URL) {
+  const params: Record<string, string | string[]> = {};
+  for (const key of url.searchParams.keys()) {
+    params[key] = url.searchParams.getAll(key);
+    
+    if (params[key].length === 1) {
+      params[key] = params[key][0];
+    }
+  }
+
+  return params;
+}
+
 function getParamsAndQuery(route: string, pathname: string, url: URL) {
   const routeParts = route.split('/');
   const pathnameParts = pathname.split('/');
@@ -131,12 +144,6 @@ function getParamsAndQuery(route: string, pathname: string, url: URL) {
   );
 
   const query = { ...params, ...getURLParams(url) };
-  for (const key of url.searchParams.keys()) {
-    query[key] = url.searchParams.getAll(key);
-    if (query[key].length === 1) {
-      query[key] = query[key][0];
-    }
-  }
 
   return { params, query };
 }

--- a/packages/brisa/src/utils/file-system-router/index.ts
+++ b/packages/brisa/src/utils/file-system-router/index.ts
@@ -117,7 +117,7 @@ function getURLParams(url: URL) {
   const params: Record<string, string | string[]> = {};
   for (const key of url.searchParams.keys()) {
     params[key] = url.searchParams.getAll(key);
-    
+
     if (params[key].length === 1) {
       params[key] = params[key][0];
     }

--- a/packages/brisa/src/utils/file-system-router/index.ts
+++ b/packages/brisa/src/utils/file-system-router/index.ts
@@ -130,7 +130,7 @@ function getParamsAndQuery(route: string, pathname: string, url: URL) {
     {} as Record<string, string | string[]>,
   );
 
-  const query = { ...params, ...Object.fromEntries(url.searchParams) };
+  const query = { ...params, ...getURLParams(url) };
   for (const key of url.searchParams.keys()) {
     query[key] = url.searchParams.getAll(key);
     if (query[key].length === 1) {


### PR DESCRIPTION
Fixes query when there is a duplicated key, now it will properly return a string[], instead of last string.
Add test to validate this condition won't break again.