### PR TITLE
fix: avoid CF Rocket Loader in Brisa scripts to always execute during SPA

### DIFF
--- a/packages/brisa/src/cli/serve/serve-options.test.tsx
+++ b/packages/brisa/src/cli/serve/serve-options.test.tsx
@@ -195,7 +195,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       '<h1>Some internal error <web-component></web-component></h1>',
     );
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/_500.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_500.tsx"></script>`,
     );
   });
 
@@ -294,7 +294,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
@@ -312,7 +312,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
@@ -351,7 +351,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
@@ -376,7 +376,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
@@ -394,7 +394,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
@@ -414,7 +414,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       '<h1>Page not found 404 <web-component></web-component></h1>',
     );
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
@@ -429,7 +429,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(response.status).toBe(200);
     expect(html).toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
     );
     expect(html).toContain('<web-component></web-component>');
   });
@@ -445,7 +445,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(response.status).toBe(200);
     expect(html).toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
     );
     expect(html).toContain('<web-component></web-component>');
   });
@@ -468,7 +468,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(response.status).toBe(200);
     expect(html).toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
     );
     expect(html).toContain('<web-component></web-component>');
   });
@@ -991,7 +991,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
@@ -1010,7 +1010,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
-      `<script async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
+      `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 

--- a/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.test.tsx
@@ -738,10 +738,10 @@ describe('utils', () => {
       const stream = renderToReadableStream(element, { request });
       const result = await Bun.readableStreamToText(stream);
       expect(result).not.toContain(
-        `<script src="/_brisa/pages/_rpc-${constants.VERSION}.js"></script>`,
+        `<script data-cfasync="false" src="/_brisa/pages/_rpc-${constants.VERSION}.js"></script>`,
       );
       expect(result).toContain(
-        `<script src="/_brisa/pages/_unsuspense-${constants.VERSION}.js"></script>`,
+        `<script data-cfasync="false" src="/_brisa/pages/_unsuspense-${constants.VERSION}.js"></script>`,
       );
     });
 
@@ -771,10 +771,10 @@ describe('utils', () => {
       const stream = renderToReadableStream(element, { request });
       const result = await Bun.readableStreamToText(stream);
       expect(result).not.toContain(
-        `<script src="/test/_brisa/pages/_rpc-${constants.VERSION}.js"></script>`,
+        `<script data-cfasync="false" src="/test/_brisa/pages/_rpc-${constants.VERSION}.js"></script>`,
       );
       expect(result).toContain(
-        `<script src="/test/_brisa/pages/_unsuspense-${constants.VERSION}.js"></script>`,
+        `<script data-cfasync="false" src="/test/_brisa/pages/_unsuspense-${constants.VERSION}.js"></script>`,
       );
     });
 
@@ -801,10 +801,10 @@ describe('utils', () => {
       const stream = renderToReadableStream(element, { request });
       const result = await Bun.readableStreamToText(stream);
       expect(result).not.toContain(
-        `<script src="/_brisa/pages/_unsuspense-${constants.VERSION}.js"></script>`,
+        `<script data-cfasync="false" src="/_brisa/pages/_unsuspense-${constants.VERSION}.js"></script>`,
       );
       expect(result).toContain(
-        `<script src="/_brisa/pages/_rpc-${constants.VERSION}.js" async></script>`,
+        `<script data-cfasync="false" src="/_brisa/pages/_rpc-${constants.VERSION}.js" async></script>`,
       );
     });
 
@@ -834,10 +834,10 @@ describe('utils', () => {
       const stream = renderToReadableStream(element, { request });
       const result = await Bun.readableStreamToText(stream);
       expect(result).not.toContain(
-        `<script src="/test/_brisa/pages/_unsuspense-${constants.VERSION}.js"></script>`,
+        `<script data-cfasync="false" src="/test/_brisa/pages/_unsuspense-${constants.VERSION}.js"></script>`,
       );
       expect(result).toContain(
-        `<script src="/test/_brisa/pages/_rpc-${constants.VERSION}.js" async></script>`,
+        `<script data-cfasync="false" src="/test/_brisa/pages/_rpc-${constants.VERSION}.js" async></script>`,
       );
     });
 
