### PR TITLE
fix(build): fix usage of external CSS Parsers (Tailwind, PandaCSS...)

### DIFF
--- a/packages/brisa/src/utils/compile-files/index.ts
+++ b/packages/brisa/src/utils/compile-files/index.ts
@@ -13,6 +13,7 @@ import generateStaticExport from '@/utils/generate-static-export';
 import getWebComponentsPerEntryPoints from '@/utils/get-webcomponents-per-entrypoints';
 import { shouldTransferTranslatedPagePaths } from '@/utils/transfer-translated-page-paths';
 import { clientBuild } from '../client-build';
+import { getCSSLoader } from '@/utils/handle-css-files';
 
 const BRISA_DEPS = ['brisa/server'];
 
@@ -88,6 +89,7 @@ export default async function compileFiles() {
     splitting: false,
     external,
     define,
+    loader: getCSSLoader(),
     plugins: extendPlugins(
       [
         {

--- a/packages/brisa/src/utils/handle-css-files/index.test.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.test.ts
@@ -10,7 +10,7 @@ import {
 import path from 'node:path';
 import fs from 'node:fs';
 import type { BrisaConstants } from '@/types';
-import handleCSSFiles from '.';
+import handleCSSFiles, { getCSSLoader } from '.';
 import brisaTailwindCSS from 'brisa-tailwindcss';
 
 const BUILD_DIR = path.join(import.meta.dirname, 'out');
@@ -266,3 +266,34 @@ describe('utils/handle-css-files', () => {
     ]);
   });
 });
+
+describe('getCSSLoader', () => {
+  it('should return a plain text loader for CSS files when useExternalTranspiler is true', () => {
+    globalThis.mockConstants = { CONFIG: { integrations: [{ transpileCSS: true }] } } as any;
+
+    const loader = getCSSLoader();
+
+    expect(loader).toEqual({
+      '.css': 'text',
+      '.scss': 'text',
+      '.sass': 'text',
+      '.less': 'text',
+    });
+  });
+
+  it('should return a plain text loader for CSS files when useExternalTranspiler is false', () => {
+    globalThis.mockConstants = { CONFIG: { integrations: [{ transpileCSS: false }] } } as any;
+
+    const loader = getCSSLoader();
+
+    expect(loader).toBeUndefined();
+  });
+
+  it('should return a plain text loader for CSS files when useExternalTranspiler is undefined', () => {
+    globalThis.mockConstants = { CONFIG: {} };
+
+    const loader = getCSSLoader();
+
+    expect(loader).toBeUndefined();
+  });
+})

--- a/packages/brisa/src/utils/handle-css-files/index.test.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.test.ts
@@ -14,6 +14,7 @@ import handleCSSFiles, { getCSSLoader } from '.';
 import brisaTailwindCSS from 'brisa-tailwindcss';
 
 const BUILD_DIR = path.join(import.meta.dirname, 'out');
+const SRC_DIR = path.join(import.meta.dirname, 'src');
 const LOG_PREFIX = {
   INFO: '[INFO]',
   TICK: '✔',
@@ -27,6 +28,7 @@ describe('utils/handle-css-files', () => {
     if (!fs.existsSync(BUILD_DIR)) fs.mkdirSync(BUILD_DIR);
     globalThis.mockConstants = {
       BUILD_DIR,
+      SRC_DIR,
       LOG_PREFIX,
     } as unknown as BrisaConstants;
     mockHash = spyOn(Bun, 'hash');
@@ -216,6 +218,7 @@ describe('utils/handle-css-files', () => {
     const CONFIG = { integrations: [brisaTailwindCSS()] };
     globalThis.mockConstants = {
       BUILD_DIR,
+      SRC_DIR,
       CONFIG,
       LOG_PREFIX,
       IS_BUILD_PROCESS: false,
@@ -232,6 +235,7 @@ describe('utils/handle-css-files', () => {
     const CONFIG = { assetCompression: true };
     globalThis.mockConstants = {
       BUILD_DIR,
+      SRC_DIR,
       CONFIG,
       LOG_PREFIX,
       IS_PRODUCTION: true,
@@ -251,6 +255,7 @@ describe('utils/handle-css-files', () => {
     const CONFIG = { assetCompression: true };
     globalThis.mockConstants = {
       BUILD_DIR,
+      SRC_DIR,
       CONFIG,
       LOG_PREFIX,
       IS_PRODUCTION: false,

--- a/packages/brisa/src/utils/handle-css-files/index.test.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.test.ts
@@ -14,7 +14,7 @@ import handleCSSFiles, { getCSSLoader } from '.';
 import brisaTailwindCSS from 'brisa-tailwindcss';
 
 const BUILD_DIR = path.join(import.meta.dirname, 'out');
-const SRC_DIR = path.join(import.meta.dirname, 'src');
+const SRC_DIR = BUILD_DIR;
 const LOG_PREFIX = {
   INFO: '[INFO]',
   TICK: '✔',
@@ -51,7 +51,9 @@ describe('utils/handle-css-files', () => {
     await handleCSSFiles();
 
     const newFilename = 'style-123456.css';
-    expect(fs.existsSync(path.join(BUILD_DIR, 'public', newFilename))).toBeTrue();
+    expect(
+      fs.existsSync(path.join(BUILD_DIR, 'public', newFilename)),
+    ).toBeTrue();
   });
 
   it('should create a css-files.js file with the new CSS file names (renamed)', async () => {
@@ -68,7 +70,10 @@ describe('utils/handle-css-files', () => {
 
   it('should move (rename) multi CSS files style-<hash>.css inside /public', async () => {
     fs.writeFileSync(path.join(BUILD_DIR, 'test.css'), 'body { color: red; }');
-    fs.writeFileSync(path.join(BUILD_DIR, 'test2.css'), 'body { color: blue; }');
+    fs.writeFileSync(
+      path.join(BUILD_DIR, 'test2.css'),
+      'body { color: blue; }',
+    );
 
     mockHash.mockReturnValueOnce(111111).mockReturnValueOnce(222222);
 
@@ -84,11 +89,12 @@ describe('utils/handle-css-files', () => {
 
   it('should create a css-files.js file with multiple renamed css file names', async () => {
     fs.writeFileSync(path.join(BUILD_DIR, 'test.css'), 'body { color: red; }');
-    fs.writeFileSync(path.join(BUILD_DIR, 'test2.css'), 'body { color: blue; }');
+    fs.writeFileSync(
+      path.join(BUILD_DIR, 'test2.css'),
+      'body { color: blue; }',
+    );
 
-    mockHash
-      .mockReturnValueOnce(111111)
-      .mockReturnValueOnce(222222);
+    mockHash.mockReturnValueOnce(111111).mockReturnValueOnce(222222);
 
     await handleCSSFiles();
 
@@ -103,9 +109,9 @@ describe('utils/handle-css-files', () => {
 
   it('should create a base.css content file using TailwindCSS integration when no file has @tailwind', async () => {
     const CONFIG = { integrations: [brisaTailwindCSS()] };
-    globalThis.mockConstants = { BUILD_DIR, CONFIG, LOG_PREFIX };
+    globalThis.mockConstants = { BUILD_DIR, SRC_DIR, CONFIG, LOG_PREFIX };
 
-    mockHash.mockReturnValueOnce(999999); 
+    mockHash.mockReturnValueOnce(999999);
 
     await handleCSSFiles();
 
@@ -119,17 +125,20 @@ describe('utils/handle-css-files', () => {
       fs.existsSync(path.join(BUILD_DIR, 'public', expectedFilename)),
     ).toBeTrue();
     expect(
-      fs.readFileSync(path.join(BUILD_DIR, 'public', expectedFilename), 'utf-8'),
+      fs.readFileSync(
+        path.join(BUILD_DIR, 'public', expectedFilename),
+        'utf-8',
+      ),
     ).toContain('MIT License | https://tailwindcss.com');
   });
 
   it('should create the base-<hash>.css on front of the others when no file has @tailwind', async () => {
     const CONFIG = { integrations: [brisaTailwindCSS()] };
-    globalThis.mockConstants = { BUILD_DIR, CONFIG, LOG_PREFIX };
+    globalThis.mockConstants = { BUILD_DIR, SRC_DIR, CONFIG, LOG_PREFIX };
 
     fs.writeFileSync(path.join(BUILD_DIR, 'test.css'), 'body { color: red; }');
 
-    mockHash.mockReturnValueOnce(111111).mockReturnValueOnce(222222);
+    mockHash.mockReturnValueOnce(111111).mockReturnValue(222222);
 
     await handleCSSFiles();
 
@@ -142,7 +151,9 @@ describe('utils/handle-css-files', () => {
 
     expect(cssFiles).toEqual([baseCSSFilename, styleCSSFilename].toSorted());
 
-    expect(fs.existsSync(path.join(BUILD_DIR, 'public', baseCSSFilename))).toBeTrue();
+    expect(
+      fs.existsSync(path.join(BUILD_DIR, 'public', baseCSSFilename)),
+    ).toBeTrue();
     expect(
       fs.readFileSync(path.join(BUILD_DIR, 'public', baseCSSFilename), 'utf-8'),
     ).toContain('MIT License | https://tailwindcss.com');
@@ -150,7 +161,7 @@ describe('utils/handle-css-files', () => {
 
   it('should NOT create a base.css file when some file has @tailwind', async () => {
     const CONFIG = { integrations: [brisaTailwindCSS()] };
-    globalThis.mockConstants = { BUILD_DIR, CONFIG, LOG_PREFIX };
+    globalThis.mockConstants = { BUILD_DIR, SRC_DIR, CONFIG, LOG_PREFIX };
 
     fs.writeFileSync(path.join(BUILD_DIR, 'test.css'), '@tailwind base;');
 
@@ -176,7 +187,7 @@ describe('utils/handle-css-files', () => {
     fs.writeFileSync(path.join(BUILD_DIR, 'test.css'), code);
 
     const CONFIG = { integrations: [brisaTailwindCSS()] };
-    globalThis.mockConstants = { BUILD_DIR, CONFIG, LOG_PREFIX };
+    globalThis.mockConstants = { BUILD_DIR, SRC_DIR, CONFIG, LOG_PREFIX };
 
     mockHash.mockReturnValueOnce(111111);
 
@@ -193,6 +204,7 @@ describe('utils/handle-css-files', () => {
     const CONFIG = { integrations: [brisaTailwindCSS()] };
     globalThis.mockConstants = {
       BUILD_DIR,
+      SRC_DIR,
       CONFIG,
       LOG_PREFIX,
       IS_BUILD_PROCESS: true,
@@ -242,12 +254,16 @@ describe('utils/handle-css-files', () => {
     };
 
     fs.writeFileSync(path.join(BUILD_DIR, 'test.css'), 'body { color: red; }');
-    mockHash.mockReturnValueOnce(111111)
+    mockHash.mockReturnValueOnce(111111);
 
     await handleCSSFiles();
 
     expect(fs.readdirSync(path.join(BUILD_DIR, 'public')).toSorted()).toEqual(
-      ['style-111111.css', 'style-111111.css.br', 'style-111111.css.gz'].toSorted(),
+      [
+        'style-111111.css',
+        'style-111111.css.br',
+        'style-111111.css.gz',
+      ].toSorted(),
     );
   });
 
@@ -274,7 +290,9 @@ describe('utils/handle-css-files', () => {
 
 describe('getCSSLoader', () => {
   it('should return a plain text loader for CSS files when useExternalTranspiler is true', () => {
-    globalThis.mockConstants = { CONFIG: { integrations: [{ transpileCSS: true }] } } as any;
+    globalThis.mockConstants = {
+      CONFIG: { integrations: [{ transpileCSS: true }] },
+    } as any;
 
     const loader = getCSSLoader();
 
@@ -287,7 +305,9 @@ describe('getCSSLoader', () => {
   });
 
   it('should return a plain text loader for CSS files when useExternalTranspiler is false', () => {
-    globalThis.mockConstants = { CONFIG: { integrations: [{ transpileCSS: false }] } } as any;
+    globalThis.mockConstants = {
+      CONFIG: { integrations: [{ transpileCSS: false }] },
+    } as any;
 
     const loader = getCSSLoader();
 
@@ -301,4 +321,4 @@ describe('getCSSLoader', () => {
 
     expect(loader).toBeUndefined();
   });
-})
+});

--- a/packages/brisa/src/utils/handle-css-files/index.test.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.test.ts
@@ -138,11 +138,11 @@ describe('utils/handle-css-files', () => {
 
     fs.writeFileSync(path.join(BUILD_DIR, 'test.css'), 'body { color: red; }');
 
-    mockHash.mockReturnValueOnce(111111).mockReturnValue(222222);
+    mockHash.mockReturnValue(111111);
 
     await handleCSSFiles();
 
-    const baseCSSFilename = 'base-222222.css';
+    const baseCSSFilename = 'base-111111.css';
     const styleCSSFilename = 'style-111111.css';
 
     const cssFiles = (
@@ -165,7 +165,7 @@ describe('utils/handle-css-files', () => {
 
     fs.writeFileSync(path.join(BUILD_DIR, 'test.css'), '@tailwind base;');
 
-    mockHash.mockReturnValueOnce(111111);
+    mockHash.mockReturnValue(111111);
 
     await handleCSSFiles();
 
@@ -189,7 +189,7 @@ describe('utils/handle-css-files', () => {
     const CONFIG = { integrations: [brisaTailwindCSS()] };
     globalThis.mockConstants = { BUILD_DIR, SRC_DIR, CONFIG, LOG_PREFIX };
 
-    mockHash.mockReturnValueOnce(111111);
+    mockHash.mockReturnValue(111111);
 
     await handleCSSFiles();
 

--- a/packages/brisa/src/utils/handle-css-files/index.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.ts
@@ -10,19 +10,23 @@ const cssGlob = new Glob('**/*.css');
 
 export default async function handleCSSFiles() {
   try {
-    const { BUILD_DIR, CONFIG, LOG_PREFIX, IS_BUILD_PROCESS, IS_PRODUCTION } =
+    const { BUILD_DIR, CONFIG, LOG_PREFIX, IS_BUILD_PROCESS, IS_PRODUCTION, SRC_DIR } =
       getConstants();
     const publicFolder = path.join(BUILD_DIR, 'public');
 
     if (!fs.existsSync(publicFolder)) fs.mkdirSync(publicFolder);
 
-    const cssFilePaths: string[] = await moveCSSInsidePublic(BUILD_DIR);
+    const cssFilePaths: string[] = await handleCSSInsidePublic(BUILD_DIR, publicFolder);
     const integrations = (CONFIG?.integrations ?? []).filter(
       (integration) => integration.transpileCSS,
     );
 
     // Using CSS integrations
     if (integrations.length > 0) {
+      // Use the src CSS files to transpile it with the integration parser
+      //  (instead of Bun CSS Parser)
+      cssFilePaths.push(...(await handleCSSInsidePublic(SRC_DIR, publicFolder)));
+
       for (const integration of integrations) {
         const startTime = Date.now();
 
@@ -102,15 +106,15 @@ export default async function handleCSSFiles() {
   }
 }
 
-async function moveCSSInsidePublic(buildDir: string) {
+async function handleCSSInsidePublic(dir: string, outDir: string) {
   const files = [];
 
-  for await (const filename of cssGlob.scan(buildDir)) {
-    const filePath = path.join(buildDir, filename);
+  for await (const filename of cssGlob.scan(dir)) {
+    const filePath = path.join(dir, filename);
     const hash = Bun.hash(await Bun.file(filePath).arrayBuffer());
     const newFilename = `style-${hash}.css`
 
-    fs.renameSync(filePath, path.join(buildDir, 'public', newFilename));
+    fs.copyFileSync(filePath, path.join(outDir, newFilename));
     files.push(newFilename);
   }
 

--- a/packages/brisa/src/utils/handle-css-files/index.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.ts
@@ -22,8 +22,9 @@ export default async function handleCSSFiles() {
 
     if (!fs.existsSync(publicFolder)) fs.mkdirSync(publicFolder);
 
-    let cssFilePaths: Set<string> = new Set(
-      await handleCSSInsidePublic(BUILD_DIR, publicFolder),
+    const cssFilePaths: string[] = await handleCSSInsidePublic(
+      BUILD_DIR,
+      publicFolder,
     );
     const integrations = (CONFIG?.integrations ?? []).filter(
       (integration) => integration.transpileCSS,
@@ -33,9 +34,13 @@ export default async function handleCSSFiles() {
     if (integrations.length > 0) {
       // Use the "src" CSS files to transpile it with the integration parser
       // instead of the "build" because they are not transpiled by Bun CSS Parser
-      cssFilePaths = cssFilePaths.union(
-        new Set(await handleCSSInsidePublic(SRC_DIR, publicFolder)),
+      const cssFilePathsFromSrc = await handleCSSInsidePublic(
+        SRC_DIR,
+        publicFolder,
       );
+      for (const file of cssFilePathsFromSrc) {
+        if (!cssFilePaths.includes(file)) cssFilePaths.push(file);
+      }
 
       for (const integration of integrations) {
         const startTime = Date.now();
@@ -67,7 +72,7 @@ export default async function handleCSSFiles() {
             )) ?? '';
           const filename = `base-${Bun.hash(content)}.css`;
           fs.writeFileSync(path.join(publicFolder, filename), content);
-          cssFilePaths.add(filename);
+          cssFilePaths.unshift(filename);
         }
 
         if (IS_BUILD_PROCESS) {
@@ -109,7 +114,7 @@ export default async function handleCSSFiles() {
     // Write css-files.js
     fs.writeFileSync(
       path.join(BUILD_DIR, 'css-files.js'),
-      'export default ' + JSON.stringify(Array.from(cssFilePaths)),
+      'export default ' + JSON.stringify(cssFilePaths),
     );
   } catch (e: any) {
     logError({

--- a/packages/brisa/src/utils/handle-css-files/index.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type {Loader} from 'bun';
+import type { Loader } from 'bun';
 import fs from 'node:fs';
 import { getConstants } from '@/constants';
 import { logError } from '../log/log-build';
@@ -10,13 +10,21 @@ const cssGlob = new Glob('**/*.css');
 
 export default async function handleCSSFiles() {
   try {
-    const { BUILD_DIR, CONFIG, LOG_PREFIX, IS_BUILD_PROCESS, IS_PRODUCTION, SRC_DIR } =
-      getConstants();
+    const {
+      BUILD_DIR,
+      CONFIG,
+      LOG_PREFIX,
+      IS_BUILD_PROCESS,
+      IS_PRODUCTION,
+      SRC_DIR,
+    } = getConstants();
     const publicFolder = path.join(BUILD_DIR, 'public');
 
     if (!fs.existsSync(publicFolder)) fs.mkdirSync(publicFolder);
 
-    const cssFilePaths: string[] = await handleCSSInsidePublic(BUILD_DIR, publicFolder);
+    const cssFilePaths: Set<string> = new Set(
+      await handleCSSInsidePublic(BUILD_DIR, publicFolder),
+    );
     const integrations = (CONFIG?.integrations ?? []).filter(
       (integration) => integration.transpileCSS,
     );
@@ -25,7 +33,9 @@ export default async function handleCSSFiles() {
     if (integrations.length > 0) {
       // Use the src CSS files to transpile it with the integration parser
       //  (instead of Bun CSS Parser)
-      cssFilePaths.push(...(await handleCSSInsidePublic(SRC_DIR, publicFolder)));
+      cssFilePaths.union(
+        new Set(...(await handleCSSInsidePublic(SRC_DIR, publicFolder))),
+      );
 
       for (const integration of integrations) {
         const startTime = Date.now();
@@ -57,7 +67,7 @@ export default async function handleCSSFiles() {
             )) ?? '';
           const filename = `base-${Bun.hash(content)}.css`;
           fs.writeFileSync(path.join(publicFolder, filename), content);
-          cssFilePaths.unshift(filename);
+          cssFilePaths.add(filename);
         }
 
         if (IS_BUILD_PROCESS) {
@@ -78,7 +88,10 @@ export default async function handleCSSFiles() {
 
       for (const file of cssFilePaths) {
         const buffer = fs.readFileSync(path.join(publicFolder, file));
-        Bun.write(path.join(publicFolder, file + '.gz'), gzipSync(buffer as any) as any);
+        Bun.write(
+          path.join(publicFolder, file + '.gz'),
+          gzipSync(buffer as any) as any,
+        );
         Bun.write(
           path.join(publicFolder, file + '.br'),
           brotliCompressSync(buffer as any) as any,
@@ -96,7 +109,7 @@ export default async function handleCSSFiles() {
     // Write css-files.js
     fs.writeFileSync(
       path.join(BUILD_DIR, 'css-files.js'),
-      'export default ' + JSON.stringify(cssFilePaths),
+      'export default ' + JSON.stringify(Array.from(cssFilePaths)),
     );
   } catch (e: any) {
     logError({
@@ -112,7 +125,7 @@ async function handleCSSInsidePublic(dir: string, outDir: string) {
   for await (const filename of cssGlob.scan(dir)) {
     const filePath = path.join(dir, filename);
     const hash = Bun.hash(await Bun.file(filePath).arrayBuffer());
-    const newFilename = `style-${hash}.css`
+    const newFilename = `style-${hash}.css`;
 
     fs.copyFileSync(filePath, path.join(outDir, newFilename));
     files.push(newFilename);
@@ -122,20 +135,19 @@ async function handleCSSInsidePublic(dir: string, outDir: string) {
 }
 
 export function getCSSLoader(): { [x: string]: Loader } | undefined {
-  const { CONFIG } =
-  getConstants();
+  const { CONFIG } = getConstants();
   const useExternalTranspiler = (CONFIG?.integrations ?? []).some(
     (integration) => integration.transpileCSS,
   );
 
-  // Adding plain text loader for CSS files avoid the Bun CSS Parser for these files 
+  // Adding plain text loader for CSS files avoid the Bun CSS Parser for these files
   // already handled by the external transpiler (Tailwind, PandaCSS, etc)
-  if(useExternalTranspiler) {
+  if (useExternalTranspiler) {
     return {
       '.css': 'text',
       '.scss': 'text',
       '.sass': 'text',
       '.less': 'text',
-    }
+    };
   }
 }

--- a/packages/brisa/src/utils/handle-css-files/index.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import type {Loader} from 'bun';
 import fs from 'node:fs';
 import { getConstants } from '@/constants';
 import { logError } from '../log/log-build';
@@ -114,4 +115,23 @@ async function moveCSSInsidePublic(buildDir: string) {
   }
 
   return files;
+}
+
+export function getCSSLoader(): { [x: string]: Loader } | undefined {
+  const { CONFIG } =
+  getConstants();
+  const useExternalTranspiler = (CONFIG?.integrations ?? []).some(
+    (integration) => integration.transpileCSS,
+  );
+
+  // Adding plain text loader for CSS files avoid the Bun CSS Parser for these files 
+  // already handled by the external transpiler (Tailwind, PandaCSS, etc)
+  if(useExternalTranspiler) {
+    return {
+      '.css': 'text',
+      '.scss': 'text',
+      '.sass': 'text',
+      '.less': 'text',
+    }
+  }
 }

--- a/packages/brisa/src/utils/handle-css-files/index.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.ts
@@ -22,7 +22,7 @@ export default async function handleCSSFiles() {
 
     if (!fs.existsSync(publicFolder)) fs.mkdirSync(publicFolder);
 
-    const cssFilePaths: Set<string> = new Set(
+    let cssFilePaths: Set<string> = new Set(
       await handleCSSInsidePublic(BUILD_DIR, publicFolder),
     );
     const integrations = (CONFIG?.integrations ?? []).filter(
@@ -31,10 +31,10 @@ export default async function handleCSSFiles() {
 
     // Using CSS integrations
     if (integrations.length > 0) {
-      // Use the src CSS files to transpile it with the integration parser
-      //  (instead of Bun CSS Parser)
-      cssFilePaths.union(
-        new Set(...(await handleCSSInsidePublic(SRC_DIR, publicFolder))),
+      // Use the "src" CSS files to transpile it with the integration parser
+      // instead of the "build" because they are not transpiled by Bun CSS Parser
+      cssFilePaths = cssFilePaths.union(
+        new Set(await handleCSSInsidePublic(SRC_DIR, publicFolder)),
       );
 
       for (const integration of integrations) {

--- a/packages/brisa/src/utils/transpile-actions/index.ts
+++ b/packages/brisa/src/utils/transpile-actions/index.ts
@@ -8,6 +8,7 @@ import getActionsInfo from './get-actions-info';
 import { getPurgedBody } from './get-purged-body';
 import { log, logBuildError } from '@/utils/log/log-build';
 import { jsx, jsxDEV } from '../ast/constants';
+import { getCSSLoader } from '@/utils/handle-css-files';
 
 type CompileActionsParams = {
   actionsEntrypoints: string[];
@@ -620,6 +621,7 @@ export async function buildActions({
     minify: IS_PRODUCTION,
     splitting: true,
     define,
+    loader: getCSSLoader(),
   });
 
   if (!res.success) {


### PR DESCRIPTION
Related to https://github.com/brisa-build/brisa/issues/720

@AlbertSabate This avoids the re-parsing of CSS files, being only transpiled by the adapter (Tailwind or PandaCSS). Please, before merging this PR, you can use this branch with symlink to verify that it is working on your project well, your feedback will be very helpful.