### PR TITLE
feat(signals): add `peek()` + docs of `store.Map`

### DIFF
--- a/docs/building-your-application/components-details/reactivity.md
+++ b/docs/building-your-application/components-details/reactivity.md
@@ -232,3 +232,56 @@ But thanks to `store.transferToClient` method, you extend the lifecycle of some 
 - etc ...
 
 And modifying the value on server actions, is reflected in a reactive way on the client side signals.
+
+## Can I use a `state` / `store` value inside an effect without subscribing?
+
+Yes, you can use a `state` / `stor`e value inside an effect without subscribing. 
+
+For the `state`, you have the [`.peek()`](/building-your-application/components-details/web-components#peek) method to get the current value without subscribing:
+
+```tsx
+export default function Counter({}, { state, effect }: WebContext) {
+  const count = state<number>(0);
+  const addition = state<number>(1);
+
+  effect(() => {
+    count.value = count.peek() + addition.peek();
+  });
+
+  return (
+    <>
+      <button onClick={() => addition.value++}>+</button>
+      <span> Counter: {count.value} </span>
+      <button onClick={() => addition.value--}>-</button>
+    </>
+  );
+}
+```
+
+In this example, the `count` signal is updated by the `addition` signal without subscribing to `count`.
+
+For the `store`, you can use the [`.Map.get`](/building-your-application/components-details/web-components#example-with-no-reactive-store) method to get the current value without subscribing:
+
+```tsx
+export default function Counter({}, { store, effect }: WebContext) {
+  store.set('count', 0);
+  store.set('addition', 1);
+
+  effect(() => {
+    store.set('count', store.Map.get('count') + store.get('addition'));
+  });
+
+  const increment = () => store.set('addition', store.get('addition') + 1);
+  const decrement = () => store.set('addition', store.get('addition') - 1);
+
+  return (
+    <>
+      <button onClick={increment)}>+</button>
+      <span> Counter: {count.value} </span>
+      <button onClick={decrement}>-</button>
+    </>
+  );
+}
+```
+
+In this example, the `count` store field is updated by the `addition` store field without subscribing to `count`. The `store.Map` is used to have the real `Map` object without the reactivity.

--- a/docs/building-your-application/components-details/reactivity.md
+++ b/docs/building-your-application/components-details/reactivity.md
@@ -245,7 +245,7 @@ export default function Counter({}, { state, effect }: WebContext) {
   const addition = state<number>(1);
 
   effect(() => {
-    count.value = count.peek() + addition.peek();
+    count.value = count.peek() + addition.value;
   });
 
   return (

--- a/docs/building-your-application/components-details/web-components.md
+++ b/docs/building-your-application/components-details/web-components.md
@@ -470,6 +470,21 @@ export default function Counter({}, { state }: WebContext) {
 
 Whenever a state mutate (change the `.value`) reactively updates these parts of the DOM where the signal has been set.
 
+### Peek
+
+If you want to get the value of a signal without subscribing to an effect, you can use the `peek` method:
+
+```tsx
+const count = state<number>(0);
+const addition = state<number>(1);
+
+effect(() => {
+  count.value = count.peek() + addition.peek();
+});
+```
+
+In this example, the `count` state will be updated only when the `addition` state changes.
+
 ## Store (`store` method)
 
 The difference between state and `store` is that store is a **shared** state among all web-components. The store is a reactive `Map`, where the methods `get`, `has`, `set` and `delete` are reactive.
@@ -501,6 +516,20 @@ export default function SharedStore({}, { store }: WebContext) {
   );
 }
 ```
+
+### Example with no-reactive store:
+
+```tsx
+effect(() => {
+  store.set('counter', store.Map.get('counter') + store.get('addition'));
+})
+```
+
+In this example, the `effect` is used to update the store when the `addition` store entry changes. This is because the store with the `.Map` is not reactive, is a simple `Map` object.
+
+> [!NOTE]
+>
+> It's very similar than the [`.peek()`](#peek) used in the state, but in this case, the store is a `Map` object.
 
 ### Example with `derived` and `store`:
 

--- a/packages/brisa/src/types/index.d.ts
+++ b/packages/brisa/src/types/index.d.ts
@@ -483,6 +483,12 @@ export interface BaseWebContext {
    * count.value += 1;
    * ```
    *
+   * Example mutation without subscription (only setter):
+   *
+   * ```ts
+   * count.value = count.peek() + 1;
+   * ```
+   *
    * Docs:
    *  - [How to use `state`](https://brisa.build/building-your-application/components-details/web-components#state-state-method)
    */
@@ -1491,7 +1497,38 @@ export type BrisaContext<T> = {
   id: string;
 };
 
-export type Signal<T> = { value: T };
+export type Signal<T> = {
+  /**
+   * Description:
+   *
+   * The `value` property is used to get and set the value of the signal.
+   *
+   * The getter do a subscription to the effect, so when the value
+   * changes, the DOM will be updated reactively.
+   *
+   * - [How to use `value`](https://brisa.build/building-your-application/components-details/web-components#state)
+   */
+  value: T;
+  /**
+   * Description:
+   *
+   * The `peek` method is used to get the value of the signal without
+   * subscribing to the effect.
+   *
+   * Example:
+   *
+   * ```ts
+   * effect(() => {
+   *   count.value = count.peek() + 1;
+   * });
+   * ```
+   *
+   * Docs:
+   *
+   * - [How to use `peek`](https://brisa.build/building-your-application/components-details/web-components#peek)
+   */
+  peek(): T;
+};
 
 export type IndicatorSignal = {
   id: string;

--- a/packages/brisa/src/utils/signals/index.test.ts
+++ b/packages/brisa/src/utils/signals/index.test.ts
@@ -692,4 +692,29 @@ describe('signals', () => {
     expect(window._s.get('foo')).toBe('BAR!');
     expect(window._s.get('bar')).toBe('FOO!');
   });
+
+  it('should count.peek() return the value without subscription to the effect', () => {
+    const { state, effect, reset } = signals();
+    const count = state<number>(0);
+    const addition = state<number>(1);
+    const mockEffect = mock<(count?: number) => void>(() => {});
+
+    effect(() => {
+      count.value = count.peek() + addition.value;
+      mockEffect(count.peek());
+    });
+
+    expect(mockEffect).toHaveBeenCalledTimes(1);
+    expect(mockEffect.mock.calls[0][0]).toBe(1);
+
+    count.value = 1;
+
+    expect(mockEffect).toHaveBeenCalledTimes(1);
+
+    addition.value = 2;
+
+    expect(mockEffect).toHaveBeenCalledTimes(2);
+    expect(mockEffect.mock.calls[1][0]).toBe(3);
+    reset();
+  });
 });

--- a/packages/brisa/src/utils/signals/index.ts
+++ b/packages/brisa/src/utils/signals/index.ts
@@ -101,8 +101,11 @@ export default function signals() {
     subEffectsPerEffect.delete(fn);
   }
 
-  function state<T>(currentValue?: T): { value: T } {
+  function state<T>(currentValue?: T): { value: T; peek(): T } {
     return {
+      peek() {
+        return currentValue!;
+      },
       get value() {
         if (stack[0]) {
           effects.set(this, getSet<Effect>(effects, this).add(stack[0]));


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/748

## Can I use a `state` / `store` value inside an effect without subscribing?

Yes, you can use a `state` / `stor`e value inside an effect without subscribing. 

For the `state`, you have the [`.peek()`](/building-your-application/components-details/web-components#peek) method to get the current value without subscribing:

```tsx
export default function Counter({}, { state, effect }: WebContext) {
  const count = state<number>(0);
  const addition = state<number>(1);

  effect(() => {
    count.value = count.peek() + addition.value;
  });

  return (
    <>
      <button onClick={() => addition.value++}>+</button>
      <span> Counter: {count.value} </span>
      <button onClick={() => addition.value--}>-</button>
    </>
  );
}
```

In this example, the `count` signal is updated by the `addition` signal without subscribing to `count`.

For the `store`, you can use the [`.Map.get`](/building-your-application/components-details/web-components#example-with-no-reactive-store) method to get the current value without subscribing:

```tsx
export default function Counter({}, { store, effect }: WebContext) {
  store.set('count', 0);
  store.set('addition', 1);

  effect(() => {
    store.set('count', store.Map.get('count') + store.get('addition'));
  });

  const increment = () => store.set('addition', store.get('addition') + 1);
  const decrement = () => store.set('addition', store.get('addition') - 1);

  return (
    <>
      <button onClick={increment)}>+</button>
      <span> Counter: {count.value} </span>
      <button onClick={decrement}>-</button>
    </>
  );
}
```

In this example, the `count` store field is updated by the `addition` store field without subscribing to `count`. The `store.Map` is used to have the real `Map` object without the reactivity.
