### PR TITLE
docs(reactivity): improve reactivity docs + types docs

### DIFF
--- a/docs/api-reference/components/web-context.md
+++ b/docs/api-reference/components/web-context.md
@@ -69,6 +69,16 @@ For more details, refer to the [store](/building-your-application/components-det
 
 ### `setOptimistic`
 
+Optimistic updates are a strategy used in client-server architectures to enhance the user experience by locally updating the user interface (UI) optimistically before receiving confirmation from the server about the success of an operation. This approach aims to reduce perceived latency and provide a more responsive application.
+
+```ts
+store.setOptimistic("some-server-action-name", "count", (value) => value + 1);
+```
+
+> [!NOTE]
+>
+> See the [optimistic updates](/building-your-application/data-management/server-actions#optimistic-updates) documentation for more details.
+
 ## `useContext`
 
 `useContext: <T>(context: BrisaContext<T>) => { value: T }`

--- a/packages/brisa/src/types/index.d.ts
+++ b/packages/brisa/src/types/index.d.ts
@@ -845,15 +845,84 @@ type SitemapItem = {
 export type Sitemap = SitemapItem[] | Promise<SitemapItem[]>;
 
 export type ReactiveMap = {
+  /**
+   * Description:
+   *
+   * The `get` method is used to get a reactive value from the store.
+   * This means that when the value changes, the effect that uses it
+   * will be re-executed. In the case to be used inside the JSX, it
+   * will update only the part of the DOM where it is used.
+   *
+   * Docs:
+   * https://brisa.build/api-reference/components/web-context#store
+   */
   get: <T>(key: string) => T;
+  /**
+   * Description:
+   *
+   * The `set` method is used to set a reactive value in the store.
+   * This means that when the value changes, the effect that uses it
+   * will be re-executed. In the case to be used inside the JSX, it
+   * will update only the part of the DOM where it is used.
+   *
+   * Docs:
+   * https://brisa.build/api-reference/components/web-context#store
+   */
   set: <T>(key: string, value: T) => void;
+  /**
+   * Description:
+   *
+   * The `delete` method is used to delete a reactive value from the store.
+   * This means that when the value changes, the effect that uses it
+   * will be re-executed. In the case to be used inside the JSX, it
+   * will update only the part of the DOM where it is used.
+   *
+   * Docs:
+   * https://brisa.build/building-your-application/components-details/web-components#store-store-method
+   */
   delete: (key: string) => void;
+  /**
+   * Description:
+   *
+   * The `has` method is used to check if a reactive value exists in the store.
+   *
+   * Docs:
+   * https://brisa.build/building-your-application/components-details/web-components#store-store-method
+   */
   has: (key: string) => boolean;
+  /**
+   * Description:
+   *
+   * The `setOptimistic` method is used to set a reactive value in the store with the optimistic
+   * approach after an action. If the action fails, the value will be rolled back.
+   *
+   * Docs:
+   * https://brisa.build/building-your-application/data-management/server-actions#optimistic-updates
+   */
   setOptimistic: <T>(
     actionName: string,
     storeKey: string,
     updater: (value: T) => T,
   ) => void;
+  /**
+   * Description:
+   *
+   * The `Map` method is used to get the store as a Map object (without reactivity).
+   *
+   * As a Map, you can use `get`, `set`, `delete`, `has`, etc. Without reactivity. Useful
+   * to use values without an effect subscription:
+   *
+   * ```ts
+   * effect(() => {
+   *  store.set('count', store.Map.get('count') + store.get('addition'));
+   * })
+   * ```
+   *
+   * In this case, the effect will be re-executed when the `addition` value changes, but not the `count`.
+   *
+   * Docs:
+   * https://brisa.build/building-your-application/components-details/web-components#example-with-no-reactive-store
+   */
   Map: Map<string, unknown>;
 };
 


### PR DESCRIPTION
Following the idea of the code being documented, the methods and attributes of the reactive `store` were missing.

The `store.setOptimistic` documentation was also missing.

<img width="767" alt="Screenshot 2025-02-09 at 22 36 02" src="https://github.com/user-attachments/assets/e5d1c07c-14cb-475f-a32e-e95f4a23d440" />

<img width="1115" alt="Screenshot 2025-02-09 at 22 35 46" src="https://github.com/user-attachments/assets/52499d69-10a8-4889-9d7c-bd07543efae0" />
