### PR TITLE
fix(render): remove overlapping nodes + old connected nodes

### DIFF
--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -329,6 +329,7 @@ export default function brisaElement(
               const last = lastNodes.at(-1)!;
               let current = nodes.at(-1)?.nextSibling;
 
+              // Remove connected nodes #686
               while (current && current !== last) {
                 const nodeToRemove = current;
                 current = current.nextSibling;

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -326,11 +326,12 @@ export default function brisaElement(
             const index = insertedNodes?.findIndex((n) => el.contains(n))!;
             let curr: ChildNode | null | undefined = insertedNodes?.[index];
 
-            // avoid node overlapping #686
+            // If the first node is no longer in the DOM (it is "disconnected"),
+            // it is necessary to clean up or rearrange other overlapping nodes.
+            // This can happen with different effects that use the same element.
+            // https://github.com/brisa-build/brisa/issues/686
             if (index > 0) {
-              for (let node of nodes) {
-                curr!.previousSibling?.remove();
-              }
+              for (let node of nodes) curr!.previousSibling?.remove();
             }
 
             if (curr) {
@@ -340,9 +341,9 @@ export default function brisaElement(
 
               // Remove connected nodes #686
               while (curr && curr !== last) {
-                const nodeToRemove = curr;
-                curr = curr.nextSibling;
-                nodeToRemove.remove();
+                const next = curr.nextSibling as ChildNode;
+                curr.remove();
+                curr = next;
               }
 
               last.remove();

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -324,8 +324,18 @@ export default function brisaElement(
 
           const insertOrUpdate = (nodes: ChildNode[]) => {
             if (lastNodes && el.contains(lastNodes[0])) {
-              lastNodes[0].after(...nodes);
-              for (const node of lastNodes) node.remove();
+              lastNodes[0].before(...nodes);
+
+              const last = lastNodes.at(-1)!;
+              let current = nodes.at(-1)?.nextSibling;
+
+              while (current && current !== last) {
+                const nodeToRemove = current;
+                current = current.nextSibling;
+                nodeToRemove.remove();
+              }
+
+              last.remove();
             } else {
               el.append(...nodes);
             }

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -323,10 +323,11 @@ export default function brisaElement(
           let insertedNodes: ChildNode[] | undefined;
 
           const insertOrUpdate = (nodes: ChildNode[]) => {
-            let index = insertedNodes?.findIndex((n) => el.contains(n))!;
-            let curr: ChildNode | null | undefined = insertedNodes?.[index];
+            let anchorIndex = insertedNodes?.findIndex((n) => el.contains(n))!;
+            let oldNode: ChildNode | null | undefined =
+              insertedNodes?.[anchorIndex];
 
-            if (curr) {
+            if (oldNode) {
               const last = insertedNodes!.at(-1)!;
               let nodeToClean;
 
@@ -334,17 +335,20 @@ export default function brisaElement(
               // it is necessary to clean up to fix overlapping nodes.
               // This can happen with different effects that use the same element.
               // https://github.com/brisa-build/brisa/issues/686
-              while (index > 0 && (nodeToClean = curr!.previousSibling)) {
+              while (
+                anchorIndex > 0 &&
+                (nodeToClean = oldNode!.previousSibling)
+              ) {
                 nodeToClean.remove();
               }
 
-              curr.before(...nodes);
+              oldNode.before(...nodes);
 
               // Remove old connected nodes #686
-              while (curr && curr !== last) {
-                const next = curr.nextSibling as ChildNode;
-                curr.remove();
-                curr = next;
+              while (oldNode && oldNode !== last) {
+                const next = oldNode.nextSibling as ChildNode;
+                oldNode.remove();
+                oldNode = next;
               }
 
               last.remove();

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -328,7 +328,7 @@ export default function brisaElement(
             let nodeToClean;
 
             // If the first node is no longer in the DOM (it is "disconnected"),
-            // it is necessary to clean up or rearrange other overlapping nodes.
+            // it is necessary to clean up to fix overlapping nodes.
             // This can happen with different effects that use the same element.
             // https://github.com/brisa-build/brisa/issues/686
             while (index > 0 && (nodeToClean = curr!.previousSibling)) {

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -340,9 +340,11 @@ export default function brisaElement(
                 [child, el] = handlePortal(child, el);
 
                 const isDangerHTML = (child as any)?.[0] === HTML;
-                
+
                 // Fix disconnected elements #618 & #686
-                if (lastNodes && !el.isConnected) el = shadowRoot as any;
+                if (lastNodes && !el.parentNode) {
+                  el = shadowRoot as any;
+                }
 
                 if (isDangerHTML || isReactiveArray(child)) {
                   const tempContainer = createElement(CONTEXT) as any;

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -323,15 +323,16 @@ export default function brisaElement(
           let insertedNodes: ChildNode[] | undefined;
 
           const insertOrUpdate = (nodes: ChildNode[]) => {
-            const index = insertedNodes?.findIndex((n) => el.contains(n))!;
+            let index = insertedNodes?.findIndex((n) => el.contains(n))!;
             let curr: ChildNode | null | undefined = insertedNodes?.[index];
 
             // If the first node is no longer in the DOM (it is "disconnected"),
             // it is necessary to clean up or rearrange other overlapping nodes.
             // This can happen with different effects that use the same element.
             // https://github.com/brisa-build/brisa/issues/686
-            if (index > 0) {
-              for (let node of nodes) curr!.previousSibling?.remove();
+            let node;
+            while (index > 0 && (node = curr!.previousSibling)) {
+              node.remove();
             }
 
             if (curr) {

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -323,13 +323,11 @@ export default function brisaElement(
           let lastNodes: ChildNode[] | undefined;
 
           const insertOrUpdate = (nodes: ChildNode[]) => {
-            const element = lastNodes && !el.isConnected ? shadowRoot : el;
-
-            if (lastNodes && element.contains(lastNodes[0])) {
+            if (lastNodes && el.contains(lastNodes[0])) {
               lastNodes[0].after(...nodes);
               for (const node of lastNodes) node.remove();
             } else {
-              element.append(...nodes);
+              el.append(...nodes);
             }
             lastNodes = nodes;
           };
@@ -342,6 +340,9 @@ export default function brisaElement(
                 [child, el] = handlePortal(child, el);
 
                 const isDangerHTML = (child as any)?.[0] === HTML;
+                
+                // Fix disconnected elements #618 & #686
+                if (lastNodes && !el.isConnected) el = shadowRoot as any;
 
                 if (isDangerHTML || isReactiveArray(child)) {
                   const tempContainer = createElement(CONTEXT) as any;

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -365,14 +365,11 @@ export default function brisaElement(
                     );
                   }
 
-                  const nodes = arr(tempContainer.childNodes) as ChildNode[];
-
-                  insertOrUpdate(nodes);
+                  insertOrUpdate(arr(tempContainer.childNodes) as ChildNode[]);
                 }
                 // Reactive text node
                 else {
-                  const textNodes = [createTextNode(child)];
-                  insertOrUpdate(textNodes);
+                  insertOrUpdate([createTextNode(child)]);
                 }
               }
               if (childOrPromise instanceof Promise)

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -365,11 +365,14 @@ export default function brisaElement(
                     );
                   }
 
-                  insertOrUpdate(arr(tempContainer.childNodes) as ChildNode[]);
+                  const nodes = arr(tempContainer.childNodes) as ChildNode[];
+
+                  insertOrUpdate(nodes);
                 }
                 // Reactive text node
                 else {
-                  insertOrUpdate([createTextNode(child)]);
+                  const textNodes = [createTextNode(child)];
+                  insertOrUpdate(textNodes);
                 }
               }
               if (childOrPromise instanceof Promise)

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -323,18 +323,19 @@ export default function brisaElement(
           let insertedNodes: ChildNode[] | undefined;
 
           const insertOrUpdate = (nodes: ChildNode[]) => {
-            const firstNode = insertedNodes?.find((n) => el.contains(n));
+            let curr: ChildNode | null | undefined = insertedNodes?.find((n) =>
+              el.contains(n),
+            );
 
-            if (firstNode) {
-              firstNode.before(...nodes);
+            if (curr) {
+              curr.before(...nodes);
 
               const last = insertedNodes!.at(-1)!;
-              let current = nodes.at(-1)?.nextSibling;
 
               // Remove connected nodes #686
-              while (current && current !== last) {
-                const nodeToRemove = current;
-                current = current.nextSibling;
+              while (curr && curr !== last) {
+                const nodeToRemove = curr;
+                curr = curr.nextSibling;
                 nodeToRemove.remove();
               }
 

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -323,9 +323,14 @@ export default function brisaElement(
           let insertedNodes: ChildNode[] | undefined;
 
           const insertOrUpdate = (nodes: ChildNode[]) => {
-            let curr: ChildNode | null | undefined = insertedNodes?.find((n) =>
-              el.contains(n),
-            );
+            const index = insertedNodes?.findIndex((n) => el.contains(n))!;
+            let curr: ChildNode | null | undefined = insertedNodes?.[index];
+
+            if (index > 0) {
+              for (let node of nodes) {
+                curr!.previousSibling?.remove();
+              }
+            }
 
             if (curr) {
               curr.before(...nodes);

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -323,10 +323,12 @@ export default function brisaElement(
           let lastNodes: ChildNode[] | undefined;
 
           const insertOrUpdate = (nodes: ChildNode[]) => {
-            if (lastNodes && el.contains(lastNodes[0])) {
-              lastNodes[0].before(...nodes);
+            const firstNode = lastNodes?.find((n) => el.contains(n));
 
-              const last = lastNodes.at(-1)!;
+            if (firstNode) {
+              firstNode.before(...nodes);
+
+              const last = lastNodes!.at(-1)!;
               let current = nodes.at(-1)?.nextSibling;
 
               // Remove connected nodes #686

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -356,7 +356,7 @@ export default function brisaElement(
                     for (const c of child as Children[]) {
                       mount(NULL, {}, c, tempContainer, r(r2), effect);
                     }
-                  } else if ((child as ReactiveArray).length) {
+                  } else {
                     mount(
                       ...(child as ReactiveArray),
                       tempContainer,

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -340,7 +340,7 @@ export default function brisaElement(
 
               curr.before(...nodes);
 
-              // Remove connected nodes #686
+              // Remove old connected nodes #686
               while (curr && curr !== last) {
                 const next = curr.nextSibling as ChildNode;
                 curr.remove();

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -320,15 +320,15 @@ export default function brisaElement(
             mount(...(children as [string, Attr, Children]), el, r, effect);
           }
         } else if (isFunction(children)) {
-          let lastNodes: ChildNode[] | undefined;
+          let insertedNodes: ChildNode[] | undefined;
 
           const insertOrUpdate = (nodes: ChildNode[]) => {
-            const firstNode = lastNodes?.find((n) => el.contains(n));
+            const firstNode = insertedNodes?.find((n) => el.contains(n));
 
             if (firstNode) {
               firstNode.before(...nodes);
 
-              const last = lastNodes!.at(-1)!;
+              const last = insertedNodes!.at(-1)!;
               let current = nodes.at(-1)?.nextSibling;
 
               // Remove connected nodes #686
@@ -342,7 +342,7 @@ export default function brisaElement(
             } else {
               el.append(...nodes);
             }
-            lastNodes = nodes;
+            insertedNodes = nodes;
           };
 
           effect(
@@ -355,7 +355,7 @@ export default function brisaElement(
                 const isDangerHTML = (child as any)?.[0] === HTML;
 
                 // Fix disconnected elements #618 & #686
-                if (lastNodes && !el.parentNode) {
+                if (insertedNodes && !el.parentNode) {
                   el = shadowRoot as any;
                 }
 

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -325,20 +325,20 @@ export default function brisaElement(
           const insertOrUpdate = (nodes: ChildNode[]) => {
             let index = insertedNodes?.findIndex((n) => el.contains(n))!;
             let curr: ChildNode | null | undefined = insertedNodes?.[index];
-            let nodeToClean;
-
-            // If the first node is no longer in the DOM (it is "disconnected"),
-            // it is necessary to clean up to fix overlapping nodes.
-            // This can happen with different effects that use the same element.
-            // https://github.com/brisa-build/brisa/issues/686
-            while (index > 0 && (nodeToClean = curr!.previousSibling)) {
-              nodeToClean.remove();
-            }
 
             if (curr) {
-              curr.before(...nodes);
-
               const last = insertedNodes!.at(-1)!;
+              let nodeToClean;
+
+              // If the first node is no longer in the DOM (it is "disconnected"),
+              // it is necessary to clean up to fix overlapping nodes.
+              // This can happen with different effects that use the same element.
+              // https://github.com/brisa-build/brisa/issues/686
+              while (index > 0 && (nodeToClean = curr!.previousSibling)) {
+                nodeToClean.remove();
+              }
+
+              curr.before(...nodes);
 
               // Remove connected nodes #686
               while (curr && curr !== last) {

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -326,6 +326,7 @@ export default function brisaElement(
             const index = insertedNodes?.findIndex((n) => el.contains(n))!;
             let curr: ChildNode | null | undefined = insertedNodes?.[index];
 
+            // avoid node overlapping #686
             if (index > 0) {
               for (let node of nodes) {
                 curr!.previousSibling?.remove();

--- a/packages/brisa/src/utils/brisa-element/index.ts
+++ b/packages/brisa/src/utils/brisa-element/index.ts
@@ -325,14 +325,14 @@ export default function brisaElement(
           const insertOrUpdate = (nodes: ChildNode[]) => {
             let index = insertedNodes?.findIndex((n) => el.contains(n))!;
             let curr: ChildNode | null | undefined = insertedNodes?.[index];
+            let nodeToClean;
 
             // If the first node is no longer in the DOM (it is "disconnected"),
             // it is necessary to clean up or rearrange other overlapping nodes.
             // This can happen with different effects that use the same element.
             // https://github.com/brisa-build/brisa/issues/686
-            let node;
-            while (index > 0 && (node = curr!.previousSibling)) {
-              node.remove();
+            while (index > 0 && (nodeToClean = curr!.previousSibling)) {
+              nodeToClean.remove();
             }
 
             if (curr) {

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -6322,6 +6322,208 @@ describe('integration', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
     });
 
+    it('should handle signals at multiple levels correctly', async () => {
+      const code = `
+        export default function MultiLevelSignals({ active }, { state }) {
+          const showOuter = state(false);
+          const showInner = state(false);
+    
+          return (
+            <div>
+              {active ? (
+                <>
+                  <div>
+                    Outer Section
+                    <button onClick={() => (showOuter.value = !showOuter.value)}>
+                      Toggle Outer
+                    </button>
+                    {showOuter.value ? (
+                      <>
+                        <p>Outer Visible</p>
+                        <button onClick={() => (showInner.value = !showInner.value)}>
+                          Toggle Inner
+                        </button>
+                        {showInner.value ? (
+                          <span>Inner Content Visible</span>
+                        ) : (
+                          <span>Inner Content Hidden</span>
+                        )}
+                      </>
+                    ) : (
+                      <p>Outer Hidden</p>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <div>No Active Section</div>
+              )}
+            </div>
+          );
+        }
+      `;
+
+      defineBrisaWebComponent(
+        code,
+        'src/web-components/multi-level-signals.tsx',
+      );
+
+      document.body.innerHTML =
+        '<multi-level-signals active="true"></multi-level-signals>';
+      await Bun.sleep(0);
+
+      const component = document.querySelector(
+        'multi-level-signals',
+      ) as HTMLElement;
+      const shadowRoot = component.shadowRoot!;
+      const toggleOuterButton = shadowRoot.querySelector('button');
+
+      // Initial render
+      expect(normalizeHTML(shadowRoot.innerHTML)).toBe(
+        normalizeHTML(`
+          <div>
+            <div>
+              Outer Section
+              <button>Toggle Outer</button>
+              <p>Outer Hidden</p>
+            </div>
+          </div>
+        `),
+      );
+
+      // Toggle outer section
+      toggleOuterButton!.click();
+      await Bun.sleep(0);
+
+      // After toggling outer section
+      expect(normalizeHTML(shadowRoot.innerHTML)).toBe(
+        normalizeHTML(`
+          <div>
+            <div>
+              Outer Section
+              <button>Toggle Outer</button>
+              <p>Outer Visible</p>
+              <button>Toggle Inner</button>
+              <span>Inner Content Hidden</span>
+            </div>
+          </div>
+        `),
+      );
+
+      // Change active prop
+      component.setAttribute('active', 'false');
+      await Bun.sleep(0);
+
+      // Check render after active becomes false
+      expect(normalizeHTML(shadowRoot.innerHTML)).toBe(
+        normalizeHTML(`
+          <div>
+            <div>No Active Section</div>
+          </div>
+        `),
+      );
+    });
+
+    it('should handle nested ternaries with cross-signal dependencies', async () => {
+      const code = `
+        export default function CrossSignals({ toggle }, { state }) {
+          const outerSignal = state(false);
+          const innerSignal = state(false);
+    
+          return (
+            <div>
+              {toggle ? (
+                <>
+                  <div>
+                    Outer {toggle}
+                    <button onClick={() => (outerSignal.value = !outerSignal.value)}>
+                      Toggle Outer
+                    </button>
+                    {outerSignal.value ? (
+                      <>
+                        <p>Outer is Active</p>
+                        {innerSignal.value ? (
+                          <p>Inner is Active</p>
+                        ) : (
+                          <button onClick={() => (innerSignal.value = true)}>
+                            Activate Inner
+                          </button>
+                        )}
+                      </>
+                    ) : (
+                      <p>Outer is Inactive</p>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <p>Toggle is off</p>
+              )}
+            </div>
+          );
+        }
+      `;
+
+      defineBrisaWebComponent(code, 'src/web-components/cross-signals.tsx');
+
+      document.body.innerHTML = '<cross-signals toggle="true"></cross-signals>';
+      await Bun.sleep(0);
+
+      const component = document.querySelector('cross-signals') as HTMLElement;
+      const shadowRoot = component.shadowRoot!;
+      const toggleOuterButton = shadowRoot.querySelector('button');
+
+      // Initial render
+      expect(normalizeHTML(shadowRoot.innerHTML)).toBe(
+        normalizeHTML(`
+          <div>
+            <div>
+              Outer true
+              <button>Toggle Outer</button>
+              <p>Outer is Inactive</p>
+            </div>
+          </div>
+        `),
+      );
+
+      // Toggle outer
+      toggleOuterButton!.click();
+      await Bun.sleep(0);
+
+      // After toggling outer
+      expect(normalizeHTML(shadowRoot.innerHTML)).toBe(
+        normalizeHTML(`
+          <div>
+            <div>
+              Outer true
+              <button>Toggle Outer</button>
+              <p>Outer is Active</p>
+              <button>Activate Inner</button>
+            </div>
+          </div>
+        `),
+      );
+
+      // Activate inner
+      const activateInnerButton = shadowRoot.querySelector(
+        'button:nth-of-type(2)',
+      ) as HTMLButtonElement;
+      activateInnerButton!.click();
+      await Bun.sleep(0);
+
+      // After activating inner
+      expect(normalizeHTML(shadowRoot.innerHTML)).toBe(
+        normalizeHTML(`
+          <div>
+            <div>
+              Outer true
+              <button>Toggle Outer</button>
+              <p>Outer is Active</p>
+              <p>Inner is Active</p>
+            </div>
+          </div>
+        `),
+      );
+    });
+
     it('should handle nested ternaries with signals correctly #686', async () => {
       const code = `
         export default function NestedTernaries({ level1, level2 }, { state }) {

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -6322,6 +6322,149 @@ describe('integration', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
     });
 
+    it('should not duplicate "Open" button after change state + change prop signal #686', async () => {
+      const code = `
+        export default async function Chat({ foo, bar }, { state }) {
+          const message = state(false);
+
+          return (
+            <div>
+              {foo ? (
+                <>
+                  <div>
+                    U
+                    <h3 class="text-sm">
+                      {foo} {bar}
+                    </h3>
+                  </div>
+                  {message.value ? (
+                    <div>
+                      Opened
+                    </div>
+                  ) : (
+                    <div>
+                      Closed
+                    </div>
+                  )}
+                  <div>
+                    <div>
+                      <button
+                        type="button"
+                        onClick={() => (message.value = !message.value)}
+                      >
+                        Open
+                      </button>
+                    </div>
+                    <div>Foo</div>
+                    <div>Bar</div>
+                  </div>
+                </>
+              ) : (
+                <div>
+                Foo
+                </div>
+              )}
+            </div>
+          );
+        }
+      `;
+
+      defineBrisaWebComponent(code, 'src/web-components/chat-example.tsx');
+
+      document.body.innerHTML = '<chat-example foo="bar" bar="baz" />';
+      await Bun.sleep(0);
+
+      const chatExample = document.querySelector('chat-example') as HTMLElement;
+      const button = chatExample.shadowRoot!.querySelector('button') as HTMLButtonElement;
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              bar baz
+            </h3>
+          </div>
+          <div>
+            Closed
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+
+      button.click();
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              bar baz
+            </h3>
+          </div>
+          <div>
+            Opened
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+
+      chatExample.setAttribute('foo', 'baz');
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              baz baz
+            </h3>
+          </div>
+          <div>
+            Opened
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+    });
+
     // TODO: This test should work after this happydom feat about ElementInternals
     // https://github.com/capricorn86/happy-dom/issues/1419
     it.todo('it should work associating a form to the custom element', () => {

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -6766,6 +6766,160 @@ describe('integration', () => {
       );
     });
 
+    it('should work different signals also with an array of elements #686', async () => {
+      const code = `
+        export default async function Chat({ foo, bar }, { state }) {
+          const message = state(false);
+
+          return (
+            <div>
+              {foo ? (
+                <>
+                  <div>
+                    U
+                    <h3 class="text-sm">
+                      {foo} {bar}
+                    </h3>
+                  </div>
+                  {message.value ? (
+                    [<div>
+                      Is
+                    </div>,
+                    <div>
+                      Opened
+                    </div>]
+                  ) : (
+                    <div>
+                      Closed
+                    </div>
+                  )}
+                  <div>
+                    <div>
+                      <button
+                        type="button"
+                        onClick={() => (message.value = !message.value)}
+                      >
+                        Open
+                      </button>
+                    </div>
+                    <div>Foo</div>
+                    <div>Bar</div>
+                  </div>
+                </>
+              ) : (
+                <div>
+                Foo
+                </div>
+              )}
+            </div>
+          );
+        }
+      `;
+
+      defineBrisaWebComponent(code, 'src/web-components/chat-example.tsx');
+
+      document.body.innerHTML = '<chat-example foo="bar" bar="baz" />';
+      await Bun.sleep(0);
+
+      const chatExample = document.querySelector('chat-example') as HTMLElement;
+      const button = chatExample.shadowRoot!.querySelector(
+        'button',
+      ) as HTMLButtonElement;
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              bar baz
+            </h3>
+          </div>
+          <div>
+            Closed
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+
+      button.click();
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              bar baz
+            </h3>
+          </div>
+          <div>
+            Is
+          </div>
+           <div>
+            Opened
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+
+      chatExample.setAttribute('foo', 'baz');
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              baz baz
+            </h3>
+          </div>
+           <div>
+            Is
+          </div>
+           <div>
+            Opened
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+    });
+
     // TODO: This test should work after this happydom feat about ElementInternals
     // https://github.com/capricorn86/happy-dom/issues/1419
     it.todo('it should work associating a form to the custom element', () => {

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -6322,7 +6322,7 @@ describe('integration', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
     });
 
-    it('should not duplicate "Open" button after change state + change prop signal #686', async () => {
+    it('should render well after change state + change prop signal #686', async () => {
       const code = `
         export default async function Chat({ foo, bar }, { state }) {
           const message = state(false);
@@ -6375,7 +6375,9 @@ describe('integration', () => {
       await Bun.sleep(0);
 
       const chatExample = document.querySelector('chat-example') as HTMLElement;
-      const button = chatExample.shadowRoot!.querySelector('button') as HTMLButtonElement;
+      const button = chatExample.shadowRoot!.querySelector(
+        'button',
+      ) as HTMLButtonElement;
 
       expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
         normalizeHTML(`

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -6930,6 +6930,272 @@ describe('integration', () => {
               {foo ? (
                 <>
                   {message.value ? (
+                    <div>
+                      Opened
+                    </div>
+                  ) : (
+                    <div>
+                      Closed
+                    </div>
+                  )}
+                  <div>
+                    <div>
+                      <button
+                        type="button"
+                        onClick={() => (message.value = !message.value)}
+                      >
+                        Open
+                      </button>
+                    </div>
+                    <div>Foo</div>
+                    <div>Bar</div>
+                  </div>
+                </>
+              ) : (
+                <div>
+                Foo
+                </div>
+              )}
+            </div>
+          );
+        }
+      `;
+
+      defineBrisaWebComponent(code, 'src/web-components/chat-example.tsx');
+
+      document.body.innerHTML = '<chat-example foo="bar" bar="baz" />';
+      await Bun.sleep(0);
+
+      const chatExample = document.querySelector('chat-example') as HTMLElement;
+      const button = chatExample.shadowRoot!.querySelector(
+        'button',
+      ) as HTMLButtonElement;
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            Closed
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+
+      button.click();
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            Opened
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+
+      chatExample.setAttribute('foo', 'baz');
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            Opened
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+    });
+
+    it('should work when the signal condition is the last child #686', async () => {
+      const code = `
+        export default async function Chat({ foo, bar }, { state }) {
+          const message = state(false);
+
+          return (
+            <div>
+              {foo ? (
+                <>
+                  <div>
+                    U
+                    <h3 class="text-sm">
+                      {foo} {bar}
+                    </h3>
+                  </div>
+                  <div>
+                    <div>
+                      <button
+                        type="button"
+                        onClick={() => (message.value = !message.value)}
+                      >
+                        Open
+                      </button>
+                    </div>
+                    <div>Foo</div>
+                    <div>Bar</div>
+                  </div>
+                 {message.value ? (
+                    <div>
+                      Opened
+                    </div>
+                  ) : (
+                    <div>
+                      Closed
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div>
+                Foo
+                </div>
+              )}
+            </div>
+          );
+        }
+      `;
+
+      defineBrisaWebComponent(code, 'src/web-components/chat-example.tsx');
+
+      document.body.innerHTML = '<chat-example foo="bar" bar="baz" />';
+      await Bun.sleep(0);
+
+      const chatExample = document.querySelector('chat-example') as HTMLElement;
+      const button = chatExample.shadowRoot!.querySelector(
+        'button',
+      ) as HTMLButtonElement;
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              bar baz
+            </h3>
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+          <div>
+            Closed
+          </div>
+        </div>  
+      `),
+      );
+
+      button.click();
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              bar baz
+            </h3>
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+          <div>
+            Opened
+          </div>
+        </div>  
+      `),
+      );
+
+      chatExample.setAttribute('foo', 'baz');
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              baz baz
+            </h3>
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+          <div>
+            Opened
+          </div>
+        </div>  
+      `),
+      );
+    });
+
+    it('should work when the signal condition is the first child + array #686', async () => {
+      const code = `
+        export default async function Chat({ foo, bar }, { state }) {
+          const message = state(false);
+
+          return (
+            <div>
+              {foo ? (
+                <>
+                  {message.value ? (
                     [<div>
                       Is
                     </div>,
@@ -7050,7 +7316,7 @@ describe('integration', () => {
       );
     });
 
-    it('should work when the signal condition is the last child #686', async () => {
+    it('should work when the signal condition is the last child + array #686', async () => {
       const code = `
         export default async function Chat({ foo, bar }, { state }) {
           const message = state(false);

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -6322,6 +6322,103 @@ describe('integration', () => {
       expect(testComponent?.shadowRoot?.innerHTML).toBe('last number = 10');
     });
 
+    it('should handle nested ternaries with signals correctly #686', async () => {
+      const code = `
+        export default function NestedTernaries({ level1, level2 }, { state }) {
+          const showInner = state(false);
+          
+          return (
+            <div>
+              {level1 ? (
+                <>
+                  <div>
+                    Outer {level1}
+                    {level2 ? (
+                      <>
+                        <span>Level 2 - Active</span>
+                        <button onClick={() => (showInner.value = !showInner.value)}>
+                          Toggle Inner
+                        </button>
+                        {showInner.value ? (
+                          <p>Inner Content Visible</p>
+                        ) : (
+                          <p>Inner Content Hidden</p>
+                        )}
+                      </>
+                    ) : (
+                      <span>Level 2 - Inactive</span>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <div>No Level 1</div>
+              )}
+            </div>
+          );
+        }
+      `;
+
+      defineBrisaWebComponent(code, 'src/web-components/nested-ternaries.tsx');
+
+      document.body.innerHTML =
+        '<nested-ternaries level1="true" level2="true"></nested-ternaries>';
+      await Bun.sleep(0);
+
+      const component = document.querySelector(
+        'nested-ternaries',
+      ) as HTMLElement;
+      const shadowRoot = component.shadowRoot!;
+      const toggleButton = shadowRoot.querySelector('button');
+
+      // Initial render
+      expect(normalizeHTML(shadowRoot.innerHTML)).toBe(
+        normalizeHTML(`
+          <div>
+            <div>
+              Outer true
+              <span>Level 2 - Active</span>
+              <button>Toggle Inner</button>
+              <p>Inner Content Hidden</p>
+            </div>
+          </div>
+        `),
+      );
+
+      // Simulate toggle click
+      toggleButton!.click();
+      await Bun.sleep(0);
+
+      // After toggling inner content
+      expect(normalizeHTML(shadowRoot.innerHTML)).toBe(
+        normalizeHTML(`
+          <div>
+            <div>
+              Outer true
+              <span>Level 2 - Active</span>
+              <button>Toggle Inner</button>
+              <p>Inner Content Visible</p>
+            </div>
+          </div>
+        `),
+      );
+
+      // Change props
+      component.setAttribute('level2', 'false');
+      await Bun.sleep(0);
+
+      // Check render after level2 becomes inactive
+      expect(normalizeHTML(shadowRoot.innerHTML)).toBe(
+        normalizeHTML(`
+          <div>
+            <div>
+              Outer true
+              <span>Level 2 - Inactive</span>
+            </div>
+          </div>
+        `),
+      );
+    });
+
     it('should render well after change state + change prop signal #686', async () => {
       const code = `
         export default async function Chat({ foo, bar }, { state }) {

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -7050,6 +7050,160 @@ describe('integration', () => {
       );
     });
 
+    it('should work when the signal condition is the last child #686', async () => {
+      const code = `
+        export default async function Chat({ foo, bar }, { state }) {
+          const message = state(false);
+
+          return (
+            <div>
+              {foo ? (
+                <>
+                  <div>
+                    U
+                    <h3 class="text-sm">
+                      {foo} {bar}
+                    </h3>
+                  </div>
+                  <div>
+                    <div>
+                      <button
+                        type="button"
+                        onClick={() => (message.value = !message.value)}
+                      >
+                        Open
+                      </button>
+                    </div>
+                    <div>Foo</div>
+                    <div>Bar</div>
+                  </div>
+                  {message.value ? (
+                    [<div>
+                      Is
+                    </div>,
+                    <div>
+                      Opened
+                    </div>]
+                  ) : (
+                    <div>
+                      Closed
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div>
+                Foo
+                </div>
+              )}
+            </div>
+          );
+        }
+      `;
+
+      defineBrisaWebComponent(code, 'src/web-components/chat-example.tsx');
+
+      document.body.innerHTML = '<chat-example foo="bar" bar="baz" />';
+      await Bun.sleep(0);
+
+      const chatExample = document.querySelector('chat-example') as HTMLElement;
+      const button = chatExample.shadowRoot!.querySelector(
+        'button',
+      ) as HTMLButtonElement;
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              bar baz
+            </h3>
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+         <div>
+            Closed
+          </div>
+        </div>  
+      `),
+      );
+
+      button.click();
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              bar baz
+            </h3>
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+          <div>
+            Is
+          </div>
+          <div>
+            Opened
+          </div>
+        </div>  
+      `),
+      );
+
+      chatExample.setAttribute('foo', 'baz');
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            U
+            <h3 class="text-sm">
+              baz baz
+            </h3>
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+          <div>
+            Is
+          </div>
+           <div>
+            Opened
+          </div>
+        </div>  
+      `),
+      );
+    });
+
     // TODO: This test should work after this happydom feat about ElementInternals
     // https://github.com/capricorn86/happy-dom/issues/1419
     it.todo('it should work associating a form to the custom element', () => {

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -6920,6 +6920,136 @@ describe('integration', () => {
       );
     });
 
+    it('should work when the signal condition is the first child #686', async () => {
+      const code = `
+        export default async function Chat({ foo, bar }, { state }) {
+          const message = state(false);
+
+          return (
+            <div>
+              {foo ? (
+                <>
+                  {message.value ? (
+                    [<div>
+                      Is
+                    </div>,
+                    <div>
+                      Opened
+                    </div>]
+                  ) : (
+                    <div>
+                      Closed
+                    </div>
+                  )}
+                  <div>
+                    <div>
+                      <button
+                        type="button"
+                        onClick={() => (message.value = !message.value)}
+                      >
+                        Open
+                      </button>
+                    </div>
+                    <div>Foo</div>
+                    <div>Bar</div>
+                  </div>
+                </>
+              ) : (
+                <div>
+                Foo
+                </div>
+              )}
+            </div>
+          );
+        }
+      `;
+
+      defineBrisaWebComponent(code, 'src/web-components/chat-example.tsx');
+
+      document.body.innerHTML = '<chat-example foo="bar" bar="baz" />';
+      await Bun.sleep(0);
+
+      const chatExample = document.querySelector('chat-example') as HTMLElement;
+      const button = chatExample.shadowRoot!.querySelector(
+        'button',
+      ) as HTMLButtonElement;
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            Closed
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+
+      button.click();
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+          <div>
+            Is
+          </div>
+           <div>
+            Opened
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+
+      chatExample.setAttribute('foo', 'baz');
+      await Bun.sleep(0);
+
+      expect(normalizeHTML(chatExample.shadowRoot!.innerHTML)).toBe(
+        normalizeHTML(`
+        <div>
+           <div>
+            Is
+          </div>
+           <div>
+            Opened
+          </div>
+          <div>
+            <div>
+              <button type="button">Open</button>
+            </div>
+            <div>
+              Foo
+            </div>
+            <div>
+              Bar
+            </div>
+          </div>
+        </div>  
+      `),
+      );
+    });
+
     // TODO: This test should work after this happydom feat about ElementInternals
     // https://github.com/capricorn86/happy-dom/issues/1419
     it.todo('it should work associating a form to the custom element', () => {


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/686

This PR fixes bugs encountered with different reactive parts sharing nodes of the same element. 

Example:

Signal 1 -> when true -> fragment -> Signal 2 -> when true -> render
&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; -> render sibling

In this scenario, when Signal 2 changes, it updates the local refs of this reactivity part but does not communicate with Signal 1 to update this ref (so hard to do this...). So after this PR, when Signal 1 needs to update the nodes without this ref, it cleans the overlapped nodes first to do the job correctly. Then, instead of removing the referenced nodes, it removes the real ones, doing `nextSibling` until the last ref.

For me, the ideal solution would be not to depend on these local references. But, at least, with this solution we avoid doing a reconciler for it or adding markers to the HTML. 😅

> [!CAUTION]
>
> **Bad part**: It increases 110 bytes the client code, (still 3kb but rounded is 4kb). At least in a previous PR I reduce 26 bytes this code, so the total new bytes in the next release will be +84 bytes.