### PR TITLE
feat: add `headersSnapshot` to `responseHeaders` (BREAKING CHANGE)

### DIFF
--- a/docs/building-your-application/configuring/content-security-policy.md
+++ b/docs/building-your-application/configuring/content-security-policy.md
@@ -25,7 +25,7 @@ Every time a page is viewed, a fresh nonce should be generated. This means that 
 For example:
 
 ```ts filename="src/middleware.ts"
-import type { RequestContext } from "brisa";
+import type { RequestContext, ResponseHeaders } from "brisa";
 
 export default function middleware(request: RequestContext) {
   const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
@@ -51,10 +51,12 @@ export default function middleware(request: RequestContext) {
   );
 }
 
-export function responseHeaders(request: RequestContext) {
-  return {
-    "Content-Security-Policy": request.headers.get("Content-Security-Policy"),
-  };
+export function responseHeaders(request: RequestContext, { headersSnapshot }: ResponseHeaders) {
+  const headers = headersSnapshot();
+
+  headers.append("Content-Security-Policy", request.headers.get("Content-Security-Policy"));
+  
+  return headers;
 }
 ```
 

--- a/docs/building-your-application/data-management/server-actions.md
+++ b/docs/building-your-application/data-management/server-actions.md
@@ -418,7 +418,7 @@ export async function createPost(id: string) {
 You can access to the request inside the server action to read cookies from headers, then you can communicate via request store to the [`responseHeaders`](/building-your-application/routing/pages-and-layouts#response-headers-in-layouts-and-pages) of the page:
 
 ```tsx
-import type { RequestContext } from "brisa";
+import type { RequestContext, ResponseHeaders } from "brisa";
 
 export default function Login({}, req: RequestContext) {
   return (
@@ -436,13 +436,12 @@ export default function Login({}, req: RequestContext) {
   );
 }
 
-export function responseHeaders(req: RequestContext) {
-  // Read the stored data:
-  const newCookies = req.store.get("new-cookies");
+export function responseHeaders(req: RequestContext, { headersSnapshot }: ResponseHeaders) {
+  const headers = headersSnapshot();
 
-  return {
-    "Set-Cookie": newCookies,
-  };
+  headers.append('Set-Cookies', req.store.get("new-cookies"))
+
+  return headers;
 }
 ```
 

--- a/docs/building-your-application/routing/middleware.md
+++ b/docs/building-your-application/routing/middleware.md
@@ -213,33 +213,37 @@ All responseHeaders will be mixed in this order:
 ==TypeScript
 
 ```ts
-import { type RequestContext } from "brisa";
+import type { RequestContext, ResponseHeaders } from "brisa";
 
 export function responseHeaders(
   request: RequestContext,
-  responseStatus: number,
+  { headersSnapshot, responseStatus }: ResponseHeaders,
 ) {
-  return {
-    "Cache-Control": "public, max-age=3600",
-    "X-Example": "This header is added from middleware",
-  };
+  const headers = headersSnapshot();
+  
+  headers.append("Cache-Control", "public, max-age=3600");
+  headers.append("X-Example", "This header is added from middleware");
+
+  return headers;
 }
 ```
 
 ==JavaScript
 
 ```js
-export function responseHeaders(request, responseStatus) {
-  return {
-    "Cache-Control": "public, max-age=3600",
-    "X-Example": "This header is added from middleware",
-  };
+export function responseHeaders(request, { headersSnapshot, responseStatus }) {
+  const headers = headersSnapshot();
+  
+  headers.append("Cache-Control", "public, max-age=3600");
+  headers.append("X-Example", "This header is added from middleware");
+  
+  return headers;
 }
 ```
 
 :::
 
-## Share data between `middleware` → `layout` → `page` → `component` → `responseHeaders`
+## Share data between `middleware` → `responseHeaders` → `layout` → `page` → `component`
 
 You can share data between different parts of the application using the [`store`](/api-reference/components/request-context#store).
 

--- a/docs/building-your-application/routing/middleware.md
+++ b/docs/building-your-application/routing/middleware.md
@@ -243,6 +243,17 @@ export function responseHeaders(request, { headersSnapshot, responseStatus }) {
 
 :::
 
+You can also pass the `HeadersInit` to the snapshot, to call `.append` in each new entry:
+
+```ts
+export function responseHeaders(request, { headersSnapshot, responseStatus }) {
+  return headersSnapshot({
+    "Cache-Control": "public, max-age=3600",
+    "X-Example": "This header is added from middleware"
+  });
+}
+```
+
 ## Share data between `middleware` → `responseHeaders` → `layout` → `page` → `component`
 
 You can share data between different parts of the application using the [`store`](/api-reference/components/request-context#store).

--- a/docs/building-your-application/routing/pages-and-layouts.md
+++ b/docs/building-your-application/routing/pages-and-layouts.md
@@ -158,29 +158,33 @@ All `responseHeaders` will be mixed in this order:
 ==TypeScript
 
 ```ts
-import { type RequestContext } from "brisa";
+import type { RequestContext, ResponseHeaders } from "brisa";
 
 export function responseHeaders(
   request: RequestContext,
-  responseStatus: number,
+  { headersSnapshot, responseStatus }: ResponseHeaders,
 ) {
-  return {
-    "Cache-Control": "public, max-age=3600",
-    "Content-Security-Policy": "script-src 'self' 'unsafe-inline';",
-    "X-Example": "This header is added from layout",
-  };
+  const headers = headersSnapshot();
+
+  headers.append("Cache-Control", "public, max-age=3600");
+  headers.append("Content-Security-Policy", "script-src 'self' 'unsafe-inline';");
+  headers.append("X-Example", "This header is added from layout");
+
+  return headers;
 }
 ```
 
 ==JavaScript
 
 ```js
-export function responseHeaders(request, responseStatus) {
-  return {
-    "Cache-Control": "public, max-age=3600",
-    "Content-Security-Policy": "script-src 'self' 'unsafe-inline';",
-    "X-Example": "This header is added from layout",
-  };
+export function responseHeaders(request, { headersSnapshot, responseStatus }) {
+  const headers = headersSnapshot();
+
+  headers.append("Cache-Control", "public, max-age=3600");
+  headers.append("Content-Security-Policy", "script-src 'self' 'unsafe-inline';");
+  headers.append("X-Example", "This header is added from layout");
+
+  return headers;
 }
 ```
 
@@ -215,7 +219,7 @@ export default function AboutUsPage() {
 >
 > If you want to mash existing head fields (title, link, meta, etc) because you already have them defined in the layout, you must use the `id` attribute in both parts, and only this one will be rendered. On pages that do not overwrite it, the one in the layout will be rendered.
 
-## Share data between `middleware` → `layout` → `page` → `component` → `responseHeaders` → `Head` → `web-components`
+## Share data between `middleware` → `responseHeaders` → `layout` → `page` → `component` → `Head` → `web-components`
 
 You can share data between different parts of the application using the [`request context`](/api-reference/components/request-context).
 

--- a/docs/building-your-application/routing/pages-and-layouts.md
+++ b/docs/building-your-application/routing/pages-and-layouts.md
@@ -188,6 +188,18 @@ export function responseHeaders(request, { headersSnapshot, responseStatus }) {
 }
 ```
 
+You can also pass the `HeadersInit` to the snapshot in order to call the `.append` of each entry:
+
+```ts
+export function responseHeaders(request, { headersSnapshot, responseStatus }) {
+  return headersSnapshot({
+    "Cache-Control": "public, max-age=3600",
+    "Content-Security-Policy": "script-src 'self' 'unsafe-inline';",
+    "X-Example": "This header is added from layout"
+  });
+}
+```
+
 > [!IMPORTANT]
 >
 > As in Brisa we render the server components in streaming, the headers are **ALWAYS sent before rendering the page**. It is very important to keep this in mind.

--- a/packages/brisa/src/__fixtures__/js/pages/index.mjs
+++ b/packages/brisa/src/__fixtures__/js/pages/index.mjs
@@ -15,8 +15,13 @@ Home.suspense = () => {
   });
 };
 
-export async function responseHeaders(req, status) {
-  return {
-    'x-test': status === 500 ? 'fail' : 'success',
-  };
+export async function responseHeaders(
+  req,
+  { headersSnapshot, responseStatus },
+) {
+  const headers = headersSnapshot();
+
+  headers.append('x-test', responseStatus === 500 ? 'fail' : 'success');
+
+  return headers;
 }

--- a/packages/brisa/src/__fixtures__/js/pages/somepage.mjs
+++ b/packages/brisa/src/__fixtures__/js/pages/somepage.mjs
@@ -4,10 +4,10 @@ export default async function SomePage() {
   return jsx('h1', { children: 'Some page' });
 }
 
-export function responseHeaders(request) {
-  return {
+export function responseHeaders(request, { headersSnapshot }) {
+  return headersSnapshot({
     'x-test': 'test',
     'x-initiator': request.initiator,
     cookie: 'test=1; Path=/; Max-Age=3600',
-  };
+  });
 }

--- a/packages/brisa/src/__fixtures__/pages/index.tsx
+++ b/packages/brisa/src/__fixtures__/pages/index.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import type { RequestContext } from '@/types';
+import type { RequestContext, ResponseHeaders } from '@/types';
 
 export default async function Home({}, { i18n }: RequestContext) {
   return (
@@ -15,8 +15,11 @@ Home.suspense = () => {
   );
 };
 
-export async function responseHeaders(req: RequestContext, status: number) {
-  return {
-    'x-test': status === 500 ? 'fail' : 'success',
-  };
+export async function responseHeaders(
+  req: RequestContext,
+  { responseStatus, headersSnapshot }: ResponseHeaders,
+) {
+  return headersSnapshot({
+    'x-test': responseStatus === 500 ? 'fail' : 'success',
+  });
 }

--- a/packages/brisa/src/__fixtures__/pages/somepage.tsx
+++ b/packages/brisa/src/__fixtures__/pages/somepage.tsx
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { createContext } from '@/core';
-import type { RequestContext } from '@/types';
+import type { RequestContext, ResponseHeaders } from '@/types';
 
 const context = createContext('foo');
 
@@ -14,9 +14,12 @@ export default async function SomePage() {
   );
 }
 
-export function responseHeaders(request: RequestContext) {
-  return {
+export function responseHeaders(
+  request: RequestContext,
+  { headersSnapshot }: ResponseHeaders,
+) {
+  return headersSnapshot({
     'x-test': 'test',
     'x-initiator': request.initiator,
-  };
+  });
 }

--- a/packages/brisa/src/types/index.d.ts
+++ b/packages/brisa/src/types/index.d.ts
@@ -970,10 +970,24 @@ export type ReactiveMap = {
 
 type Props<T extends Record<string, unknown> = Record<string, unknown>> = T;
 
-export type ResponseHeaders = (
+export type ResponseHeaders = {
+  /**
+   * Useful to get an snapshot of the current headers, modify some headers and return it.
+   *
+   * These headers are propagated between the `responseHeaders` of the middleware to the
+   * `responseHeaders` of the layout, to finally the `responseHeaders` of the page.
+   */
+  headersSnapshot: (init?: HeadersInit) => Headers;
+  /**
+   * Status of the response (200, 404, 500, etc)
+   */
+  responseStatus: number;
+};
+
+export type ResponseHeadersFunction = (
   req: RequestContext,
-  status: number,
-) => HeadersInit;
+  responseHeadersContext: ResponseHeaders,
+) => Headers;
 
 export type Primitives = symbol | string | number | boolean | undefined | null;
 
@@ -1556,7 +1570,7 @@ export type TranslateOptions = {
 
 export type PageModule = {
   default: (props: { error?: Error }) => JSX.Element;
-  responseHeaders?: (req: Request, status: number) => HeadersInit;
+  responseHeaders?: ResponseHeadersFunction;
   Head?: ComponentType;
 };
 

--- a/packages/brisa/src/utils/client-build/layout-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/layout-build/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 3653;
 const brisaSize = 5721; // TODO: Reduce this size :/
 const webComponents = 1118;
 const unsuspenseSize = 213;
-const rpcSize = 2500; // TODO: Reduce this size
+const rpcSize = 2509; // TODO: Reduce this size
 const lazyRPCSize = 4308; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/compile-files/__fixtures__/with-complex-files/pages/index.tsx
+++ b/packages/brisa/src/utils/compile-files/__fixtures__/with-complex-files/pages/index.tsx
@@ -14,8 +14,11 @@ Home.suspense = () => {
   );
 };
 
-export async function responseHeaders() {
-  return {
+export async function responseHeaders(
+  _: RequestContext,
+  { headersSnapshot }: ResponseHeaders,
+) {
+  return headersSnapshot({
     'x-test': 'test',
-  };
+  });
 }

--- a/packages/brisa/src/utils/compile-files/__fixtures__/with-complex-files/pages/somepage.tsx
+++ b/packages/brisa/src/utils/compile-files/__fixtures__/with-complex-files/pages/somepage.tsx
@@ -10,8 +10,8 @@ export default async function SomePage() {
   );
 }
 
-export function responseHeaders() {
-  return {
+export function responseHeaders(_, { headersSnapshot }) {
+  return headersSnapshot({
     'x-test': 'test',
-  };
+  });
 }

--- a/packages/brisa/src/utils/compile-files/index.test.ts
+++ b/packages/brisa/src/utils/compile-files/index.test.ts
@@ -276,7 +276,7 @@ describe('utils', () => {
     ${info}Ω /i18n                          | 162 B     |
     ${info}Ψ /websocket                     | 207 B     |
     ${info}Θ /web-components/_integrations  | 67 B      |
-    ${info}λ /pages/index                   | 827 B     | ${greenLog('3 kB')}
+    ${info}λ /pages/index                   | 852 B     | ${greenLog('3 kB')}
     ${info}λ /pages/page-with-web-component | 761 B     | ${greenLog('5 kB')}
     ${info}λ /pages/somepage                | 1 kB      | ${greenLog('0 B')}
     ${info}λ /pages/somepage-with-context   | 1 kB      | ${greenLog('0 B')}  

--- a/packages/brisa/src/utils/create-response-headers-context/index.test.ts
+++ b/packages/brisa/src/utils/create-response-headers-context/index.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'bun:test';
+import createResponseHeadersContext from '.';
+
+describe('createResponseHeadersContext', () => {
+  it('should return an immutable snapshot of the original headers', () => {
+    const originalHeaders = new Headers({ 'x-test': '123' });
+    const context = createResponseHeadersContext(originalHeaders, 200);
+    const snapshot = context.headersSnapshot();
+
+    expect(snapshot.get('x-test')).toBe('123');
+
+    snapshot.set('x-test', '456');
+    expect(originalHeaders.get('x-test')).toBe('123');
+    expect(snapshot.get('x-test')).toBe('456');
+  });
+
+  it('should return a new headers object with the same values as the original', () => {
+    const originalHeaders = new Headers({ 'content-type': 'application/json' });
+    const context = createResponseHeadersContext(originalHeaders, 200);
+    const snapshot = context.headersSnapshot();
+
+    expect(snapshot.get('content-type')).toBe('application/json');
+    expect(snapshot).not.toBe(originalHeaders);
+  });
+
+  it('should correctly append headers from HeadersInit (Headers instance)', () => {
+    const originalHeaders = new Headers({ 'x-original': 'keep' });
+    const additionalHeaders = new Headers({ 'x-added': 'new' });
+
+    const context = createResponseHeadersContext(originalHeaders, 200);
+    const snapshot = context.headersSnapshot(additionalHeaders);
+
+    expect(snapshot.get('x-original')).toBe('keep');
+    expect(snapshot.get('x-added')).toBe('new');
+    expect(originalHeaders.has('x-added')).toBe(false);
+  });
+
+  it('should correctly append headers from HeadersInit (plain object)', () => {
+    const originalHeaders = new Headers({ 'cache-control': 'no-cache' });
+    const additionalHeaders = { 'x-custom': 'custom-value' };
+
+    const context = createResponseHeadersContext(originalHeaders, 200);
+    const snapshot = context.headersSnapshot(additionalHeaders);
+
+    expect(snapshot.get('cache-control')).toBe('no-cache');
+    expect(snapshot.get('x-custom')).toBe('custom-value');
+    expect(originalHeaders.has('x-custom')).toBe(false);
+  });
+
+  it('should correctly append headers from HeadersInit (array of tuples)', () => {
+    const originalHeaders = new Headers({ 'x-static': 'unchanged' });
+    const additionalHeaders: [string, string][] = [
+      ['x-array', 'value-from-array'],
+    ];
+
+    const context = createResponseHeadersContext(originalHeaders, 200);
+    const snapshot = context.headersSnapshot(additionalHeaders);
+
+    expect(snapshot.get('x-static')).toBe('unchanged');
+    expect(snapshot.get('x-array')).toBe('value-from-array');
+    expect(originalHeaders.has('x-array')).toBe(false);
+  });
+
+  it('should correctly handle multiple headers with the same name', () => {
+    const originalHeaders = new Headers({ 'x-duplicate': 'first' });
+    const additionalHeaders: [string, string][] = [['x-duplicate', 'second']];
+
+    const context = createResponseHeadersContext(originalHeaders, 200);
+    const snapshot = context.headersSnapshot(additionalHeaders);
+
+    expect(snapshot.get('x-duplicate')).toBe('first, second');
+    expect(originalHeaders.get('x-duplicate')).toBe('first');
+  });
+
+  it('should correctly set the responseStatus', () => {
+    const context = createResponseHeadersContext(new Headers(), 404);
+    expect(context.responseStatus).toBe(404);
+  });
+});

--- a/packages/brisa/src/utils/create-response-headers-context/index.ts
+++ b/packages/brisa/src/utils/create-response-headers-context/index.ts
@@ -1,0 +1,20 @@
+export default function createResponseHeadersContext(
+  pageHeaders: Headers,
+  responseStatus: number,
+) {
+  return {
+    responseStatus,
+    headersSnapshot: (init?: HeadersInit) => {
+      const snapshot = new Headers(pageHeaders);
+
+      if (init) {
+        const headersToAppend = new Headers(init);
+        for (const [key, value] of headersToAppend.entries()) {
+          snapshot.append(key, value);
+        }
+      }
+
+      return snapshot;
+    },
+  };
+}

--- a/packages/brisa/src/utils/get-page-component-with-headers/index.ts
+++ b/packages/brisa/src/utils/get-page-component-with-headers/index.ts
@@ -2,6 +2,7 @@ import { getConstants } from '@/constants';
 import type { MatchedBrisaRoute, RequestContext } from '@/types';
 import importFileIfExists from '@/utils/import-file-if-exists';
 import processPageRoute from '@/utils/process-page-route';
+import createResponseHeadersContext from '@/utils/create-response-headers-context';
 
 type Params = {
   req: RequestContext;
@@ -22,25 +23,34 @@ export default async function getPageComponentWithHeaders({
   headers,
 }: Params) {
   const { Page, module, layoutModule } = await processPageRoute(route, error);
-  const middlewareResponseHeaders =
-    (await middlewareModule?.responseHeaders?.(req, status)) ?? {};
-
-  const layoutResponseHeaders =
-    (await layoutModule?.responseHeaders?.(req, status)) ?? {};
-
-  const pageResponseHeaders =
-    (await module.responseHeaders?.(req, status)) ?? {};
-
-  const pageHeaders = new Headers({
+  let pageHeaders = new Headers({
     'cache-control': HEADERS.CACHE_CONTROL,
-    ...middlewareResponseHeaders,
-    ...layoutResponseHeaders,
-    ...pageResponseHeaders,
     ...headers,
     'transfer-encoding': 'chunked',
     vary: 'Accept-Encoding',
     'content-type': 'text/html; charset=utf-8',
   });
+
+  const middlewareResponseHeaders = await middlewareModule?.responseHeaders?.(
+    req,
+    createResponseHeadersContext(pageHeaders, status),
+  );
+
+  if (middlewareResponseHeaders) pageHeaders = middlewareResponseHeaders;
+
+  const layoutResponseHeaders = await layoutModule?.responseHeaders?.(
+    req,
+    createResponseHeadersContext(pageHeaders, status),
+  );
+
+  if (layoutResponseHeaders) pageHeaders = layoutResponseHeaders;
+
+  const pageResponseHeaders = await module.responseHeaders?.(
+    req,
+    createResponseHeadersContext(pageHeaders, status),
+  );
+
+  if (pageResponseHeaders) pageHeaders = pageResponseHeaders;
 
   return {
     PageComponent: Page,

--- a/packages/brisa/src/utils/response-action/index.ts
+++ b/packages/brisa/src/utils/response-action/index.ts
@@ -8,6 +8,7 @@ import { logError } from '@/utils/log/log-build';
 import { pathToFileURLWhenNeeded } from '../get-importable-filepath';
 import importFileIfExists from '../import-file-if-exists';
 import { getConstants } from '@/constants';
+import createResponseHeadersContext from '@/utils/create-response-headers-context';
 
 const DEPENDENCIES = Symbol.for('DEPENDENCIES');
 
@@ -177,12 +178,16 @@ export default async function responseAction(
   const module = req.route
     ? await import(pathToFileURLWhenNeeded(req.route.filePath))
     : {};
-  const pageResponseHeaders =
-    (await module.responseHeaders?.(req, response.status)) ?? {};
 
-  // Transfer page response headers
-  for (const [key, value] of Object.entries(pageResponseHeaders)) {
-    response.headers.set(key, value);
+  const pageResponseHeaders = await module.responseHeaders?.(
+    req,
+    createResponseHeadersContext(response.headers, response.status),
+  );
+
+  if (pageResponseHeaders) {
+    for (const [key, value] of pageResponseHeaders.entries()) {
+      response.headers.set(key, value);
+    }
   }
 
   // Reset form after use e.target.reset() in server action


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/744

**BREAKING CHANGE**: Change the parameters and the headers propagation way (no more spread), and the developers have 100% control over the full headers each time.

> [!NOTE]
>
> `responseHeaders` are in middleware, layout & page. We need to propagate accurately.

### Before 🟨

```ts
export function responseHeaders(req: RequestContext) {
  return {
    "Set-Cookie":  req.store.get("new-cookies"),
  };
}
```

### Now 🟩

`headersSnapshot` returns a clone of the current headers. In this way, it is immutable and needs a return with the new headers.

```ts
export function responseHeaders(request: RequestContext, { headersSnapshot }: ResponseHeaders) {
  const headers = headersSnapshot();

  headers.append('Set-Cookies', request.store.get("new-cookies"))

  return headers;
}
```

You can also pass the `HeadersInit` to the snapshot, to call `.append` in each new entry:

```ts
export function responseHeaders(request, { headersSnapshot, responseStatus }) {
  return headersSnapshot({
    "Set-Cookies": request.store.get("new-cookies"),
  });
}
```

### BAD 🟥

Now, instead of merging, is overwriting.

This is going to fail for missing headers (default Brisa headers and also overwriting the middleware `responseHeaders`):

```ts
export function responseHeaders(req: RequestContext) {
  return {
    // Missing headers here to work the page with streaming (default headers of Brisa)...
    "Set-Cookie": req.store.get("new-cookies"),
  };
}
```

And this too...

```ts
export function responseHeaders(req: RequestContext) {
  return new Headers({
    // Missing headers here to work the page with streaming (default headers of Brisa)... 
    "Set-Cookie": req.store.get("new-cookies"),
  });
}
```

This one also is not working because `headers` is immutable, you need to return it:

```ts
export function responseHeaders(request: RequestContext, { headersSnapshot }: ResponseHeaders) {
  const headers = headersSnapshot();

  headers.append('Set-Cookies', request.store.get("new-cookies"))

  // without return is not going to do the change (is immutable)
}
```