### PR TITLE
feat: add `useId`  to RequestContext too

### DIFF
--- a/docs/api-reference/components/request-context.md
+++ b/docs/api-reference/components/request-context.md
@@ -14,6 +14,9 @@ export default function ServerComponent(props, requestContext: RequestContext) {
     // Useful to control pending state in server components
     indicate,
 
+    // Useful to use a unique ID for each invocation
+    useId,
+
     // Data of the current route
     route,
 
@@ -130,7 +133,8 @@ For more details, refer to the [context](/building-your-application/components-d
 The `indicate` method is used to add it in the `indicator` HTML extended attribute. This `indicator` automatically set the `brisa-request` class while the indicated server action is pending.
 
 ```tsx
-const pending = indicate('some-server-action-name');
+const id = useId();
+const pending = indicate(`some-server-action-${id}`);
 // ...
 css`
  span { display: none }
@@ -144,6 +148,33 @@ css`
   <span indicator={pending}>Pending...</span>
 </>
 ```
+
+## `useId`
+
+`useId(): string`
+
+The `useId` method generates a unique identifier for the server component. It is useful for creating unique keys for elements in lists or for other purposes that require unique identifiers, like Server Action IDs to use insie the [`indicate`](#indicate). The generated ID is unique across all server components and after re-renders on the server actions.
+
+Example:
+
+```tsx
+const passwordHintId = useId();
+
+return (
+  <>
+    <input type="password" aria-describedby={passwordHintId} />
+    <p id={passwordHintId}>
+  </>
+)
+```
+
+> [!NOTE]
+>
+> To ensure better performance than `crypto.randomUUID()`, it is an autoincrement number next to the request id.
+
+> [!TIP]
+>
+> See [`useId` on Web Components](/api-reference/components/web-context#useId) too. To ensure the same id value after hydration.
 
 ### Parameters:
 

--- a/docs/api-reference/components/web-context.md
+++ b/docs/api-reference/components/web-context.md
@@ -276,6 +276,10 @@ return (
 )
 ```
 
+> [!TIP]
+>
+> See [`useId` on Server Components](/api-reference/components/request-context#useId) too.
+
 ## `css`
 
 `css(strings: TemplateStringsArray, ...values: string[]): void`

--- a/packages/brisa/src/types/index.d.ts
+++ b/packages/brisa/src/types/index.d.ts
@@ -197,6 +197,33 @@ export interface RequestContext extends Request {
   /**
    * Description:
    *
+   * The `useId` method will generate a unique identifier for each invocation.
+   *
+   * A common use case for consistent IDs are forms, where <label>-elements use the for attribute
+   * to associate them with a specific <input>-element. The useId hook isn't tied to just forms
+   * though and can be used whenever you need a unique ID, for example Server Action ID to use inside
+   * the [`indicate`](https://brisa.build/api-reference/components/request-context#indicate) method.
+   *
+   * ```js
+   * const passwordHintId = useId();
+   *
+   * return (
+   *   <>
+   *    <input type="password" aria-describedby={passwordHintId} />
+   *    <p id={passwordHintId}>
+   *   </>
+   * )
+   * ```
+   *
+   * Docs:
+   *
+   * - [How to use `useId`](https://brisa.build/api-reference/components/request-context#useId)
+   */
+  useId(): string;
+
+  /**
+   * Description:
+   *
    * The route is the matched route of the request.
    *
    * You can access to:
@@ -602,6 +629,21 @@ export interface BaseWebContext {
    * A common use case for consistent IDs are forms, where <label>-elements use the for attribute
    * to associate them with a specific <input>-element. The useId hook isn't tied to just forms
    * though and can be used whenever you need a unique ID.
+   *
+   * ```js
+   * const passwordHintId = useId();
+   *
+   * return (
+   *   <>
+   *    <input type="password" aria-describedby={passwordHintId} />
+   *    <p id={passwordHintId}>
+   *   </>
+   * )
+   * ```
+   *
+   * Docs:
+   *
+   * - [How to use `useId`](https://brisa.build/building-your-application/components-details/web-components#useId)
    */
   useId(): string;
 

--- a/packages/brisa/src/utils/extend-request-context/index.test.ts
+++ b/packages/brisa/src/utils/extend-request-context/index.test.ts
@@ -81,6 +81,26 @@ describe('brisa core', () => {
       expect((requestContext as any).webStore.get('foo')).toBe('baz');
     });
 
+    it('should useId increment the request.id by 1 each time', () => {
+      const request = new Request('https://example.com?foo=bar');
+      const webStore = new Map() as RequestContext['store'];
+      const route = { path: '/' } as any;
+      const id = crypto.randomUUID();
+
+      webStore.set('foo', 'baz');
+
+      const requestContext = extendRequestContext({
+        originalRequest: request,
+        route,
+        id,
+        webStore,
+      } as any);
+      expect((requestContext as any).useId()).toBe(`${id}_0`);
+      expect((requestContext as any).useId()).toBe(`${id}_1`);
+      expect((requestContext as any).useId()).toBe(`${id}_2`);
+      expect((requestContext as any).useId()).toBe(`${id}_3`);
+    });
+
     it('should encrypt transferToClient with options "encrypt"', () => {
       const request = new Request('https://example.com');
       const route = {

--- a/packages/brisa/src/utils/extend-request-context/index.ts
+++ b/packages/brisa/src/utils/extend-request-context/index.ts
@@ -80,6 +80,11 @@ export default function extendRequestContext({
   // id
   originalRequest.id = id ?? originalRequest.id;
 
+  // useId
+  originalRequest.count = originalRequest.count ?? 0;
+  originalRequest.useId = () =>
+    `${originalRequest.id}_${originalRequest.count++}`;
+
   // ws
   originalRequest.ws = globalThis.sockets?.get(originalRequest.id) ?? null;
   globalThis.sockets?.delete(originalRequest.id);


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/769
Related to https://github.com/brisa-build/brisa/issues/758

This PR adds `useId` to use it also in Server Components via `RequestContext`. (Currently, it was only accessible in Web Components). 

This is useful for forms, and also for Server Action IDs to use together with the [`indicate`](https://brisa.build/api-reference/components/request-context#indicate) method.

Ensuring that each execution of useId is distinct. For better performance than `crypto.randomUUID()`, it is an **auto-incremental number**, **next** to the **request id** that is already generated. This way, if a [component is rendered from a Server Action](https://brisa.build/api-reference/server-apis/renderComponent#rendercomponent-element-target-mode-withtransition-rendercomponentprops-never), it will remain distinct, with no collisions.

### Form


```tsx
const passwordHintId = useId();

return (
  <>
    <input type="password" aria-describedby={passwordHintId} />
    <p id={passwordHintId}>
  </>
)
```

### For Server Action ID

To ensure that each component has a different registered pending status without JS client code:

```tsx
const id = useId();
const pending = indicate(`some-server-action-${id}`);
// ...
css`
 span { display: none }
 span.brisa-request { display: inline }
`
// ...
<>
  <button onClick={someAction} indicateClick={pending}>
    Run some action
  </button>
  <span indicator={pending}>Pending...</span>
</>
```