### PR TITLE
fix(build): mark devDependencies as external

### DIFF
--- a/docs/building-your-application/configuring/external.md
+++ b/docs/building-your-application/configuring/external.md
@@ -6,6 +6,10 @@ description: Learn how to configure external dependencies.
 
 The `external` configuration property in `brisa.config.ts` allows you to define external dependencies that should not be included in the final bundle. This is useful for libraries that are already included in the runtime environment, or for libraries that should be resolved at runtime.
 
+> [!NOTE]
+>
+> Brisa is including your `devDependencies` as external dependencies by default. This means that you don't need to include them in the `external` configuration property.
+
 ## Example
 
 In the next example, we are importing the `lightningcss` library as an external dependency. This means that the library will not be included in the final bundle, but will be resolved at runtime.

--- a/examples/with-pandacss/package.json
+++ b/examples/with-pandacss/package.json
@@ -5,19 +5,19 @@
   "example-category": "integrations",
   "type": "module",
   "scripts": {
-    "dev": "brisa dev",
+    "dev": "bun run prepare && brisa dev",
     "dev:debug": "brisa dev --debug",
     "prepare": "panda codegen",
-    "build": "brisa build",
+    "build": "bun run prepare && brisa build",
     "start": "brisa start"
   },
   "dependencies": {
     "brisa": "0.2.2-canary.4"
   },
   "devDependencies": {
-    "@pandacss/dev": "0.46.1",
+    "@pandacss/dev": "0.51.1",
     "@types/bun": "latest",
-    "postcss": "8.4.47",
+    "postcss": "8.4.49",
     "typescript": "latest"
   }
 }

--- a/packages/brisa/src/utils/load-constants/index.ts
+++ b/packages/brisa/src/utils/load-constants/index.ts
@@ -116,7 +116,7 @@ export async function loadProjectConstants({
     idleTimeout: 30,
   };
 
-  const binaryExternalLibs = ['lightningcss'];
+  const defaultExternalDeps = [...getDevDeps(), 'lightningcss'];
   const CSS_FILES =
     (await importFileIfExists('css-files', BUILD_DIR))?.default ?? [];
   const integrations = await importFileIfExists(
@@ -150,8 +150,8 @@ export async function loadProjectConstants({
   }
 
   // Add external libraries to the list of external libraries
-  if (!CONFIG.external) CONFIG.external = binaryExternalLibs;
-  else CONFIG.external = [...CONFIG.external, ...binaryExternalLibs];
+  if (!CONFIG.external) CONFIG.external = defaultExternalDeps;
+  else CONFIG.external = [...CONFIG.external, ...defaultExternalDeps];
 
   // This is needed for some helpers like "navigate" to work properly
   // in the server side. (For the client-side it's solved during the build process)
@@ -165,4 +165,11 @@ export async function loadProjectConstants({
     LOCALES_SET,
     IS_STATIC_EXPORT,
   };
+}
+
+function getDevDeps() {
+  const packageJSONDir = process.env.npm_package_json;
+  if (!packageJSONDir) return [];
+  const packageJSON = require(packageJSONDir);
+  return Object.keys(packageJSON.devDependencies || {});
 }


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/700

From now on all devDependencies in package.json will be treated as external, avoiding conflicts trying to add the dependencies in the build.

Currently there were conflicts when building PandaCSS, when it is a devDependency and you would not have to put it in the build.

CC: @artydev 