### PR TITLE
fix(build): avoid "undefined" as identifier transpiling actions

### DIFF
--- a/packages/brisa/src/utils/ast/get-var-declaration-identifiers/index.ts
+++ b/packages/brisa/src/utils/ast/get-var-declaration-identifiers/index.ts
@@ -11,7 +11,11 @@ export default function getVarDeclarationIdentifiers(node: ESTree.Node) {
     const deps = new Set<string>();
 
     JSON.stringify(node, function (k, v) {
-      if (v?.type === 'Identifier' && this?.property !== v) {
+      if (
+        v?.type === 'Identifier' &&
+        this?.property !== v &&
+        v.name !== 'undefined'
+      ) {
         deps.add(v.name);
         if (identifiers.has(v.name)) {
           for (const dep of identifiers.get(v.name)!) {

--- a/packages/brisa/src/utils/transpile-actions/get-purged-body/index.test.ts
+++ b/packages/brisa/src/utils/transpile-actions/get-purged-body/index.test.ts
@@ -476,6 +476,33 @@ describe('utils', () => {
       expectCodeToPurge(codeToPurge).toBe(expectedCode);
     });
 
+    it('should not co-relate "undefined" as identifier #712', () => {
+      const codeToPurge = `
+        function SomeComponent() {
+          let foo = 0 || undefined;
+          const bar = 'hello world';
+
+          function onAction() {
+            const baz = bar || undefined;
+            console.log(baz);
+          }
+
+          return <div onClick={onAction} data-action-onClick="a1_1"> Click me </div>;
+        }`;
+
+      const expectedCode = `
+        function SomeComponent() {
+          const bar = 'hello world';
+
+          function onAction() {
+            const baz = bar || undefined;
+            console.log(baz);
+          }
+        }`;
+
+      expectCodeToPurge(codeToPurge).toBe(expectedCode);
+    });
+
     it('should not purge a used variable after a condition of another used variable #712', () => {
       const codeToPurge = `
         function SomeComponent() {

--- a/packages/brisa/src/utils/transpile-actions/get-purged-body/index.test.ts
+++ b/packages/brisa/src/utils/transpile-actions/get-purged-body/index.test.ts
@@ -503,6 +503,33 @@ describe('utils', () => {
       expectCodeToPurge(codeToPurge).toBe(expectedCode);
     });
 
+    it('should not co-relate "null" as identifier #712', () => {
+      const codeToPurge = `
+        function SomeComponent() {
+          let foo = 0 || null;
+          const bar = 'hello world';
+
+          function onAction() {
+            const baz = bar || null;
+            console.log(baz);
+          }
+
+          return <div onClick={onAction} data-action-onClick="a1_1"> Click me </div>;
+        }`;
+
+      const expectedCode = `
+        function SomeComponent() {
+          const bar = 'hello world';
+
+          function onAction() {
+            const baz = bar || null;
+            console.log(baz);
+          }
+        }`;
+
+      expectCodeToPurge(codeToPurge).toBe(expectedCode);
+    });
+
     it('should not purge a used variable after a condition of another used variable #712', () => {
       const codeToPurge = `
         function SomeComponent() {

--- a/packages/brisa/src/utils/transpile-actions/index.test.ts
+++ b/packages/brisa/src/utils/transpile-actions/index.test.ts
@@ -3195,6 +3195,69 @@ describe('utils', () => {
       expect(output).toBe(expected);
     });
 
+    it('should undefined identifiers not be detected as variables inside a condition #712', () => {
+      const code = `
+        export default async function SomeComponent() {
+          async function onAction() {
+            const json = await foo() || undefined;
+            if (json.success) {}
+          }
+
+          const sessionResponse = await fetchClient().api.v1.enquiry.$get();
+          const sessionJson = await sessionResponse.json();
+          const enquiryForm = sessionJson.success ? sessionJson.data : undefined;
+
+          return <div data-foo={enquiryForm} onClick={onAction}> Click me </div>;
+        }`;
+
+      const output = buildActions(code);
+
+      const expected = normalizeHTML(`
+        import {resolveAction as __resolveAction} from 'brisa/server';
+
+        async function SomeComponent() {
+          async function onAction() {
+            const json = await foo() || undefined;
+            if (json.success) {}
+          }
+
+          const sessionResponse = await fetchClient().api.v1.enquiry.$get();
+          const sessionJson = await sessionResponse.json();
+          const enquiryForm = sessionJson.success ? sessionJson.data : undefined;
+
+          return jsxDEV("div", {
+            "data-foo": enquiryForm,
+            onClick: (...args) => onAction(...args),
+            children: " Click me ",
+            "data-action-onclick": "a1_1",
+            "data-action": true
+          }, undefined, false, undefined, this);
+        }
+
+        SomeComponent._hasActions = true;
+
+        export async function a1_1({}, req) {
+          try {
+            const __action = (...args) => req._p(onAction(...args));
+            async function onAction() {
+              const json = await foo() || undefined;
+              if (json.success) {}
+            }
+            await __action(...req.store.get('__params:a1_1'));
+            await req._waitActionCallPromises("a1_1");
+          } catch (error) {
+            return __resolveAction({
+              req,
+              error,
+              actionId: "a1_1",
+              component: __props => jsxDEV(SomeComponent, {...__props}, undefined, false, undefined, this)
+            });
+          }
+        }`);
+
+      expect(output).toBe(expected);
+    });
+
     it.todo(
       'should work mixing elements with element generators and components',
       () => {

--- a/packages/brisa/src/utils/transpile-actions/index.test.ts
+++ b/packages/brisa/src/utils/transpile-actions/index.test.ts
@@ -3195,7 +3195,7 @@ describe('utils', () => {
       expect(output).toBe(expected);
     });
 
-    it('should undefined identifiers not be detected as variables inside a condition #712', () => {
+    it('should "undefined" identifiers not be detected as variables inside a condition #712', () => {
       const code = `
         export default async function SomeComponent() {
           async function onAction() {
@@ -3241,6 +3241,69 @@ describe('utils', () => {
             const __action = (...args) => req._p(onAction(...args));
             async function onAction() {
               const json = await foo() || undefined;
+              if (json.success) {}
+            }
+            await __action(...req.store.get('__params:a1_1'));
+            await req._waitActionCallPromises("a1_1");
+          } catch (error) {
+            return __resolveAction({
+              req,
+              error,
+              actionId: "a1_1",
+              component: __props => jsxDEV(SomeComponent, {...__props}, undefined, false, undefined, this)
+            });
+          }
+        }`);
+
+      expect(output).toBe(expected);
+    });
+
+    it('should "null" identifiers not be detected as variables inside a condition #712', () => {
+      const code = `
+        export default async function SomeComponent() {
+          async function onAction() {
+            const json = await foo() || null;
+            if (json.success) {}
+          }
+
+          const sessionResponse = await fetchClient().api.v1.enquiry.$get();
+          const sessionJson = await sessionResponse.json();
+          const enquiryForm = sessionJson.success ? sessionJson.data : null;
+
+          return <div data-foo={enquiryForm} onClick={onAction}> Click me </div>;
+        }`;
+
+      const output = buildActions(code);
+
+      const expected = normalizeHTML(`
+        import {resolveAction as __resolveAction} from 'brisa/server';
+
+        async function SomeComponent() {
+          async function onAction() {
+            const json = await foo() || null;
+            if (json.success) {}
+          }
+
+          const sessionResponse = await fetchClient().api.v1.enquiry.$get();
+          const sessionJson = await sessionResponse.json();
+          const enquiryForm = sessionJson.success ? sessionJson.data : null;
+
+          return jsxDEV("div", {
+            "data-foo": enquiryForm,
+            onClick: (...args) => onAction(...args),
+            children: " Click me ",
+            "data-action-onclick": "a1_1",
+            "data-action": true
+          }, undefined, false, undefined, this);
+        }
+
+        SomeComponent._hasActions = true;
+
+        export async function a1_1({}, req) {
+          try {
+            const __action = (...args) => req._p(onAction(...args));
+            async function onAction() {
+              const json = await foo() || null;
               if (json.success) {}
             }
             await __action(...req.store.get('__params:a1_1'));


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/712

We eliminated the identifiers that were not first level, correcting part of the issue https://github.com/brisa-build/brisa/issues/712, but it was not completely fixed, since “undefined” is also considered an identifier, and we do not want to correlate it, because it will make incorrect correlations during the transpilation process. Fixing this fixes the issue. Tested also with null, but with null no fix is needed, because null is not an identifier, it is a Literal. Very curious how AST works 😊

![ast](https://github.com/user-attachments/assets/22245ece-78ff-4324-86ce-7f8e63e1a28e)
