### PR TITLE
fix: avoid collision between CSS generated and existing public CSS files

### DIFF
--- a/packages/brisa/src/utils/client-build/layout-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/layout-build/index.test.ts
@@ -19,10 +19,10 @@ const pageWebComponents = {
 };
 
 const i18nCode = 3653;
-const brisaSize = 5721; // TODO: Reduce this size :/
+const brisaSize = 5738; // TODO: Reduce this size :/
 const webComponents = 1118;
 const unsuspenseSize = 213;
-const rpcSize = 2498; // TODO: Reduce this size
+const rpcSize = 2489; // TODO: Reduce this size
 const lazyRPCSize = 4308; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/handle-css-files/index.test.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.test.ts
@@ -286,6 +286,22 @@ describe('utils/handle-css-files', () => {
       'style-111111.css',
     ]);
   });
+
+  it('should NOT override existing .css files in /public #780', async () => {
+    fs.writeFileSync(path.join(BUILD_DIR, 'test.css'), 'body { color: red; }');
+    fs.mkdirSync(path.join(BUILD_DIR, 'public'));
+    fs.writeFileSync(path.join(BUILD_DIR, 'public', 'style-123456.css'), 'OK');
+    mockHash.mockReturnValueOnce(123456);
+
+    await expect(handleCSSFiles()).resolves.toBeUndefined();
+
+    expect(
+      fs.readFileSync(
+        path.join(BUILD_DIR, 'public', 'style-123456.css'),
+        'utf-8',
+      ),
+    ).toBe('OK');
+  });
 });
 
 describe('getCSSLoader', () => {

--- a/packages/brisa/src/utils/handle-css-files/index.ts
+++ b/packages/brisa/src/utils/handle-css-files/index.ts
@@ -124,7 +124,10 @@ async function handleCSSInsidePublic(dir: string, outDir: string) {
     const hash = Bun.hash(await Bun.file(filePath).arrayBuffer());
     const newFilename = `style-${hash}.css`;
 
-    fs.copyFileSync(filePath, path.join(outDir, newFilename));
+    if (!fs.existsSync(path.join(outDir, newFilename))) {
+      fs.copyFileSync(filePath, path.join(outDir, newFilename));
+    }
+
     files.push(newFilename);
   }
 


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/780