@@ -891,9 +891,9 @@ describe('utils', () => {
           <html lang="en" dir="ltr">
             <head></head>
             <body>
-              <script src="/_brisa/pages/page-with-web-component-hash-en.js"></script>
+              <script data-cfasync="false" src="/_brisa/pages/page-with-web-component-hash-en.js"></script>
               <script>window.r={"name":"/page-with-web-component","pathname":"/page-with-web-component","query":{},"params":{}}</script>
-              <script async fetchpriority="high" src="/_brisa/pages/page-with-web-component-hash.js"></script>
+              <script data-cfasync="false" async fetchpriority="high" src="/_brisa/pages/page-with-web-component-hash.js"></script>
             </body>
           </html>
       `),
@@ -953,9 +953,9 @@ describe('utils', () => {
           <html lang="en" dir="ltr">
             <head basepath="/test"></head>
             <body>
-              <script src="/test/_brisa/pages/page-with-web-component-hash-en.js"></script>
+              <script data-cfasync="false" src="/test/_brisa/pages/page-with-web-component-hash-en.js"></script>
               <script>window.r={"name":"/page-with-web-component","pathname":"/page-with-web-component","query":{},"params":{}}</script>
-              <script async fetchpriority="high" src="/test/_brisa/pages/page-with-web-component-hash.js"></script>
+              <script data-cfasync="false" async fetchpriority="high" src="/test/_brisa/pages/page-with-web-component-hash.js"></script>
             </body>
           </html>
       `),
@@ -1020,7 +1020,7 @@ describe('utils', () => {
             <body>
               <script>window.i18nMessages={...window.i18nMessages,...({"clientOne":"foo"})}</script>
               <script>window.r={"name":"/page-with-web-component","pathname":"/page-with-web-component","query":{},"params":{}}</script>
-              <script async fetchpriority="high" src="/_brisa/pages/page-with-web-component-hash.js"></script>
+              <script data-cfasync="false" async fetchpriority="high" src="/_brisa/pages/page-with-web-component-hash.js"></script>
             </body>
           </html>
       `),
@@ -1088,7 +1088,7 @@ describe('utils', () => {
             <body>
               <script>window.i18nMessages={...window.i18nMessages,...({"clientOne":"foo"})}</script>
               <script>window.r={"name":"/page-with-web-component","pathname":"/page-with-web-component","query":{},"params":{}}</script>
-              <script async fetchpriority="high" src="/test/_brisa/pages/page-with-web-component-hash.js"></script>
+              <script data-cfasync="false" async fetchpriority="high" src="/test/_brisa/pages/page-with-web-component-hash.js"></script>
             </body>
           </html>
       `),
@@ -3860,7 +3860,7 @@ describe('utils', () => {
             <head></head>
             <body>
               <script>window.r={"name":"/page-with-web-component","pathname":"/page-with-web-component","query":{},"params":{}}</script>
-              <script async fetchpriority="high" src="/_brisa/pages/page-with-web-component-hash.js"></script>
+              <script data-cfasync="false" async fetchpriority="high" src="/_brisa/pages/page-with-web-component-hash.js"></script>
             </body>
           </html>
       `),

--- a/packages/brisa/src/utils/render-to-readable-stream/index.ts
+++ b/packages/brisa/src/utils/render-to-readable-stream/index.ts
@@ -388,13 +388,13 @@ async function enqueueDuringRendering(
       // Script to unsuspense all suspense components
       if (controller.hasUnsuspense) {
         controller.enqueue(
-          `<script src="${compiledPagesPath}/_unsuspense-${VERSION}.js"></script>`,
+          `<script data-cfasync="false" src="${compiledPagesPath}/_unsuspense-${VERSION}.js"></script>`,
           suspenseId,
         );
       }
       if (controller.hasActionRPC) {
         controller.enqueue(
-          `<script src="${compiledPagesPath}/_rpc-${VERSION}.js" async></script>`,
+          `<script data-cfasync="false" src="${compiledPagesPath}/_rpc-${VERSION}.js" async></script>`,
           suspenseId,
         );
       }
@@ -450,7 +450,7 @@ async function enqueueDuringRendering(
           );
 
           if (fs.existsSync(pathPageI18n)) {
-            let script = `<script src="${compiledPagesPath}/${filenameI18n}"></script>`;
+            let script = `<script data-cfasync="false" src="${compiledPagesPath}/${filenameI18n}"></script>`;
 
             // Script to override client translations caused by "overrideMessages" function
             if (request.store.has('_messages')) {
@@ -475,7 +475,7 @@ async function enqueueDuringRendering(
         controller.areSignalsInjected = true;
         controller.enqueue(`<script>window.r=${route}</script>`, suspenseId);
         controller.enqueue(
-          `<script async fetchpriority="high" src="${compiledPagesPath}/${filename}"></script>`,
+          `<script data-cfasync="false" async fetchpriority="high" src="${compiledPagesPath}/${filename}"></script>`,
           suspenseId,
         );
       }


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/739 ? @AlbertSabate  the best way to confirm that this solves the issue is if you try the next canary