### PR TITLE
fix: avoid parsing assets

### DIFF
--- a/packages/brisa/src/utils/client-build/get-client-build-details/index.test.ts
+++ b/packages/brisa/src/utils/client-build/get-client-build-details/index.test.ts
@@ -51,7 +51,7 @@ describe('client build -> get-client-build-details', () => {
 
     await writeTempFiles([page]);
 
-    const pages = [{ path: page.filePath }] as any;
+    const pages = [{ path: page.filePath, kind: 'entry-point' }] as any;
     const options = {
       allWebComponents: {},
       webComponentsPerEntrypoint: {},
@@ -101,7 +101,7 @@ describe('client build -> get-client-build-details', () => {
       'my-component': wcFile.filePath,
     };
 
-    const pages = [{ path: page.filePath }] as any;
+    const pages = [{ path: page.filePath, kind: 'entry-point' }] as any;
     const options: Options = {
       allWebComponents: webComponentsMap,
       webComponentsPerEntrypoint: {
@@ -158,7 +158,7 @@ describe('client build -> get-client-build-details', () => {
 
     await writeTempFiles([nonPageFile]);
 
-    const pages = [{ path: nonPageFile.filePath }] as any;
+    const pages = [{ path: nonPageFile.filePath, kind: 'entry-point' }] as any;
     const options = {
       allWebComponents: {},
       webComponentsPerEntrypoint: {},
@@ -206,8 +206,8 @@ describe('client build -> get-client-build-details', () => {
     };
 
     const pagesOutputs = [
-      { path: page1.filePath },
-      { path: page2.filePath },
+      { path: page1.filePath, kind: 'entry-point' },
+      { path: page2.filePath, kind: 'entry-point' },
     ] as any;
 
     const options = {
@@ -262,7 +262,7 @@ describe('client build -> get-client-build-details', () => {
     );
 
     await writeTempFiles([page]);
-    const pages = [{ path: page.filePath }] as any;
+    const pages = [{ path: page.filePath, kind: 'entry-point' }] as any;
 
     const options = {
       allWebComponents: {},

--- a/packages/brisa/src/utils/client-build/get-client-build-details/index.ts
+++ b/packages/brisa/src/utils/client-build/get-client-build-details/index.ts
@@ -11,7 +11,9 @@ export async function getClientBuildDetails(
 ) {
   return (
     await Promise.all(
-      pages.map((p) => getClientEntrypointBuildDetails(p, options)),
+      pages
+        .filter((p) => p.kind === 'entry-point')
+        .map((p) => getClientEntrypointBuildDetails(p, options)),
     )
   ).filter(Boolean) as EntryPointData[];
 }

--- a/packages/brisa/src/utils/client-build/pages-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/pages-build/index.test.ts
@@ -18,7 +18,11 @@ const pageWebComponents = {
 };
 
 const toArtifact = (path: string) =>
-  ({ path, text: () => Bun.file(path).text() }) as BuildArtifact;
+  ({
+    path,
+    text: () => Bun.file(path).text(),
+    kind: 'entry-point',
+  }) as BuildArtifact;
 
 describe('client-build', () => {
   beforeEach(async () => {


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/735

We only want to parse `entry-points`. With Bun 1.2 we also receive assets (`.css`...), and is not necessary to analyse and parse them