### PR TITLE
fix(build): transform middleware import from dynamic to static

### DIFF
--- a/packages/brisa/package.json
+++ b/packages/brisa/package.json
@@ -110,7 +110,7 @@
   "scripts": {
     "build": "bun run clean && bun run build:jsx-runtime && bun run build:jsx-dev-runtime && bun run build:core && bun run build:core-client && bun run build:core-server && bun run build:core-macros && bun run build:core-test && bun run build:core-compiler",
     "build:bin": "bun build --minify --target=bun --outdir=./ src/bin/index.ts && bun run build:cli-utils",
-    "build:cli-utils": "bun build --minify --target=bun --outdir=out/cli src/cli/build.ts src/cli/build-standalone/index.ts && bun build --minify --target=node --outdir=out/cli src/cli/serve/index.tsx src/cli/integrations/mdx/index.ts src/cli/integrations/tailwindcss/index.ts src/cli/integrations/pandacss/index.ts",
+    "build:cli-utils": "bun build --minify --target=bun --outdir=out/cli src/cli/build.ts src/cli/build-standalone/index.ts && bun build --minify --target=node --outdir=out/cli src/cli/serve/index.tsx src/cli/integrations/mdx/index.ts src/cli/integrations/tailwindcss/index.ts src/cli/integrations/pandacss/index.ts --external brisa-project-internals",
     "build:core": "bun build --minify --outdir=out/core src/core/index.ts && bun run build:bin && cp src/types/index.d.ts out/core/index.d.ts",
     "build:core-compiler": "cd scripts && bun run core-compiler-build.ts && cd .. && cp src/types/compiler.d.ts compiler/index.d.ts",
     "build:core-macros": "bun build --minify --target=bun --outdir=macros src/core/macros/index.ts && bun run build:bin",

--- a/packages/brisa/src/brisa-project-internals.ts
+++ b/packages/brisa/src/brisa-project-internals.ts
@@ -1,0 +1,27 @@
+import importFileIfExists from '@/utils/import-file-if-exists';
+import { getConstants } from '@/constants';
+
+const { BUILD_DIR } = getConstants();
+
+/**
+ * WIP https://github.com/brisa-build/brisa/issues/628
+ *
+ * All these content is replaced in project build-time with the correct project content,
+ * by packages/brisa/src/utils/attach-brisa-project-internals/index.ts
+ *
+ * Useful to avoid dynamic imports. Being possible to compile the app into binary to
+ * improve memory in runtime.
+ */
+const middlewareModule = await importFileIfExists('middleware', BUILD_DIR);
+export const middleware = middlewareModule?.default;
+
+// TODO:
+export const i18n = null;
+export const config = null;
+export const api = [];
+export const layout = null;
+export const websockets = null;
+export const actions = null;
+export const pages = [];
+export const integrations = null;
+export const cssFiles = [];

--- a/packages/brisa/src/cli/serve/serve-options.test.tsx
+++ b/packages/brisa/src/cli/serve/serve-options.test.tsx
@@ -1,4 +1,4 @@
-import type { BunFile } from 'bun';
+import type { BunFile, ServerWebSocket } from "bun";
 import {
   afterEach,
   beforeEach,
@@ -8,33 +8,35 @@ import {
   spyOn,
   mock,
   jest,
-} from 'bun:test';
-import { brotliDecompressSync, gunzipSync } from 'node:zlib';
-import path from 'node:path';
-import { getConstants } from '@/constants';
-import type { ServerWebSocket } from 'bun';
-import type { RequestContext } from '@/types';
-import { Initiator } from '@/public-constants';
-import { AVOID_DECLARATIVE_SHADOW_DOM_SYMBOL } from '@/utils/ssr-web-component';
-import { getServeOptions } from './serve-options';
-import type { RequestContent } from '@/utils/transfer-store-service';
+} from "bun:test";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import path from "node:path";
+import { getConstants } from "@/constants";
+import type { RequestContext } from "@/types";
+import { Initiator } from "@/public-constants";
+import { AVOID_DECLARATIVE_SHADOW_DOM_SYMBOL } from "@/utils/ssr-web-component";
+import { getServeOptions } from "./serve-options";
+import type { RequestContent } from "@/utils/transfer-store-service";
 import {
   ENCRYPT_NONTEXT_PREFIX,
   encrypt,
   ENCRYPT_PREFIX,
-} from '@/utils/crypto';
+} from "@/utils/crypto";
 
-const BUILD_DIR = path.join(import.meta.dir, '..', '..', '__fixtures__');
-const PAGES_DIR = path.join(BUILD_DIR, 'pages');
-const ASSETS_DIR = path.join(BUILD_DIR, 'public');
-const BASE_PATHS = ['', '/some-dir', '/es', '/some/dir'];
+// @ts-ignore
+import middleware from "../../__fixtures__/middleware.ts";
+
+const BUILD_DIR = path.join(import.meta.dir, "..", "..", "__fixtures__");
+const PAGES_DIR = path.join(BUILD_DIR, "pages");
+const ASSETS_DIR = path.join(BUILD_DIR, "public");
+const BASE_PATHS = ["", "/some-dir", "/es", "/some/dir"];
 
 async function testRequest(
   request: Request,
   upgrade = false,
 ): Promise<Response> {
   const serveOptions = await (
-    await import('./serve-options')
+    await import("./serve-options")
   ).getServeOptions();
 
   return (
@@ -42,27 +44,29 @@ async function testRequest(
     ((await serveOptions.fetch(request, {
       requestIP: () => {},
       upgrade: () => upgrade,
-    })) || new Response('', { status: 101 })) as Response
+    })) || new Response("", { status: 101 })) as Response
   );
 }
 
 const __CRYPTO_KEY__ = process.env.__CRYPTO_KEY__;
 const __CRYPTO_IV__ = process.env.__CRYPTO_IV__;
 
-describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
+describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
   beforeEach(async () => {
+    mock.module("brisa-project-internals", () => ({ middleware }));
+
     // @ts-ignore - We need to test real server scenarios
-    if (typeof window !== 'undefined') window = undefined;
+    if (typeof window !== "undefined") window = undefined;
     globalThis.mockConstants = {
       ...(getConstants() ?? {}),
       PAGES_DIR,
       BUILD_DIR,
       SRC_DIR: BUILD_DIR,
       ASSETS_DIR,
-      LOCALES_SET: new Set(['en', 'es']),
+      LOCALES_SET: new Set(["en", "es"]),
       I18N_CONFIG: {
-        locales: ['en', 'es'],
-        defaultLocale: 'es',
+        locales: ["en", "es"],
+        defaultLocale: "es",
       },
       CONFIG: {
         basePath,
@@ -72,72 +76,72 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
   });
 
   afterEach(() => {
-    globalThis.__BASE_PATH__ = '';
+    globalThis.__BASE_PATH__ = "";
     process.env.__CRYPTO_KEY__ = __CRYPTO_KEY__;
     process.env.__CRYPTO_IV__ = __CRYPTO_IV__;
-    process.env.BRISA_BUILD_FOLDER = '';
+    process.env.BRISA_BUILD_FOLDER = "";
     globalThis.mockConstants = undefined;
     delete process.argv[1];
     jest.restoreAllMocks();
   });
 
-  it('should set the env variables when they are not set for a custom server when no argument neither process.argv[1]', async () => {
-    await (await import('./serve-options')).setUpEnvVars();
+  it("should set the env variables when they are not set for a custom server when no argument neither process.argv[1]", async () => {
+    await (await import("./serve-options")).setUpEnvVars();
 
     expect(process.env.__CRYPTO_KEY__).toBeDefined();
     expect(process.env.__CRYPTO_IV__).toBeDefined();
     expect(process.env.BRISA_BUILD_FOLDER).toBe(
-      path.join(process.cwd(), 'build'),
+      path.join(process.cwd(), "build"),
     );
   });
 
-  it('should detect as isCLI false when process.argv[1] NOT include serve/index.js', async () => {
+  it("should detect as isCLI false when process.argv[1] NOT include serve/index.js", async () => {
     process.env.__CRYPTO_KEY__ = undefined;
     process.env.__CRYPTO_IV__ = undefined;
-    process.argv[1] = path.join('brisa', 'out', 'cli', 'build', 'index.js');
-    await (await import('./serve-options')).setUpEnvVars();
+    process.argv[1] = path.join("brisa", "out", "cli", "build", "index.js");
+    await (await import("./serve-options")).setUpEnvVars();
 
     expect(process.env.__CRYPTO_KEY__).toBeDefined();
     expect(process.env.__CRYPTO_IV__).toBeDefined();
     expect(process.env.BRISA_BUILD_FOLDER).toBe(
-      path.join(process.cwd(), 'build'),
+      path.join(process.cwd(), "build"),
     );
   });
 
-  it('should set the env variables when they are not set for a custom server', async () => {
+  it("should set the env variables when they are not set for a custom server", async () => {
     process.env.__CRYPTO_KEY__ = undefined;
     process.env.__CRYPTO_IV__ = undefined;
-    await (await import('./serve-options')).setUpEnvVars(false);
+    await (await import("./serve-options")).setUpEnvVars(false);
 
     expect(process.env.__CRYPTO_KEY__).toBeDefined();
     expect(process.env.__CRYPTO_IV__).toBeDefined();
     expect(process.env.BRISA_BUILD_FOLDER).toBe(
-      path.join(process.cwd(), 'build'),
+      path.join(process.cwd(), "build"),
     );
   });
 
-  it('should BRISA_BUILD_FOLDER env variable be defined always (to use prebuild)', async () => {
+  it("should BRISA_BUILD_FOLDER env variable be defined always (to use prebuild)", async () => {
     process.env.__CRYPTO_KEY__ = undefined;
     process.env.__CRYPTO_IV__ = undefined;
-    await (await import('./serve-options')).setUpEnvVars(true);
+    await (await import("./serve-options")).setUpEnvVars(true);
 
     expect(process.env.__CRYPTO_KEY__).not.toBeDefined();
     expect(process.env.__CRYPTO_IV__).not.toBeDefined();
     expect(process.env.BRISA_BUILD_FOLDER).toBe(
-      path.join(process.cwd(), 'build'),
+      path.join(process.cwd(), "build"),
     );
   });
 
-  it('should detect as isCLI true when process.argv[1] include serve/index.js', async () => {
+  it("should detect as isCLI true when process.argv[1] include serve/index.js", async () => {
     process.env.__CRYPTO_KEY__ = undefined;
     process.env.__CRYPTO_IV__ = undefined;
-    process.argv[1] = path.join('brisa', 'out', 'cli', 'serve', 'index.js');
-    await (await import('./serve-options')).setUpEnvVars();
+    process.argv[1] = path.join("brisa", "out", "cli", "serve", "index.js");
+    await (await import("./serve-options")).setUpEnvVars();
 
     expect(process.env.__CRYPTO_KEY__).not.toBeDefined();
     expect(process.env.__CRYPTO_IV__).not.toBeDefined();
     expect(process.env.BRISA_BUILD_FOLDER).toBe(
-      path.join(process.cwd(), 'build'),
+      path.join(process.cwd(), "build"),
     );
   });
 
@@ -146,11 +150,11 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     globalThis.mockConstants = {
       ...constants,
       IS_PRODUCTION: true,
-      BUILD_DIR: '/some-path',
+      BUILD_DIR: "/some-path",
     };
 
     expect(
-      async () => await (await import('./serve-options')).getServeOptions(),
+      async () => await (await import("./serve-options")).getServeOptions(),
     ).toThrowError('Not exist "build" yet. Please run "brisa build" first');
   });
 
@@ -159,11 +163,11 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     globalThis.mockConstants = {
       ...constants,
       IS_PRODUCTION: true,
-      PAGES_DIR: '/some-path',
+      PAGES_DIR: "/some-path",
     };
 
     expect(
-      async () => await (await import('./serve-options')).getServeOptions(),
+      async () => await (await import("./serve-options")).getServeOptions(),
     ).toThrowError(
       `Not exist build/pages" directory. It's required to run "brisa start"`,
     );
@@ -174,17 +178,17 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     globalThis.mockConstants = {
       ...constants,
       IS_PRODUCTION: false,
-      PAGES_DIR: '/some-path',
+      PAGES_DIR: "/some-path",
     };
 
     expect(
-      async () => await (await import('./serve-options')).getServeOptions(),
+      async () => await (await import("./serve-options")).getServeOptions(),
     ).toThrowError(
       `Not exist src/pages" directory. It's required to run "brisa dev"`,
     );
   });
 
-  it('should no fetch anything when server upgrades to websocket', async () => {
+  it("should no fetch anything when server upgrades to websocket", async () => {
     const upgrade = true;
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/somepage`),
@@ -192,10 +196,10 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
 
     expect(response.status).toBe(101);
-    expect(response.text()).resolves.toBe('');
+    expect(response.text()).resolves.toBe("");
   });
 
-  it('should return 500 page if the middleware throws an error', async () => {
+  it("should return 500 page if the middleware throws an error", async () => {
     const response = await testRequest(
       // "throws-error" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -205,11 +209,11 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(500);
-    expect(html).toStartWith('<!DOCTYPE html>');
+    expect(html).toStartWith("<!DOCTYPE html>");
     expect(html).toContain('<title id="title">Some internal error</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      '<h1>Some internal error <web-component></web-component></h1>',
+      "<h1>Some internal error <web-component></web-component></h1>",
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_500.tsx"></script>`,
@@ -225,10 +229,10 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe('/es');
+    expect(response.headers.get("Location")).toBe("/es");
   });
 
-  it('should navigate when the middleware throws a navigate error', async () => {
+  it("should navigate when the middleware throws a navigate error", async () => {
     const response = await testRequest(
       // "navigate" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -237,12 +241,12 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `http://localhost:1234${basePath}/es/somepage`,
     );
   });
 
-  it('should navigate resolving i18n when the middleware throws a navigate error', async () => {
+  it("should navigate resolving i18n when the middleware throws a navigate error", async () => {
     const response = await testRequest(
       // "navigate" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -251,10 +255,10 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(`${basePath}/es/somepage`);
+    expect(response.headers.get("Location")).toBe(`${basePath}/es/somepage`);
   });
 
-  it('should navigate removing trailing slash when the middleware throws a navigate error', async () => {
+  it("should navigate removing trailing slash when the middleware throws a navigate error", async () => {
     const response = await testRequest(
       // "navigate" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -263,12 +267,12 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `http://localhost:1234${basePath}/es/somepage`,
     );
   });
 
-  it('should navigate removing trailing slash and adding i18n at the same time when the middleware throws a navigate error', async () => {
+  it("should navigate removing trailing slash and adding i18n at the same time when the middleware throws a navigate error", async () => {
     const response = await testRequest(
       // "navigate" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -277,10 +281,10 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(`${basePath}/es/somepage`);
+    expect(response.headers.get("Location")).toBe(`${basePath}/es/somepage`);
   });
 
-  it('should navigate to an external url without i18n and trailing slash when the middleware throws a navigate error', async () => {
+  it("should navigate to an external url without i18n and trailing slash when the middleware throws a navigate error", async () => {
     const response = await testRequest(
       // "navigate" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -289,12 +293,12 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `https://brisa.build${basePath}/foo/`,
     );
   });
 
-  it('should return 404 page when the middleware throws a not found error', async () => {
+  it("should return 404 page when the middleware throws a not found error", async () => {
     const response = await testRequest(
       // "throws-not-found" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -304,11 +308,11 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith('<!DOCTYPE html>');
+    expect(html).toStartWith("<!DOCTYPE html>");
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      '<h1>Page not found 404 es<web-component></web-component></h1>',
+      "<h1>Page not found 404 es<web-component></web-component></h1>",
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
@@ -322,21 +326,21 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith('<!DOCTYPE html>');
+    expect(html).toStartWith("<!DOCTYPE html>");
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      '<h1>Page not found 404 es<web-component></web-component></h1>',
+      "<h1>Page not found 404 es<web-component></web-component></h1>",
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
-  it('should return 404 error if the 404 page does not exist and the page does not exist', async () => {
+  it("should return 404 error if the 404 page does not exist and the page does not exist", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
-      PAGE_404: '',
+      PAGE_404: "",
     };
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}/not-found-page`),
@@ -344,7 +348,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const text = await response.text();
 
     expect(response.status).toBe(404);
-    expect(text).toBe('Not found');
+    expect(text).toBe("Not found");
   });
 
   it("should return 404 page without redirect to the trailingSlash if the page doesn't exist", async () => {
@@ -361,11 +365,11 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith('<!DOCTYPE html>');
+    expect(html).toStartWith("<!DOCTYPE html>");
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      '<h1>Page not found 404 es<web-component></web-component></h1>',
+      "<h1>Page not found 404 es<web-component></web-component></h1>",
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
@@ -386,36 +390,36 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith('<!DOCTYPE html>');
+    expect(html).toStartWith("<!DOCTYPE html>");
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      '<h1>Page not found 404 es<web-component></web-component></h1>',
+      "<h1>Page not found 404 es<web-component></web-component></h1>",
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
-  it('should return 404 page', async () => {
+  it("should return 404 page", async () => {
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}/es/not-found-page`),
     );
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith('<!DOCTYPE html>');
+    expect(html).toStartWith("<!DOCTYPE html>");
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      '<h1>Page not found 404 es<web-component></web-component></h1>',
+      "<h1>Page not found 404 es<web-component></web-component></h1>",
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
-  it('should return 404 page with a valid url but with the param _not-found in the query string and work with i18n', async () => {
+  it("should return 404 page with a valid url but with the param _not-found in the query string and work with i18n", async () => {
     const response = await testRequest(
       new Request(
         `http://localhost:1234${basePath}/es/page-with-web-component?_not-found=1`,
@@ -424,18 +428,18 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith('<!DOCTYPE html>');
+    expect(html).toStartWith("<!DOCTYPE html>");
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      '<h1>Page not found 404 es<web-component></web-component></h1>',
+      "<h1>Page not found 404 es<web-component></web-component></h1>",
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
-  it('should return 200 page with client page code', async () => {
+  it("should return 200 page with client page code", async () => {
     const response = await testRequest(
       new Request(
         `http://localhost:1234${basePath}/es/page-with-web-component`,
@@ -448,10 +452,10 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
     );
-    expect(html).toContain('<web-component></web-component>');
+    expect(html).toContain("<web-component></web-component>");
   });
 
-  it('should return 200 page with client page code using a hash', async () => {
+  it("should return 200 page with client page code using a hash", async () => {
     const response = await testRequest(
       new Request(
         `http://localhost:1234${basePath}/es/page-with-web-component#hash`,
@@ -464,10 +468,10 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
     );
-    expect(html).toContain('<web-component></web-component>');
+    expect(html).toContain("<web-component></web-component>");
   });
 
-  it('should return 200 page with client page code using a hash and trailingSlash', async () => {
+  it("should return 200 page with client page code using a hash and trailingSlash", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -487,14 +491,14 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
     );
-    expect(html).toContain('<web-component></web-component>');
+    expect(html).toContain("<web-component></web-component>");
   });
 
-  it('should return 404 page with client page code without the basePath', async () => {
+  it("should return 404 page with client page code without the basePath", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
-        basePath: '/incorrect',
+        basePath: "/incorrect",
       },
     };
     const response = await testRequest(
@@ -505,23 +509,23 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(response.status).toBe(404);
   });
 
-  it('should redirect the home to the correct locale', async () => {
+  it("should redirect the home to the correct locale", async () => {
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(`${basePath}/es`);
+    expect(response.headers.get("Location")).toBe(`${basePath}/es`);
   });
 
-  it('should redirect the home to the correct locale with parameters', async () => {
+  it("should redirect the home to the correct locale with parameters", async () => {
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}?param=1`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(`${basePath}/es?param=1`);
+    expect(response.headers.get("Location")).toBe(`${basePath}/es?param=1`);
   });
 
-  it('should redirect the /api/example to the trailingSlash with parameters', async () => {
+  it("should redirect the /api/example to the trailingSlash with parameters", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -534,12 +538,12 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       new Request(`http://localhost:1234${basePath}/api/example?param=1`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `http://localhost:1234${basePath}/api/example/?param=1`,
     );
   });
 
-  it('should redirect the home to the correct locale and trailingSlash', async () => {
+  it("should redirect the home to the correct locale and trailingSlash", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -551,10 +555,10 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       new Request(`http://localhost:1234${basePath}/`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(`${basePath}/es/`);
+    expect(response.headers.get("Location")).toBe(`${basePath}/es/`);
   });
 
-  it('should redirect the home to the correct locale and trailingSlash with params', async () => {
+  it("should redirect the home to the correct locale and trailingSlash with params", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -566,42 +570,42 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       new Request(`http://localhost:1234${basePath}/?param=1`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(`${basePath}/es/?param=1`);
+    expect(response.headers.get("Location")).toBe(`${basePath}/es/?param=1`);
   });
 
-  it('should redirect to the correct locale', async () => {
+  it("should redirect to the correct locale", async () => {
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(`${basePath}/es/somepage`);
+    expect(response.headers.get("Location")).toBe(`${basePath}/es/somepage`);
   });
 
-  it('should redirect to the correct browser locale', async () => {
+  it("should redirect to the correct browser locale", async () => {
     const req = new Request(`http://localhost:1234${basePath}/somepage`);
 
-    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
+    req.headers.set("Accept-Language", "en-US,en;q=0.5");
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(`${basePath}/en/somepage`);
+    expect(response.headers.get("Location")).toBe(`${basePath}/en/somepage`);
   });
 
-  it('should redirect to the correct default locale of the subdomain', async () => {
+  it("should redirect to the correct default locale of the subdomain", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
       I18N_CONFIG: {
-        locales: ['en', 'es'],
-        defaultLocale: 'es',
+        locales: ["en", "es"],
+        defaultLocale: "es",
         domains: {
-          'en.test.com': {
-            defaultLocale: 'en',
-            protocol: 'https',
+          "en.test.com": {
+            defaultLocale: "en",
+            protocol: "https",
           },
-          'es.test.com': {
-            defaultLocale: 'es',
-            protocol: 'http',
+          "es.test.com": {
+            defaultLocale: "es",
+            protocol: "http",
           },
         },
       },
@@ -616,28 +620,28 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `https://en.test.com${basePath}/en/somepage`,
     );
     expect(responseEs.status).toBe(301);
-    expect(responseEs.headers.get('Location')).toBe(
+    expect(responseEs.headers.get("Location")).toBe(
       `http://es.test.com${basePath}/es/somepage`,
     );
   });
 
-  it('should redirect to the correct browser locale changing the subdomain', async () => {
+  it("should redirect to the correct browser locale changing the subdomain", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
       I18N_CONFIG: {
-        locales: ['en', 'es'],
-        defaultLocale: 'es',
+        locales: ["en", "es"],
+        defaultLocale: "es",
         domains: {
-          'en.test.com': {
-            defaultLocale: 'en',
+          "en.test.com": {
+            defaultLocale: "en",
           },
-          'es.test.com': {
-            defaultLocale: 'es',
+          "es.test.com": {
+            defaultLocale: "es",
           },
         },
       },
@@ -645,33 +649,33 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const req = new Request(`https://es.test.com${basePath}/somepage`);
 
-    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
+    req.headers.set("Accept-Language", "en-US,en;q=0.5");
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `https://en.test.com${basePath}/en/somepage`,
     );
   });
 
-  it('should redirect to the correct browser locale changing the subdomain and the page route name', async () => {
+  it("should redirect to the correct browser locale changing the subdomain and the page route name", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
       I18N_CONFIG: {
-        locales: ['en', 'es'],
-        defaultLocale: 'es',
+        locales: ["en", "es"],
+        defaultLocale: "es",
         domains: {
-          'en.test.com': {
-            defaultLocale: 'en',
+          "en.test.com": {
+            defaultLocale: "en",
           },
-          'es.test.com': {
-            defaultLocale: 'es',
+          "es.test.com": {
+            defaultLocale: "es",
           },
         },
         pages: {
-          '/somepage': {
-            en: '/somepage-en',
+          "/somepage": {
+            en: "/somepage-en",
           },
         },
       },
@@ -679,33 +683,33 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const req = new Request(`https://es.test.com${basePath}/somepage`);
 
-    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
+    req.headers.set("Accept-Language", "en-US,en;q=0.5");
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `https://en.test.com${basePath}/en/somepage-en`,
     );
   });
 
-  it('should redirect to the correct browser locale changing the subdomain and the page route name with hash', async () => {
+  it("should redirect to the correct browser locale changing the subdomain and the page route name with hash", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
       I18N_CONFIG: {
-        locales: ['en', 'es'],
-        defaultLocale: 'es',
+        locales: ["en", "es"],
+        defaultLocale: "es",
         domains: {
-          'en.test.com': {
-            defaultLocale: 'en',
+          "en.test.com": {
+            defaultLocale: "en",
           },
-          'es.test.com': {
-            defaultLocale: 'es',
+          "es.test.com": {
+            defaultLocale: "es",
           },
         },
         pages: {
-          '/somepage': {
-            en: '/somepage-en',
+          "/somepage": {
+            en: "/somepage-en",
           },
         },
       },
@@ -713,16 +717,16 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const req = new Request(`https://es.test.com${basePath}/somepage#hash`);
 
-    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
+    req.headers.set("Accept-Language", "en-US,en;q=0.5");
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `https://en.test.com${basePath}/en/somepage-en#hash`,
     );
   });
 
-  it('should redirect to the correct browser locale changing the subdomain, adding trailing slash and translating the route name', async () => {
+  it("should redirect to the correct browser locale changing the subdomain, adding trailing slash and translating the route name", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -731,19 +735,19 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
         trailingSlash: true,
       },
       I18N_CONFIG: {
-        locales: ['en', 'es'],
-        defaultLocale: 'es',
+        locales: ["en", "es"],
+        defaultLocale: "es",
         domains: {
-          'en.test.com': {
-            defaultLocale: 'en',
+          "en.test.com": {
+            defaultLocale: "en",
           },
-          'es.test.com': {
-            defaultLocale: 'es',
+          "es.test.com": {
+            defaultLocale: "es",
           },
         },
         pages: {
-          '/somepage': {
-            en: '/somepage-en',
+          "/somepage": {
+            en: "/somepage-en",
           },
         },
       },
@@ -751,28 +755,28 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const req = new Request(`https://es.test.com${basePath}/somepage`);
 
-    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
+    req.headers.set("Accept-Language", "en-US,en;q=0.5");
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `https://en.test.com${basePath}/en/somepage-en/`,
     );
   });
 
-  it('should redirect to the correct browser locale without changing the subdomain in development', async () => {
+  it("should redirect to the correct browser locale without changing the subdomain in development", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       I18N_CONFIG: {
-        locales: ['en', 'es'],
-        defaultLocale: 'es',
+        locales: ["en", "es"],
+        defaultLocale: "es",
         domains: {
-          'en.test.com': {
-            defaultLocale: 'en',
+          "en.test.com": {
+            defaultLocale: "en",
           },
-          'es.test.com': {
-            defaultLocale: 'es',
+          "es.test.com": {
+            defaultLocale: "es",
           },
         },
       },
@@ -780,27 +784,27 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const req = new Request(`http://localhost:1234${basePath}/somepage`);
 
-    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
+    req.headers.set("Accept-Language", "en-US,en;q=0.5");
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(`${basePath}/en/somepage`);
+    expect(response.headers.get("Location")).toBe(`${basePath}/en/somepage`);
   });
 
-  it('should redirect to the correct browser locale and changing the subdomain in development', async () => {
+  it("should redirect to the correct browser locale and changing the subdomain in development", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       I18N_CONFIG: {
-        locales: ['en', 'es'],
-        defaultLocale: 'es',
+        locales: ["en", "es"],
+        defaultLocale: "es",
         domains: {
-          'en.test.com': {
-            defaultLocale: 'en',
+          "en.test.com": {
+            defaultLocale: "en",
             dev: true,
           },
-          'es.test.com': {
-            defaultLocale: 'es',
+          "es.test.com": {
+            defaultLocale: "es",
             dev: true,
           },
         },
@@ -809,16 +813,16 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const req = new Request(`http://localhost:1234${basePath}/somepage`);
 
-    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
+    req.headers.set("Accept-Language", "en-US,en;q=0.5");
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `https://en.test.com${basePath}/en/somepage`,
     );
   });
 
-  it('should redirect to the correct browser locale changing the subdomain and trailingSlash', async () => {
+  it("should redirect to the correct browser locale changing the subdomain and trailingSlash", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -827,15 +831,15 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
         trailingSlash: true,
       },
       I18N_CONFIG: {
-        locales: ['en', 'es'],
-        defaultLocale: 'es',
+        locales: ["en", "es"],
+        defaultLocale: "es",
         domains: {
-          'en.test.com': {
-            defaultLocale: 'en',
-            protocol: 'http',
+          "en.test.com": {
+            defaultLocale: "en",
+            protocol: "http",
           },
-          'es.test.com': {
-            defaultLocale: 'es',
+          "es.test.com": {
+            defaultLocale: "es",
           },
         },
       },
@@ -843,16 +847,16 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const req = new Request(`http://es.test.com${basePath}/somepage`);
 
-    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
+    req.headers.set("Accept-Language", "en-US,en;q=0.5");
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `http://en.test.com${basePath}/en/somepage/`,
     );
   });
 
-  it('should redirect with trailingSlash', async () => {
+  it("should redirect with trailingSlash", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -864,12 +868,12 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       new Request(`http://localhost:1234${basePath}/es/somepage`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(
+    expect(response.headers.get("Location")).toBe(
       `http://localhost:1234${basePath}/es/somepage/`,
     );
   });
 
-  it('should redirect with locale and trailingSlash', async () => {
+  it("should redirect with locale and trailingSlash", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -881,32 +885,32 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       new Request(`http://localhost:1234${basePath}/somepage`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get('Location')).toBe(`${basePath}/es/somepage/`);
+    expect(response.headers.get("Location")).toBe(`${basePath}/es/somepage/`);
   });
 
-  it('should return a page with layout and i18n', async () => {
+  it("should return a page with layout and i18n", async () => {
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`),
     );
     const html = await response.text();
     expect(response.status).toBe(200);
-    expect(html).toStartWith('<!DOCTYPE html>');
+    expect(html).toStartWith("<!DOCTYPE html>");
     expect(html).toContain('<html lang="es" dir="ltr">');
     expect(html).toContain('<title id="title">CUSTOM LAYOUT</title>');
-    expect(html).toContain('<h1>Some page</h1>');
+    expect(html).toContain("<h1>Some page</h1>");
   });
 
-  it('should be possible to fetch an api route GET', async () => {
+  it("should be possible to fetch an api route GET", async () => {
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/example`),
     );
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ hello: 'world' });
+    expect(json).toEqual({ hello: "world" });
   });
 
-  it('should be possible to fetch an api route GET from root', async () => {
+  it("should be possible to fetch an api route GET from root", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -919,10 +923,10 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ hello: 'world' });
+    expect(json).toEqual({ hello: "world" });
   });
 
-  it('should be possible to fetch an api route POST from root', async () => {
+  it("should be possible to fetch an api route POST from root", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -931,44 +935,44 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/api`, {
-        method: 'POST',
-        body: JSON.stringify({ hello: 'world' }),
+        method: "POST",
+        body: JSON.stringify({ hello: "world" }),
       }),
     );
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ hello: 'world' });
+    expect(json).toEqual({ hello: "world" });
   });
 
-  it('should be possible to fetch an api route GET from root (with i18n)', async () => {
+  it("should be possible to fetch an api route GET from root (with i18n)", async () => {
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api`),
     );
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ hello: 'world' });
+    expect(json).toEqual({ hello: "world" });
   });
 
-  it('should be possible to fetch an api route POST from root (with i18n)', async () => {
+  it("should be possible to fetch an api route POST from root (with i18n)", async () => {
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api`, {
-        method: 'POST',
-        body: JSON.stringify({ hello: 'world' }),
+        method: "POST",
+        body: JSON.stringify({ hello: "world" }),
       }),
     );
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ hello: 'world' });
+    expect(json).toEqual({ hello: "world" });
   });
 
-  it('should not be possible to fetch an api route GET without the correct basePath', async () => {
+  it("should not be possible to fetch an api route GET without the correct basePath", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
-        basePath: '/incorrect',
+        basePath: "/incorrect",
       },
     };
     const response = await testRequest(
@@ -977,25 +981,25 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(response.status).toBe(404);
   });
 
-  it('should be possible to fetch an api route POST with a FormData', async () => {
+  it("should be possible to fetch an api route POST with a FormData", async () => {
     const body = new FormData();
 
-    body.append('name', 'Brisa');
-    body.append('email', 'test@brisa.com');
+    body.append("name", "Brisa");
+    body.append("email", "test@brisa.com");
 
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/example`, {
-        method: 'POST',
+        method: "POST",
         body,
       }),
     );
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ name: 'Brisa', email: 'test@brisa.com' });
+    expect(json).toEqual({ name: "Brisa", email: "test@brisa.com" });
   });
 
-  it('should return 404 page if the api route does not exist', async () => {
+  it("should return 404 page if the api route does not exist", async () => {
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/not-found`),
     );
@@ -1005,7 +1009,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      '<h1>Page not found 404 es<web-component></web-component></h1>',
+      "<h1>Page not found 404 es<web-component></web-component></h1>",
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
@@ -1013,11 +1017,11 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
   });
 
   it('should be possible to access to store variables from "x-s" store body', async () => {
-    const xs = [['foo', 'bar']];
+    const xs = [["foo", "bar"]];
     const options = {
-      method: 'POST',
+      method: "POST",
       body: JSON.stringify({
-        'x-s': xs,
+        "x-s": xs,
       }),
     };
     const req = new Request(
@@ -1027,7 +1031,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const res = await testRequest(req);
     const html = await res.text();
 
-    expect(req.store.get('foo')).toBe('bar');
+    expect(req.store.get("foo")).toBe("bar");
     expect(html).toContain(
       `<script type="application/json" id="S">[["foo","bar"]]</script>`,
     );
@@ -1035,13 +1039,13 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
   it('should remove the field "x-s" from form-data (Brisa internal field)', async () => {
     const formData = new FormData();
-    formData.append('foo', 'bar');
+    formData.append("foo", "bar");
 
     // Should ignore the "x-s" field
-    formData.append('x-s', '[["foo", "bar"]]');
+    formData.append("x-s", '[["foo", "bar"]]');
 
     const options = {
-      method: 'POST',
+      method: "POST",
       body: formData,
     };
     const req = new Request(
@@ -1051,8 +1055,8 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const res = await testRequest(req);
     const html = await res.text();
 
-    expect(req.store.get('foo')).toBe('bar');
-    expect(res.headers.get('x-reset')).toBeEmpty();
+    expect(req.store.get("foo")).toBe("bar");
+    expect(res.headers.get("x-reset")).toBeEmpty();
     expect(html).toContain(
       `<script type="application/json" id="S">[["foo","bar"]]</script>`,
     );
@@ -1060,10 +1064,10 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
   it('should form-data work with "x-s" store appended to the form-data"', async () => {
     const formData = new FormData();
-    formData.append('x-s', JSON.stringify([['foo', 'bar']]));
+    formData.append("x-s", JSON.stringify([["foo", "bar"]]));
 
     const options = {
-      method: 'POST',
+      method: "POST",
       body: formData,
     };
     const req = new Request(
@@ -1073,19 +1077,19 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const res = await testRequest(req);
     const html = await res.text();
 
-    expect(req.store.get('foo')).toBe('bar');
-    expect(res.headers.get('x-reset')).toBeEmpty();
+    expect(req.store.get("foo")).toBe("bar");
+    expect(res.headers.get("x-reset")).toBeEmpty();
     expect(html).toContain(
       `<script type="application/json" id="S">[["foo","bar"]]</script>`,
     );
   });
 
   it('should decrypt the store variables from "x-s" store that starts with ENCRYPT_PREFIX', async () => {
-    const xs = [['sensitive-data', encrypt('foo')]];
+    const xs = [["sensitive-data", encrypt("foo")]];
     const options = {
-      method: 'POST',
+      method: "POST",
       body: JSON.stringify({
-        'x-s': xs,
+        "x-s": xs,
       }),
     };
     const request = new Request(
@@ -1095,18 +1099,18 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const response = await testRequest(request);
     const html = await response.text();
 
-    expect(request.store.get('sensitive-data')).toEqual('foo');
+    expect(request.store.get("sensitive-data")).toEqual("foo");
     expect(html).toContain(
       `<script type="application/json" id="S">[["sensitive-data","${ENCRYPT_PREFIX}`,
     );
   });
 
   it('should decrypt the store variables from "x-s" body that starts with ENCRYPT_NONTEXT_PREFIX', async () => {
-    const xs = [['sensitive-data', encrypt({ foo: 'bar' })]];
+    const xs = [["sensitive-data", encrypt({ foo: "bar" })]];
     const options = {
-      method: 'POST',
+      method: "POST",
       body: JSON.stringify({
-        'x-s': xs,
+        "x-s": xs,
       }),
     };
     const request = new Request(
@@ -1116,17 +1120,17 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const response = await testRequest(request);
     const html = await response.text();
 
-    expect(request.store.get('sensitive-data')).toEqual({ foo: 'bar' });
+    expect(request.store.get("sensitive-data")).toEqual({ foo: "bar" });
     expect(html).toContain(
       `<script type="application/json" id="S">[["sensitive-data","${ENCRYPT_NONTEXT_PREFIX}`,
     );
   });
 
-  it('should emojis work inside store', async () => {
+  it("should emojis work inside store", async () => {
     const options = {
-      method: 'POST',
+      method: "POST",
       body: JSON.stringify({
-        'x-s': [['sensitive-data', '👍']],
+        "x-s": [["sensitive-data", "👍"]],
       }),
     };
     const request = new Request(
@@ -1136,7 +1140,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const response = await testRequest(request);
     const html = await response.text();
 
-    expect(request.store.get('sensitive-data')).toBe('👍');
+    expect(request.store.get("sensitive-data")).toBe("👍");
     expect(html).toContain(
       `<script type="application/json" id="S">[["sensitive-data","👍"]]</script>`,
     );
@@ -1144,14 +1148,14 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
   it('should log and render an error if the decryption fails from "x-s" store body', async () => {
     const options = {
-      method: 'POST',
+      method: "POST",
       body: JSON.stringify({
-        'x-s': [
-          ['sensitive-data', ENCRYPT_NONTEXT_PREFIX + 'invalid-encrypted-data'],
+        "x-s": [
+          ["sensitive-data", ENCRYPT_NONTEXT_PREFIX + "invalid-encrypted-data"],
         ],
       }),
     };
-    const mockLog = spyOn(console, 'log');
+    const mockLog = spyOn(console, "log");
     const request = new Request(
       `http:///localhost:1234${basePath}/es/page-with-web-component`,
       options,
@@ -1166,14 +1170,14 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(mockLog).toHaveBeenCalled();
   });
 
-  it('should clear the context store', async () => {
+  it("should clear the context store", async () => {
     const options = {
-      method: 'POST',
+      method: "POST",
       body: JSON.stringify({
-        'x-s': [
-          ['context:0:1:0', 'foo'],
-          ['context:0:1:1', 'bar'],
-          ['foo', 'bar'],
+        "x-s": [
+          ["context:0:1:0", "foo"],
+          ["context:0:1:1", "bar"],
+          ["foo", "bar"],
         ],
       }),
     };
@@ -1190,14 +1194,14 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
   });
 
-  it('should clear the context store', async () => {
+  it("should clear the context store", async () => {
     const options = {
-      method: 'POST',
+      method: "POST",
       body: JSON.stringify({
-        'x-s': [
-          ['context:0:1:0', 'foo'],
-          ['context:0:1:1', 'bar'],
-          ['foo', 'bar'],
+        "x-s": [
+          ["context:0:1:0", "foo"],
+          ["context:0:1:1", "bar"],
+          ["foo", "bar"],
         ],
       }),
     };
@@ -1214,10 +1218,10 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
   });
 
-  it('should return 404 page if the api route exist but the method does not', async () => {
+  it("should return 404 page if the api route exist but the method does not", async () => {
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/example`, {
-        method: 'PUT',
+        method: "PUT",
       }),
     );
     const html = await response.text();
@@ -1226,14 +1230,14 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      '<h1>Page not found 404 es<web-component></web-component></h1>',
+      "<h1>Page not found 404 es<web-component></web-component></h1>",
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
-  it('should return an asset in gzip if the browser accept it', async () => {
+  it("should return an asset in gzip if the browser accept it", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1242,12 +1246,12 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
         assetCompression: true,
       },
     };
-    const textDecoder = new TextDecoder('utf-8');
+    const textDecoder = new TextDecoder("utf-8");
     const req = new Request(
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          'accept-encoding': 'gzip',
+          "accept-encoding": "gzip",
         },
       },
     );
@@ -1256,15 +1260,15 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const text = textDecoder.decode(textBuffer);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-encoding')).toBe('gzip');
-    expect(response.headers.get('vary')).toBe('Accept-Encoding');
-    expect(response.headers.get('content-type')).toBe(
-      'text/plain;charset=utf-8',
+    expect(response.headers.get("content-encoding")).toBe("gzip");
+    expect(response.headers.get("vary")).toBe("Accept-Encoding");
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain;charset=utf-8",
     );
-    expect(text).toBe('Some text :D');
+    expect(text).toBe("Some text :D");
   });
 
-  it('should not return in DEVELOPMENT an asset in gzip', async () => {
+  it("should not return in DEVELOPMENT an asset in gzip", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
@@ -1277,21 +1281,21 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          'accept-encoding': 'gzip',
+          "accept-encoding": "gzip",
         },
       },
     );
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-encoding')).toBe(null);
-    expect(response.headers.get('vary')).toBe(null);
-    expect(response.headers.get('content-type')).toBe(
-      'text/plain;charset=utf-8',
+    expect(response.headers.get("content-encoding")).toBe(null);
+    expect(response.headers.get("vary")).toBe(null);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain;charset=utf-8",
     );
   });
 
-  it('should not return in PRODUCTION an asset in zip when CONFIG.assetCompression is false', async () => {
+  it("should not return in PRODUCTION an asset in zip when CONFIG.assetCompression is false", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1304,17 +1308,17 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          'accept-encoding': 'gzip',
+          "accept-encoding": "gzip",
         },
       },
     );
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-encoding')).toBe(null);
-    expect(response.headers.get('vary')).toBe(null);
-    expect(response.headers.get('content-type')).toBe(
-      'text/plain;charset=utf-8',
+    expect(response.headers.get("content-encoding")).toBe(null);
+    expect(response.headers.get("vary")).toBe(null);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain;charset=utf-8",
     );
   });
 
@@ -1327,12 +1331,12 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
         assetCompression: true,
       },
     };
-    const textDecoder = new TextDecoder('utf-8');
+    const textDecoder = new TextDecoder("utf-8");
     const req = new Request(
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          'accept-encoding': 'br',
+          "accept-encoding": "br",
         },
       },
     );
@@ -1343,15 +1347,15 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const text = textDecoder.decode(textBuffer);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-encoding')).toBe('br');
-    expect(response.headers.get('vary')).toBe('Accept-Encoding');
-    expect(response.headers.get('content-type')).toBe(
-      'text/plain;charset=utf-8',
+    expect(response.headers.get("content-encoding")).toBe("br");
+    expect(response.headers.get("vary")).toBe("Accept-Encoding");
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain;charset=utf-8",
     );
-    expect(text).toBe('Some text :D');
+    expect(text).toBe("Some text :D");
   });
 
-  it('should not return in DEVELOPMENT an asset in brotli', async () => {
+  it("should not return in DEVELOPMENT an asset in brotli", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
@@ -1364,21 +1368,21 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          'accept-encoding': 'br',
+          "accept-encoding": "br",
         },
       },
     );
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-encoding')).toBe(null);
-    expect(response.headers.get('vary')).toBe(null);
-    expect(response.headers.get('content-type')).toBe(
-      'text/plain;charset=utf-8',
+    expect(response.headers.get("content-encoding")).toBe(null);
+    expect(response.headers.get("vary")).toBe(null);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain;charset=utf-8",
     );
   });
 
-  it('should not return in PRODUCTION an asset in brotli when CONFIG.assetCompression is false', async () => {
+  it("should not return in PRODUCTION an asset in brotli when CONFIG.assetCompression is false", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1391,32 +1395,32 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          'accept-encoding': 'br',
+          "accept-encoding": "br",
         },
       },
     );
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-encoding')).toBe(null);
-    expect(response.headers.get('vary')).toBe(null);
-    expect(response.headers.get('content-type')).toBe(
-      'text/plain;charset=utf-8',
+    expect(response.headers.get("content-encoding")).toBe(null);
+    expect(response.headers.get("vary")).toBe(null);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain;charset=utf-8",
     );
   });
 
-  it('should not return an asset with incorrect basePath', async () => {
+  it("should not return an asset with incorrect basePath", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
-        basePath: '/incorrect',
+        basePath: "/incorrect",
       },
     };
     const req = new Request(
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          'accept-encoding': 'gzip',
+          "accept-encoding": "gzip",
         },
       },
     );
@@ -1424,7 +1428,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(response.status).toBe(404);
   });
 
-  it('should src/pages/user/[username].tsx dynamic page work', async () => {
+  it("should src/pages/user/[username].tsx dynamic page work", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1434,13 +1438,13 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toBe(
-      'text/html; charset=utf-8',
+    expect(response.headers.get("content-type")).toBe(
+      "text/html; charset=utf-8",
     );
-    expect(response.text()).resolves.toContain('<div>user</div>');
+    expect(response.text()).resolves.toContain("<div>user</div>");
   });
 
-  it('should prefer src/public/user/static.js asset than src/pages/user/[username].tsx page', async () => {
+  it("should prefer src/public/user/static.js asset than src/pages/user/[username].tsx page", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1450,13 +1454,13 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toBe(
-      'application/javascript;charset=utf-8',
+    expect(response.headers.get("content-type")).toBe(
+      "application/javascript;charset=utf-8",
     );
     expect(response.text()).resolves.toContain("console.log('from public')");
   });
 
-  it('should prefer src/public/user/static.js asset than src/pages/user/[username].tsx page (without .js ext)', async () => {
+  it("should prefer src/public/user/static.js asset than src/pages/user/[username].tsx page (without .js ext)", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1466,21 +1470,21 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toBe(
-      'application/javascript;charset=utf-8',
+    expect(response.headers.get("content-type")).toBe(
+      "application/javascript;charset=utf-8",
     );
     expect(response.text()).resolves.toContain("console.log('from public')");
   });
 
-  it('should cache client page code in production', async () => {
+  it("should cache client page code in production", async () => {
     globalThis.mockConstants = {
       ...getConstants(),
       IS_PRODUCTION: true,
       HEADERS: {
-        CACHE_CONTROL: 'public, max-age=31536000, immutable',
+        CACHE_CONTROL: "public, max-age=31536000, immutable",
       },
     };
-    const mockFile = spyOn(Bun, 'file').mockImplementation(
+    const mockFile = spyOn(Bun, "file").mockImplementation(
       () =>
         ({
           text: (pathname: string) => Promise.resolve(pathname),
@@ -1492,13 +1496,13 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     mockFile.mockRestore();
     expect(response.status).toBe(200);
-    expect(response.headers.get('cache-control')).toBe(
-      'public, max-age=31536000, immutable',
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable",
     );
   });
 
-  it('should not cache client page code in development', async () => {
-    const mockFile = spyOn(Bun, 'file').mockImplementation(
+  it("should not cache client page code in development", async () => {
+    const mockFile = spyOn(Bun, "file").mockImplementation(
       () =>
         ({
           text: (pathname: string) => Promise.resolve(pathname),
@@ -1510,26 +1514,26 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     mockFile.mockRestore();
     expect(response.status).toBe(200);
-    expect(response.headers.get('cache-control')).toBe(
-      'no-store, must-revalidate',
+    expect(response.headers.get("cache-control")).toBe(
+      "no-store, must-revalidate",
     );
   });
 
   it('should subscribe to hotload when "open" the websocket connection in development', async () => {
     const serverOptions = await (
-      await import('./serve-options')
+      await import("./serve-options")
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
     const mockSubscribe = mock(() => {});
     const ws = {
-      data: { id: '1234' },
+      data: { id: "1234" },
       subscribe: mockSubscribe,
     } as unknown as ServerWebSocket;
 
     socket.open(ws);
 
-    expect(mockSubscribe).toHaveBeenCalledWith('hot-reload');
+    expect(mockSubscribe).toHaveBeenCalledWith("hot-reload");
   });
 
   it('should NOT subscribe to hotload when "open" the websocket connection in production', async () => {
@@ -1539,13 +1543,13 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     };
 
     const serverOptions = await (
-      await import('./serve-options')
+      await import("./serve-options")
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
     const mockSubscribe = mock(() => {});
     const ws = {
-      data: { id: '1234' },
+      data: { id: "1234" },
       subscribe: mockSubscribe,
     } as unknown as ServerWebSocket;
 
@@ -1556,36 +1560,36 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
   it('should call the "open" method of the websocket module', async () => {
     const serverOptions = await (
-      await import('./serve-options')
+      await import("./serve-options")
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
-    const mockLog = spyOn(console, 'log');
+    const mockLog = spyOn(console, "log");
     const ws = {
-      data: { id: '1234' },
+      data: { id: "1234" },
       subscribe: () => {},
     } as unknown as ServerWebSocket;
 
     socket.open(ws);
 
-    expect(mockLog).toHaveBeenCalledWith('open');
+    expect(mockLog).toHaveBeenCalledWith("open");
   });
 
   it('should unsubscribe to hotload when "close" the websocket connection in development', async () => {
     const serverOptions = await (
-      await import('./serve-options')
+      await import("./serve-options")
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
     const mockUnsubscribe = mock(() => {});
     const ws = {
-      data: { id: '1234' },
+      data: { id: "1234" },
       unsubscribe: mockUnsubscribe,
     } as unknown as ServerWebSocket;
 
     socket.close(ws);
 
-    expect(mockUnsubscribe).toHaveBeenCalledWith('hot-reload');
+    expect(mockUnsubscribe).toHaveBeenCalledWith("hot-reload");
   });
 
   it('should NOT unsubscribe to hotload when "close" the websocket connection in production', async () => {
@@ -1595,13 +1599,13 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     };
 
     const serverOptions = await (
-      await import('./serve-options')
+      await import("./serve-options")
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
     const mockUnsubscribe = mock(() => {});
     const ws = {
-      data: { id: '1234' },
+      data: { id: "1234" },
       unsubscribe: mockUnsubscribe,
     } as unknown as ServerWebSocket;
 
@@ -1612,53 +1616,53 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
   it('should call the "close" method of the websocket module', async () => {
     const serverOptions = await (
-      await import('./serve-options')
+      await import("./serve-options")
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
-    const mockLog = spyOn(console, 'log');
+    const mockLog = spyOn(console, "log");
     const ws = {
-      data: { id: '1234' },
+      data: { id: "1234" },
       unsubscribe: () => {},
     } as unknown as ServerWebSocket;
 
     socket.close(ws);
 
-    expect(mockLog).toHaveBeenCalledWith('close');
+    expect(mockLog).toHaveBeenCalledWith("close");
   });
 
   it('should call the "drain" method of the websocket module', async () => {
     const serverOptions = await (
-      await import('./serve-options')
+      await import("./serve-options")
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
-    const mockLog = spyOn(console, 'log');
+    const mockLog = spyOn(console, "log");
     const ws = {
-      data: { id: '1234' },
+      data: { id: "1234" },
       subscribe: () => {},
     } as unknown as ServerWebSocket;
 
     socket.drain(ws);
 
-    expect(mockLog).toHaveBeenCalledWith('drain');
+    expect(mockLog).toHaveBeenCalledWith("drain");
   });
 
   it('should call the "message" method of the websocket module', async () => {
     const serverOptions = await (
-      await import('./serve-options')
+      await import("./serve-options")
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
-    const mockLog = spyOn(console, 'log');
+    const mockLog = spyOn(console, "log");
     const ws = {
-      data: { id: '1234' },
+      data: { id: "1234" },
       subscribe: () => {},
     } as unknown as ServerWebSocket;
 
-    socket.message(ws, 'hello test');
+    socket.message(ws, "hello test");
 
-    expect(mockLog).toHaveBeenCalledWith('message', 'hello test');
+    expect(mockLog).toHaveBeenCalledWith("message", "hello test");
   });
 
   it('should have req.initiator with "SERVER_ACTION" when is POST method and has x-action header', async () => {
@@ -1669,15 +1673,15 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       I18N_CONFIG: undefined,
     };
 
-    mock.module('@/utils/response-action', () => ({
+    mock.module("@/utils/response-action", () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'x-action': 'a1_1',
+          "x-action": "a1_1",
         },
       }),
     );
@@ -1690,15 +1694,15 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
   it('should have req.initiator with "SERVER_ACTION" when is POST method and has x-action header and i18n', async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
-    mock.module('@/utils/response-action', () => ({
+    mock.module("@/utils/response-action", () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'x-action': 'a1_1',
+          "x-action": "a1_1",
         },
       }),
     );
@@ -1708,34 +1712,34 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
   });
 
-  it('should the response action receive the formData', async () => {
+  it("should the response action receive the formData", async () => {
     const mockResponseAction = mock(
       (req: RequestContext, content: RequestContent) => {},
     );
     const formData = new FormData();
-    formData.append('foo', 'bar');
-    formData.append('x-s', '[["some", "value"]]');
+    formData.append("foo", "bar");
+    formData.append("x-s", '[["some", "value"]]');
 
-    mock.module('@/utils/response-action', () => ({
+    mock.module("@/utils/response-action", () => ({
       default: (req: RequestContext, content: RequestContent) =>
         mockResponseAction(req, content),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`, {
-        method: 'POST',
+        method: "POST",
         body: formData,
         headers: {
-          'x-action': 'a1_1',
+          "x-action": "a1_1",
         },
       }),
     );
 
     const [req, reqContent] = mockResponseAction.mock.calls[0];
 
-    expect(req.store.get('some')).toBe('value');
+    expect(req.store.get("some")).toBe("value");
     expect(Array.from(reqContent.formData!.entries())).toEqual([
-      ['foo', 'bar'],
+      ["foo", "bar"],
     ]);
   });
 
@@ -1747,25 +1751,25 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: 'POST',
-        body: '{}',
+        method: "POST",
+        body: "{}",
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get('x-initiator')).toBe(Initiator.SPA_NAVIGATION);
+    expect(res.headers.get("x-initiator")).toBe(Initiator.SPA_NAVIGATION);
   });
 
   it('should have req.initiator with "SPA_NAVIGATION" when the Page is POST method without x-action header and i18n', async () => {
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`, {
-        method: 'POST',
-        body: '{}',
+        method: "POST",
+        body: "{}",
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get('x-initiator')).toBe(Initiator.SPA_NAVIGATION);
+    expect(res.headers.get("x-initiator")).toBe(Initiator.SPA_NAVIGATION);
   });
 
   it('should have req.initiator with "INITIAL_REQUEST" when the Page is GET method', async () => {
@@ -1776,23 +1780,23 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: 'GET',
+        method: "GET",
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get('x-initiator')).toBe(Initiator.INITIAL_REQUEST);
+    expect(res.headers.get("x-initiator")).toBe(Initiator.INITIAL_REQUEST);
   });
 
   it('should have req.initiator with "INITIAL_REQUEST" when the Page is GET method and i18n', async () => {
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`, {
-        method: 'GET',
+        method: "GET",
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get('x-initiator')).toBe(Initiator.INITIAL_REQUEST);
+    expect(res.headers.get("x-initiator")).toBe(Initiator.INITIAL_REQUEST);
   });
 
   it('should have req.initiator with "API_REQUEST" when is POST method and is an API endpoint', async () => {
@@ -1802,35 +1806,35 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     };
     const body = new FormData();
 
-    body.append('name', 'Brisa');
-    body.append('email', 'test@brisa.com');
+    body.append("name", "Brisa");
+    body.append("email", "test@brisa.com");
 
     const res = await testRequest(
       new Request(`http:///localhost:1234${basePath}/api/example`, {
-        method: 'POST',
+        method: "POST",
         body,
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get('x-initiator')).toBe(Initiator.API_REQUEST);
+    expect(res.headers.get("x-initiator")).toBe(Initiator.API_REQUEST);
   });
 
   it('should have req.initiator with "API_REQUEST" when is POST method and is an API endpoint and i18n', async () => {
     const body = new FormData();
 
-    body.append('name', 'Brisa');
-    body.append('email', 'test@brisa.com');
+    body.append("name", "Brisa");
+    body.append("email", "test@brisa.com");
 
     const res = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/example`, {
-        method: 'POST',
+        method: "POST",
         body,
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get('x-initiator')).toBe(Initiator.API_REQUEST);
+    expect(res.headers.get("x-initiator")).toBe(Initiator.API_REQUEST);
   });
 
   it('should have req.initiator with "API_REQUEST" when is POST method and is an API endpoint with x-action header', async () => {
@@ -1840,84 +1844,84 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     };
     const body = new FormData();
 
-    body.append('name', 'Brisa');
-    body.append('email', 'test@brisa.com');
+    body.append("name", "Brisa");
+    body.append("email", "test@brisa.com");
 
     const res = await testRequest(
       new Request(`http:///localhost:1234${basePath}/api/example`, {
-        method: 'POST',
+        method: "POST",
         body,
         headers: {
-          'x-action': 'a1_1',
+          "x-action": "a1_1",
         },
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get('x-initiator')).toBe(Initiator.API_REQUEST);
+    expect(res.headers.get("x-initiator")).toBe(Initiator.API_REQUEST);
   });
 
   it('should have req.initiator with "API_REQUEST" when is POST method and is an API endpoint with x-action header and i18n', async () => {
     const body = new FormData();
 
-    body.append('name', 'Brisa');
-    body.append('email', 'test@brisa.com');
+    body.append("name", "Brisa");
+    body.append("email", "test@brisa.com");
 
     const res = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/example`, {
-        method: 'POST',
+        method: "POST",
         body,
         headers: {
-          'x-action': 'a1_1',
+          "x-action": "a1_1",
         },
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get('x-initiator')).toBe(Initiator.API_REQUEST);
+    expect(res.headers.get("x-initiator")).toBe(Initiator.API_REQUEST);
   });
 
-  it('should NOT call responseAction method with GET and return 200 with the page', async () => {
+  it("should NOT call responseAction method with GET and return 200 with the page", async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
     };
-    mock.module('@/utils/response-action', () => ({
+    mock.module("@/utils/response-action", () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: 'GET',
+        method: "GET",
         headers: {
-          'x-action': 'a1_1',
+          "x-action": "a1_1",
         },
       }),
     );
 
     expect(mockResponseAction).not.toHaveBeenCalled();
     expect(res.status).toBe(200);
-    expect(await res.text()).toContain('<h1>Some page</h1>');
+    expect(await res.text()).toContain("<h1>Some page</h1>");
   });
 
-  it('should call responseAction method when is an action', async () => {
+  it("should call responseAction method when is an action", async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
     };
-    mock.module('@/utils/response-action', () => ({
+    mock.module("@/utils/response-action", () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'x-action': 'a1_1',
+          "x-action": "a1_1",
         },
       }),
     );
@@ -1926,68 +1930,68 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     expect(mockResponseAction.mock.calls[0][0].i18n.locale).toBeEmpty();
   });
 
-  it('should call responseAction method when is an action and has i18n', async () => {
+  it("should call responseAction method when is an action and has i18n", async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
-    mock.module('@/utils/response-action', () => ({
+    mock.module("@/utils/response-action", () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'x-action': 'a1_1',
+          "x-action": "a1_1",
         },
       }),
     );
 
     expect(mockResponseAction).toHaveBeenCalled();
-    expect(mockResponseAction.mock.calls[0][0].i18n.locale).toBe('es');
+    expect(mockResponseAction.mock.calls[0][0].i18n.locale).toBe("es");
   });
 
-  it('should open the editor calling /__brisa_dev_file__ with file, line and column', async () => {
+  it("should open the editor calling /__brisa_dev_file__ with file, line and column", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       IS_DEVELOPMENT: true,
     };
-    const mockOpenInEditor = spyOn(Bun, 'openInEditor').mockImplementation(
+    const mockOpenInEditor = spyOn(Bun, "openInEditor").mockImplementation(
       () => {},
     );
     const response = await testRequest(
       new Request(
         `http://localhost:1234/__brisa_dev_file__?file=${encodeURIComponent(
-          'src/pages/somepage.tsx',
+          "src/pages/somepage.tsx",
         )}&line=1&column=1`,
-        { method: 'POST' },
+        { method: "POST" },
       ),
     );
 
     expect(response.status).toBe(200);
-    expect(mockOpenInEditor).toHaveBeenCalledWith('src/pages/somepage.tsx', {
+    expect(mockOpenInEditor).toHaveBeenCalledWith("src/pages/somepage.tsx", {
       line: 1,
       column: 1,
     });
     mockOpenInEditor.mockRestore();
   });
 
-  it('should not call Bun.openInEditor in Node.js and return 404', async () => {
+  it("should not call Bun.openInEditor in Node.js and return 404", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       IS_DEVELOPMENT: true,
-      JS_RUNTIME: 'node',
+      JS_RUNTIME: "node",
     };
-    const mockOpenInEditor = spyOn(Bun, 'openInEditor').mockImplementation(
+    const mockOpenInEditor = spyOn(Bun, "openInEditor").mockImplementation(
       () => {},
     );
     const response = await testRequest(
       new Request(
         `http://localhost:1234/__brisa_dev_file__?file=${encodeURIComponent(
-          'src/pages/somepage.tsx',
+          "src/pages/somepage.tsx",
         )}&line=1&column=1`,
-        { method: 'POST' },
+        { method: "POST" },
       ),
     );
 
@@ -1996,22 +2000,22 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     mockOpenInEditor.mockRestore();
   });
 
-  it('should not call Bun.openInEditor in Deno and return 404', async () => {
+  it("should not call Bun.openInEditor in Deno and return 404", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       IS_DEVELOPMENT: true,
-      JS_RUNTIME: 'deno',
+      JS_RUNTIME: "deno",
     };
-    const mockOpenInEditor = spyOn(Bun, 'openInEditor').mockImplementation(
+    const mockOpenInEditor = spyOn(Bun, "openInEditor").mockImplementation(
       () => {},
     );
     const response = await testRequest(
       new Request(
         `http://localhost:1234/__brisa_dev_file__?file=${encodeURIComponent(
-          'src/pages/somepage.tsx',
+          "src/pages/somepage.tsx",
         )}&line=1&column=1`,
-        { method: 'POST' },
+        { method: "POST" },
       ),
     );
 
@@ -2020,28 +2024,28 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     mockOpenInEditor.mockRestore();
   });
 
-  it('should open the editor calling /__brisa_dev_file__ with internal brisa file from build with line and column', async () => {
+  it("should open the editor calling /__brisa_dev_file__ with internal brisa file from build with line and column", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       IS_DEVELOPMENT: true,
     };
-    const mockOpenInEditor = spyOn(Bun, 'openInEditor').mockImplementation(
+    const mockOpenInEditor = spyOn(Bun, "openInEditor").mockImplementation(
       () => {},
     );
     const inputFile = encodeURIComponent(
-      '/_brisa/pages/index-595519026220381824.js',
+      "/_brisa/pages/index-595519026220381824.js",
     );
     const expectedFile = path.resolve(
       BUILD_DIR,
-      'pages-client',
-      'index-595519026220381824.js',
+      "pages-client",
+      "index-595519026220381824.js",
     );
     const response = await testRequest(
       new Request(
         `http://localhost:1234/__brisa_dev_file__?file=${inputFile}&line=1&column=1`,
         {
-          method: 'POST',
+          method: "POST",
         },
       ),
     );
@@ -2054,21 +2058,21 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     mockOpenInEditor.mockRestore();
   });
 
-  it('should return 404 trying to open the editor calling /__brisa_dev_file__ with file, line and column with method GET', async () => {
+  it("should return 404 trying to open the editor calling /__brisa_dev_file__ with file, line and column with method GET", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       IS_DEVELOPMENT: true,
     };
-    const mockOpenInEditor = spyOn(Bun, 'openInEditor').mockImplementation(
+    const mockOpenInEditor = spyOn(Bun, "openInEditor").mockImplementation(
       () => {},
     );
     const response = await testRequest(
       new Request(
         `http://localhost:1234/__brisa_dev_file__?file=${encodeURIComponent(
-          'src/pages/somepage.tsx',
+          "src/pages/somepage.tsx",
         )}&line=1&column=1`,
-        { method: 'GET' },
+        { method: "GET" },
       ),
     );
 
@@ -2077,7 +2081,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     mockOpenInEditor.mockRestore();
   });
 
-  it('should work declarative shadow DOM on server actions when is form call without RPC', async () => {
+  it("should work declarative shadow DOM on server actions when is form call without RPC", async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
     globalThis.mockConstants = {
@@ -2085,15 +2089,15 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       I18N_CONFIG: undefined,
     };
 
-    mock.module('@/utils/response-action', () => ({
+    mock.module("@/utils/response-action", () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage?_aid=2`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'x-action': 'a1_1',
+          "x-action": "a1_1",
         },
       }),
     );
@@ -2105,7 +2109,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     ).toBeFalse();
   });
 
-  it('should return a soft redirect from an action', async () => {
+  it("should return a soft redirect from an action", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
@@ -2115,36 +2119,36 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       new Request(
         `http://localhost:1234${basePath}/somepage?_aid=2&redirect=/`,
         {
-          method: 'POST',
+          method: "POST",
           headers: {
-            'x-action': 'a1_1',
+            "x-action": "a1_1",
           },
         },
       ),
     );
 
     expect(res.status).toBe(200);
-    expect(res.headers.get('x-navigate')).toBe('/');
+    expect(res.headers.get("x-navigate")).toBe("/");
   });
 
-  it('should return a soft redirect from an action with i18n resolving the correct locale', async () => {
+  it("should return a soft redirect from an action with i18n resolving the correct locale", async () => {
     const res = await testRequest(
       new Request(
         `http://localhost:1234${basePath}/en/somepage?_aid=2&redirect=/`,
         {
-          method: 'POST',
+          method: "POST",
           headers: {
-            'x-action': 'a1_1',
+            "x-action": "a1_1",
           },
         },
       ),
     );
 
     expect(res.status).toBe(200);
-    expect(res.headers.get('x-navigate')).toBe('/en');
+    expect(res.headers.get("x-navigate")).toBe("/en");
   });
 
-  it('should return a soft redirect from an SPA navigation', async () => {
+  it("should return a soft redirect from an SPA navigation", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
@@ -2152,26 +2156,26 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
 
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage?redirect=/`, {
-        method: 'POST',
+        method: "POST",
       }),
     );
 
     expect(res.status).toBe(200);
-    expect(res.headers.get('x-navigate')).toBe('/');
+    expect(res.headers.get("x-navigate")).toBe("/");
   });
 
-  it('should return a soft redirect from an SPA Navigation with i18n resolving the correct locale', async () => {
+  it("should return a soft redirect from an SPA Navigation with i18n resolving the correct locale", async () => {
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/en/somepage?redirect=/`, {
-        method: 'POST',
+        method: "POST",
       }),
     );
 
     expect(res.status).toBe(200);
-    expect(res.headers.get('x-navigate')).toBe('/en');
+    expect(res.headers.get("x-navigate")).toBe("/en");
   });
 
-  it('should return a HARD redirect from an API endpoint', async () => {
+  it("should return a HARD redirect from an API endpoint", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
@@ -2182,19 +2186,19 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
 
     expect(res.status).toBe(301);
-    expect(res.headers.get('location')).toBe('/');
+    expect(res.headers.get("location")).toBe("/");
   });
 
-  it('should return a HARD redirect from an API endpoint with i18n resolving the correct locale', async () => {
+  it("should return a HARD redirect from an API endpoint with i18n resolving the correct locale", async () => {
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/en/api/example?redirect=/`),
     );
 
     expect(res.status).toBe(301);
-    expect(res.headers.get('location')).toBe('/en');
+    expect(res.headers.get("location")).toBe("/en");
   });
 
-  it('should return a HARD redirect from an initial render', async () => {
+  it("should return a HARD redirect from an initial render", async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
@@ -2205,19 +2209,19 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     );
 
     expect(res.status).toBe(301);
-    expect(res.headers.get('location')).toBe('/');
+    expect(res.headers.get("location")).toBe("/");
   });
 
-  it('should return a HARD redirect from an initial render with i18n resolving the correct locale', async () => {
+  it("should return a HARD redirect from an initial render with i18n resolving the correct locale", async () => {
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/en/somepage?redirect=/`),
     );
 
     expect(res.status).toBe(301);
-    expect(res.headers.get('location')).toBe('/en');
+    expect(res.headers.get("location")).toBe("/en");
   });
 
-  it('should avoid declarative shadow DOM on server actions', async () => {
+  it("should avoid declarative shadow DOM on server actions", async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
     globalThis.mockConstants = {
@@ -2225,15 +2229,15 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
       I18N_CONFIG: undefined,
     };
 
-    mock.module('@/utils/response-action', () => ({
+    mock.module("@/utils/response-action", () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'x-action': 'a1_1',
+          "x-action": "a1_1",
         },
       }),
     );
@@ -2245,7 +2249,7 @@ describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
     ).toBeTrue();
   });
 
-  it('should return idleTimeout as 30 ', async () => {
+  it("should return idleTimeout as 30 ", async () => {
     const serverOptions = await getServeOptions();
     expect(serverOptions!.idleTimeout).toBe(30);
   });

--- a/packages/brisa/src/cli/serve/serve-options.test.tsx
+++ b/packages/brisa/src/cli/serve/serve-options.test.tsx
@@ -1,4 +1,4 @@
-import type { BunFile, ServerWebSocket } from "bun";
+import type { BunFile, ServerWebSocket } from 'bun';
 import {
   afterEach,
   beforeEach,
@@ -8,35 +8,35 @@ import {
   spyOn,
   mock,
   jest,
-} from "bun:test";
-import { brotliDecompressSync, gunzipSync } from "node:zlib";
-import path from "node:path";
-import { getConstants } from "@/constants";
-import type { RequestContext } from "@/types";
-import { Initiator } from "@/public-constants";
-import { AVOID_DECLARATIVE_SHADOW_DOM_SYMBOL } from "@/utils/ssr-web-component";
-import { getServeOptions } from "./serve-options";
-import type { RequestContent } from "@/utils/transfer-store-service";
+} from 'bun:test';
+import { brotliDecompressSync, gunzipSync } from 'node:zlib';
+import path from 'node:path';
+import { getConstants } from '@/constants';
+import type { RequestContext } from '@/types';
+import { Initiator } from '@/public-constants';
+import { AVOID_DECLARATIVE_SHADOW_DOM_SYMBOL } from '@/utils/ssr-web-component';
+import { getServeOptions } from './serve-options';
+import type { RequestContent } from '@/utils/transfer-store-service';
 import {
   ENCRYPT_NONTEXT_PREFIX,
   encrypt,
   ENCRYPT_PREFIX,
-} from "@/utils/crypto";
+} from '@/utils/crypto';
 
 // @ts-ignore
-import middleware from "../../__fixtures__/middleware.ts";
+import middleware from '../../__fixtures__/middleware.ts';
 
-const BUILD_DIR = path.join(import.meta.dir, "..", "..", "__fixtures__");
-const PAGES_DIR = path.join(BUILD_DIR, "pages");
-const ASSETS_DIR = path.join(BUILD_DIR, "public");
-const BASE_PATHS = ["", "/some-dir", "/es", "/some/dir"];
+const BUILD_DIR = path.join(import.meta.dir, '..', '..', '__fixtures__');
+const PAGES_DIR = path.join(BUILD_DIR, 'pages');
+const ASSETS_DIR = path.join(BUILD_DIR, 'public');
+const BASE_PATHS = ['', '/some-dir', '/es', '/some/dir'];
 
 async function testRequest(
   request: Request,
   upgrade = false,
 ): Promise<Response> {
   const serveOptions = await (
-    await import("./serve-options")
+    await import('./serve-options')
   ).getServeOptions();
 
   return (
@@ -44,29 +44,29 @@ async function testRequest(
     ((await serveOptions.fetch(request, {
       requestIP: () => {},
       upgrade: () => upgrade,
-    })) || new Response("", { status: 101 })) as Response
+    })) || new Response('', { status: 101 })) as Response
   );
 }
 
 const __CRYPTO_KEY__ = process.env.__CRYPTO_KEY__;
 const __CRYPTO_IV__ = process.env.__CRYPTO_IV__;
 
-describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
+describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
   beforeEach(async () => {
-    mock.module("brisa-project-internals", () => ({ middleware }));
+    mock.module('brisa-project-internals', () => ({ middleware }));
 
     // @ts-ignore - We need to test real server scenarios
-    if (typeof window !== "undefined") window = undefined;
+    if (typeof window !== 'undefined') window = undefined;
     globalThis.mockConstants = {
       ...(getConstants() ?? {}),
       PAGES_DIR,
       BUILD_DIR,
       SRC_DIR: BUILD_DIR,
       ASSETS_DIR,
-      LOCALES_SET: new Set(["en", "es"]),
+      LOCALES_SET: new Set(['en', 'es']),
       I18N_CONFIG: {
-        locales: ["en", "es"],
-        defaultLocale: "es",
+        locales: ['en', 'es'],
+        defaultLocale: 'es',
       },
       CONFIG: {
         basePath,
@@ -76,72 +76,72 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
   });
 
   afterEach(() => {
-    globalThis.__BASE_PATH__ = "";
+    globalThis.__BASE_PATH__ = '';
     process.env.__CRYPTO_KEY__ = __CRYPTO_KEY__;
     process.env.__CRYPTO_IV__ = __CRYPTO_IV__;
-    process.env.BRISA_BUILD_FOLDER = "";
+    process.env.BRISA_BUILD_FOLDER = '';
     globalThis.mockConstants = undefined;
     delete process.argv[1];
     jest.restoreAllMocks();
   });
 
-  it("should set the env variables when they are not set for a custom server when no argument neither process.argv[1]", async () => {
-    await (await import("./serve-options")).setUpEnvVars();
+  it('should set the env variables when they are not set for a custom server when no argument neither process.argv[1]', async () => {
+    await (await import('./serve-options')).setUpEnvVars();
 
     expect(process.env.__CRYPTO_KEY__).toBeDefined();
     expect(process.env.__CRYPTO_IV__).toBeDefined();
     expect(process.env.BRISA_BUILD_FOLDER).toBe(
-      path.join(process.cwd(), "build"),
+      path.join(process.cwd(), 'build'),
     );
   });
 
-  it("should detect as isCLI false when process.argv[1] NOT include serve/index.js", async () => {
+  it('should detect as isCLI false when process.argv[1] NOT include serve/index.js', async () => {
     process.env.__CRYPTO_KEY__ = undefined;
     process.env.__CRYPTO_IV__ = undefined;
-    process.argv[1] = path.join("brisa", "out", "cli", "build", "index.js");
-    await (await import("./serve-options")).setUpEnvVars();
+    process.argv[1] = path.join('brisa', 'out', 'cli', 'build', 'index.js');
+    await (await import('./serve-options')).setUpEnvVars();
 
     expect(process.env.__CRYPTO_KEY__).toBeDefined();
     expect(process.env.__CRYPTO_IV__).toBeDefined();
     expect(process.env.BRISA_BUILD_FOLDER).toBe(
-      path.join(process.cwd(), "build"),
+      path.join(process.cwd(), 'build'),
     );
   });
 
-  it("should set the env variables when they are not set for a custom server", async () => {
+  it('should set the env variables when they are not set for a custom server', async () => {
     process.env.__CRYPTO_KEY__ = undefined;
     process.env.__CRYPTO_IV__ = undefined;
-    await (await import("./serve-options")).setUpEnvVars(false);
+    await (await import('./serve-options')).setUpEnvVars(false);
 
     expect(process.env.__CRYPTO_KEY__).toBeDefined();
     expect(process.env.__CRYPTO_IV__).toBeDefined();
     expect(process.env.BRISA_BUILD_FOLDER).toBe(
-      path.join(process.cwd(), "build"),
+      path.join(process.cwd(), 'build'),
     );
   });
 
-  it("should BRISA_BUILD_FOLDER env variable be defined always (to use prebuild)", async () => {
+  it('should BRISA_BUILD_FOLDER env variable be defined always (to use prebuild)', async () => {
     process.env.__CRYPTO_KEY__ = undefined;
     process.env.__CRYPTO_IV__ = undefined;
-    await (await import("./serve-options")).setUpEnvVars(true);
+    await (await import('./serve-options')).setUpEnvVars(true);
 
     expect(process.env.__CRYPTO_KEY__).not.toBeDefined();
     expect(process.env.__CRYPTO_IV__).not.toBeDefined();
     expect(process.env.BRISA_BUILD_FOLDER).toBe(
-      path.join(process.cwd(), "build"),
+      path.join(process.cwd(), 'build'),
     );
   });
 
-  it("should detect as isCLI true when process.argv[1] include serve/index.js", async () => {
+  it('should detect as isCLI true when process.argv[1] include serve/index.js', async () => {
     process.env.__CRYPTO_KEY__ = undefined;
     process.env.__CRYPTO_IV__ = undefined;
-    process.argv[1] = path.join("brisa", "out", "cli", "serve", "index.js");
-    await (await import("./serve-options")).setUpEnvVars();
+    process.argv[1] = path.join('brisa', 'out', 'cli', 'serve', 'index.js');
+    await (await import('./serve-options')).setUpEnvVars();
 
     expect(process.env.__CRYPTO_KEY__).not.toBeDefined();
     expect(process.env.__CRYPTO_IV__).not.toBeDefined();
     expect(process.env.BRISA_BUILD_FOLDER).toBe(
-      path.join(process.cwd(), "build"),
+      path.join(process.cwd(), 'build'),
     );
   });
 
@@ -150,11 +150,11 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     globalThis.mockConstants = {
       ...constants,
       IS_PRODUCTION: true,
-      BUILD_DIR: "/some-path",
+      BUILD_DIR: '/some-path',
     };
 
     expect(
-      async () => await (await import("./serve-options")).getServeOptions(),
+      async () => await (await import('./serve-options')).getServeOptions(),
     ).toThrowError('Not exist "build" yet. Please run "brisa build" first');
   });
 
@@ -163,11 +163,11 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     globalThis.mockConstants = {
       ...constants,
       IS_PRODUCTION: true,
-      PAGES_DIR: "/some-path",
+      PAGES_DIR: '/some-path',
     };
 
     expect(
-      async () => await (await import("./serve-options")).getServeOptions(),
+      async () => await (await import('./serve-options')).getServeOptions(),
     ).toThrowError(
       `Not exist build/pages" directory. It's required to run "brisa start"`,
     );
@@ -178,17 +178,17 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     globalThis.mockConstants = {
       ...constants,
       IS_PRODUCTION: false,
-      PAGES_DIR: "/some-path",
+      PAGES_DIR: '/some-path',
     };
 
     expect(
-      async () => await (await import("./serve-options")).getServeOptions(),
+      async () => await (await import('./serve-options')).getServeOptions(),
     ).toThrowError(
       `Not exist src/pages" directory. It's required to run "brisa dev"`,
     );
   });
 
-  it("should no fetch anything when server upgrades to websocket", async () => {
+  it('should no fetch anything when server upgrades to websocket', async () => {
     const upgrade = true;
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/somepage`),
@@ -196,10 +196,10 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
 
     expect(response.status).toBe(101);
-    expect(response.text()).resolves.toBe("");
+    expect(response.text()).resolves.toBe('');
   });
 
-  it("should return 500 page if the middleware throws an error", async () => {
+  it('should return 500 page if the middleware throws an error', async () => {
     const response = await testRequest(
       // "throws-error" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -209,11 +209,11 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(500);
-    expect(html).toStartWith("<!DOCTYPE html>");
+    expect(html).toStartWith('<!DOCTYPE html>');
     expect(html).toContain('<title id="title">Some internal error</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      "<h1>Some internal error <web-component></web-component></h1>",
+      '<h1>Some internal error <web-component></web-component></h1>',
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_500.tsx"></script>`,
@@ -229,10 +229,10 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe("/es");
+    expect(response.headers.get('Location')).toBe('/es');
   });
 
-  it("should navigate when the middleware throws a navigate error", async () => {
+  it('should navigate when the middleware throws a navigate error', async () => {
     const response = await testRequest(
       // "navigate" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -241,12 +241,12 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `http://localhost:1234${basePath}/es/somepage`,
     );
   });
 
-  it("should navigate resolving i18n when the middleware throws a navigate error", async () => {
+  it('should navigate resolving i18n when the middleware throws a navigate error', async () => {
     const response = await testRequest(
       // "navigate" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -255,10 +255,10 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(`${basePath}/es/somepage`);
+    expect(response.headers.get('Location')).toBe(`${basePath}/es/somepage`);
   });
 
-  it("should navigate removing trailing slash when the middleware throws a navigate error", async () => {
+  it('should navigate removing trailing slash when the middleware throws a navigate error', async () => {
     const response = await testRequest(
       // "navigate" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -267,12 +267,12 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `http://localhost:1234${basePath}/es/somepage`,
     );
   });
 
-  it("should navigate removing trailing slash and adding i18n at the same time when the middleware throws a navigate error", async () => {
+  it('should navigate removing trailing slash and adding i18n at the same time when the middleware throws a navigate error', async () => {
     const response = await testRequest(
       // "navigate" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -281,10 +281,10 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(`${basePath}/es/somepage`);
+    expect(response.headers.get('Location')).toBe(`${basePath}/es/somepage`);
   });
 
-  it("should navigate to an external url without i18n and trailing slash when the middleware throws a navigate error", async () => {
+  it('should navigate to an external url without i18n and trailing slash when the middleware throws a navigate error', async () => {
     const response = await testRequest(
       // "navigate" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -293,12 +293,12 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `https://brisa.build${basePath}/foo/`,
     );
   });
 
-  it("should return 404 page when the middleware throws a not found error", async () => {
+  it('should return 404 page when the middleware throws a not found error', async () => {
     const response = await testRequest(
       // "throws-not-found" parameter is managed by __fixtures__/middleware.tsx
       new Request(
@@ -308,11 +308,11 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith("<!DOCTYPE html>");
+    expect(html).toStartWith('<!DOCTYPE html>');
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      "<h1>Page not found 404 es<web-component></web-component></h1>",
+      '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
@@ -326,21 +326,21 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith("<!DOCTYPE html>");
+    expect(html).toStartWith('<!DOCTYPE html>');
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      "<h1>Page not found 404 es<web-component></web-component></h1>",
+      '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
-  it("should return 404 error if the 404 page does not exist and the page does not exist", async () => {
+  it('should return 404 error if the 404 page does not exist and the page does not exist', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
-      PAGE_404: "",
+      PAGE_404: '',
     };
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}/not-found-page`),
@@ -348,7 +348,7 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const text = await response.text();
 
     expect(response.status).toBe(404);
-    expect(text).toBe("Not found");
+    expect(text).toBe('Not found');
   });
 
   it("should return 404 page without redirect to the trailingSlash if the page doesn't exist", async () => {
@@ -365,11 +365,11 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith("<!DOCTYPE html>");
+    expect(html).toStartWith('<!DOCTYPE html>');
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      "<h1>Page not found 404 es<web-component></web-component></h1>",
+      '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
@@ -390,36 +390,36 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith("<!DOCTYPE html>");
+    expect(html).toStartWith('<!DOCTYPE html>');
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      "<h1>Page not found 404 es<web-component></web-component></h1>",
+      '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
-  it("should return 404 page", async () => {
+  it('should return 404 page', async () => {
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}/es/not-found-page`),
     );
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith("<!DOCTYPE html>");
+    expect(html).toStartWith('<!DOCTYPE html>');
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      "<h1>Page not found 404 es<web-component></web-component></h1>",
+      '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
-  it("should return 404 page with a valid url but with the param _not-found in the query string and work with i18n", async () => {
+  it('should return 404 page with a valid url but with the param _not-found in the query string and work with i18n', async () => {
     const response = await testRequest(
       new Request(
         `http://localhost:1234${basePath}/es/page-with-web-component?_not-found=1`,
@@ -428,18 +428,18 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const html = await response.text();
 
     expect(response.status).toBe(404);
-    expect(html).toStartWith("<!DOCTYPE html>");
+    expect(html).toStartWith('<!DOCTYPE html>');
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      "<h1>Page not found 404 es<web-component></web-component></h1>",
+      '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
-  it("should return 200 page with client page code", async () => {
+  it('should return 200 page with client page code', async () => {
     const response = await testRequest(
       new Request(
         `http://localhost:1234${basePath}/es/page-with-web-component`,
@@ -452,10 +452,10 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
     );
-    expect(html).toContain("<web-component></web-component>");
+    expect(html).toContain('<web-component></web-component>');
   });
 
-  it("should return 200 page with client page code using a hash", async () => {
+  it('should return 200 page with client page code using a hash', async () => {
     const response = await testRequest(
       new Request(
         `http://localhost:1234${basePath}/es/page-with-web-component#hash`,
@@ -468,10 +468,10 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
     );
-    expect(html).toContain("<web-component></web-component>");
+    expect(html).toContain('<web-component></web-component>');
   });
 
-  it("should return 200 page with client page code using a hash and trailingSlash", async () => {
+  it('should return 200 page with client page code using a hash and trailingSlash', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -491,14 +491,14 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/page-with-web-component.tsx"></script>`,
     );
-    expect(html).toContain("<web-component></web-component>");
+    expect(html).toContain('<web-component></web-component>');
   });
 
-  it("should return 404 page with client page code without the basePath", async () => {
+  it('should return 404 page with client page code without the basePath', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
-        basePath: "/incorrect",
+        basePath: '/incorrect',
       },
     };
     const response = await testRequest(
@@ -509,23 +509,23 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     expect(response.status).toBe(404);
   });
 
-  it("should redirect the home to the correct locale", async () => {
+  it('should redirect the home to the correct locale', async () => {
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(`${basePath}/es`);
+    expect(response.headers.get('Location')).toBe(`${basePath}/es`);
   });
 
-  it("should redirect the home to the correct locale with parameters", async () => {
+  it('should redirect the home to the correct locale with parameters', async () => {
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}?param=1`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(`${basePath}/es?param=1`);
+    expect(response.headers.get('Location')).toBe(`${basePath}/es?param=1`);
   });
 
-  it("should redirect the /api/example to the trailingSlash with parameters", async () => {
+  it('should redirect the /api/example to the trailingSlash with parameters', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -538,12 +538,12 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       new Request(`http://localhost:1234${basePath}/api/example?param=1`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `http://localhost:1234${basePath}/api/example/?param=1`,
     );
   });
 
-  it("should redirect the home to the correct locale and trailingSlash", async () => {
+  it('should redirect the home to the correct locale and trailingSlash', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -555,10 +555,10 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       new Request(`http://localhost:1234${basePath}/`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(`${basePath}/es/`);
+    expect(response.headers.get('Location')).toBe(`${basePath}/es/`);
   });
 
-  it("should redirect the home to the correct locale and trailingSlash with params", async () => {
+  it('should redirect the home to the correct locale and trailingSlash with params', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -570,42 +570,42 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       new Request(`http://localhost:1234${basePath}/?param=1`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(`${basePath}/es/?param=1`);
+    expect(response.headers.get('Location')).toBe(`${basePath}/es/?param=1`);
   });
 
-  it("should redirect to the correct locale", async () => {
+  it('should redirect to the correct locale', async () => {
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(`${basePath}/es/somepage`);
+    expect(response.headers.get('Location')).toBe(`${basePath}/es/somepage`);
   });
 
-  it("should redirect to the correct browser locale", async () => {
+  it('should redirect to the correct browser locale', async () => {
     const req = new Request(`http://localhost:1234${basePath}/somepage`);
 
-    req.headers.set("Accept-Language", "en-US,en;q=0.5");
+    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(`${basePath}/en/somepage`);
+    expect(response.headers.get('Location')).toBe(`${basePath}/en/somepage`);
   });
 
-  it("should redirect to the correct default locale of the subdomain", async () => {
+  it('should redirect to the correct default locale of the subdomain', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
       I18N_CONFIG: {
-        locales: ["en", "es"],
-        defaultLocale: "es",
+        locales: ['en', 'es'],
+        defaultLocale: 'es',
         domains: {
-          "en.test.com": {
-            defaultLocale: "en",
-            protocol: "https",
+          'en.test.com': {
+            defaultLocale: 'en',
+            protocol: 'https',
           },
-          "es.test.com": {
-            defaultLocale: "es",
-            protocol: "http",
+          'es.test.com': {
+            defaultLocale: 'es',
+            protocol: 'http',
           },
         },
       },
@@ -620,28 +620,28 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
 
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `https://en.test.com${basePath}/en/somepage`,
     );
     expect(responseEs.status).toBe(301);
-    expect(responseEs.headers.get("Location")).toBe(
+    expect(responseEs.headers.get('Location')).toBe(
       `http://es.test.com${basePath}/es/somepage`,
     );
   });
 
-  it("should redirect to the correct browser locale changing the subdomain", async () => {
+  it('should redirect to the correct browser locale changing the subdomain', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
       I18N_CONFIG: {
-        locales: ["en", "es"],
-        defaultLocale: "es",
+        locales: ['en', 'es'],
+        defaultLocale: 'es',
         domains: {
-          "en.test.com": {
-            defaultLocale: "en",
+          'en.test.com': {
+            defaultLocale: 'en',
           },
-          "es.test.com": {
-            defaultLocale: "es",
+          'es.test.com': {
+            defaultLocale: 'es',
           },
         },
       },
@@ -649,33 +649,33 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const req = new Request(`https://es.test.com${basePath}/somepage`);
 
-    req.headers.set("Accept-Language", "en-US,en;q=0.5");
+    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `https://en.test.com${basePath}/en/somepage`,
     );
   });
 
-  it("should redirect to the correct browser locale changing the subdomain and the page route name", async () => {
+  it('should redirect to the correct browser locale changing the subdomain and the page route name', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
       I18N_CONFIG: {
-        locales: ["en", "es"],
-        defaultLocale: "es",
+        locales: ['en', 'es'],
+        defaultLocale: 'es',
         domains: {
-          "en.test.com": {
-            defaultLocale: "en",
+          'en.test.com': {
+            defaultLocale: 'en',
           },
-          "es.test.com": {
-            defaultLocale: "es",
+          'es.test.com': {
+            defaultLocale: 'es',
           },
         },
         pages: {
-          "/somepage": {
-            en: "/somepage-en",
+          '/somepage': {
+            en: '/somepage-en',
           },
         },
       },
@@ -683,33 +683,33 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const req = new Request(`https://es.test.com${basePath}/somepage`);
 
-    req.headers.set("Accept-Language", "en-US,en;q=0.5");
+    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `https://en.test.com${basePath}/en/somepage-en`,
     );
   });
 
-  it("should redirect to the correct browser locale changing the subdomain and the page route name with hash", async () => {
+  it('should redirect to the correct browser locale changing the subdomain and the page route name with hash', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
       I18N_CONFIG: {
-        locales: ["en", "es"],
-        defaultLocale: "es",
+        locales: ['en', 'es'],
+        defaultLocale: 'es',
         domains: {
-          "en.test.com": {
-            defaultLocale: "en",
+          'en.test.com': {
+            defaultLocale: 'en',
           },
-          "es.test.com": {
-            defaultLocale: "es",
+          'es.test.com': {
+            defaultLocale: 'es',
           },
         },
         pages: {
-          "/somepage": {
-            en: "/somepage-en",
+          '/somepage': {
+            en: '/somepage-en',
           },
         },
       },
@@ -717,16 +717,16 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const req = new Request(`https://es.test.com${basePath}/somepage#hash`);
 
-    req.headers.set("Accept-Language", "en-US,en;q=0.5");
+    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `https://en.test.com${basePath}/en/somepage-en#hash`,
     );
   });
 
-  it("should redirect to the correct browser locale changing the subdomain, adding trailing slash and translating the route name", async () => {
+  it('should redirect to the correct browser locale changing the subdomain, adding trailing slash and translating the route name', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -735,19 +735,19 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
         trailingSlash: true,
       },
       I18N_CONFIG: {
-        locales: ["en", "es"],
-        defaultLocale: "es",
+        locales: ['en', 'es'],
+        defaultLocale: 'es',
         domains: {
-          "en.test.com": {
-            defaultLocale: "en",
+          'en.test.com': {
+            defaultLocale: 'en',
           },
-          "es.test.com": {
-            defaultLocale: "es",
+          'es.test.com': {
+            defaultLocale: 'es',
           },
         },
         pages: {
-          "/somepage": {
-            en: "/somepage-en",
+          '/somepage': {
+            en: '/somepage-en',
           },
         },
       },
@@ -755,28 +755,28 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const req = new Request(`https://es.test.com${basePath}/somepage`);
 
-    req.headers.set("Accept-Language", "en-US,en;q=0.5");
+    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `https://en.test.com${basePath}/en/somepage-en/`,
     );
   });
 
-  it("should redirect to the correct browser locale without changing the subdomain in development", async () => {
+  it('should redirect to the correct browser locale without changing the subdomain in development', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       I18N_CONFIG: {
-        locales: ["en", "es"],
-        defaultLocale: "es",
+        locales: ['en', 'es'],
+        defaultLocale: 'es',
         domains: {
-          "en.test.com": {
-            defaultLocale: "en",
+          'en.test.com': {
+            defaultLocale: 'en',
           },
-          "es.test.com": {
-            defaultLocale: "es",
+          'es.test.com': {
+            defaultLocale: 'es',
           },
         },
       },
@@ -784,27 +784,27 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const req = new Request(`http://localhost:1234${basePath}/somepage`);
 
-    req.headers.set("Accept-Language", "en-US,en;q=0.5");
+    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(`${basePath}/en/somepage`);
+    expect(response.headers.get('Location')).toBe(`${basePath}/en/somepage`);
   });
 
-  it("should redirect to the correct browser locale and changing the subdomain in development", async () => {
+  it('should redirect to the correct browser locale and changing the subdomain in development', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       I18N_CONFIG: {
-        locales: ["en", "es"],
-        defaultLocale: "es",
+        locales: ['en', 'es'],
+        defaultLocale: 'es',
         domains: {
-          "en.test.com": {
-            defaultLocale: "en",
+          'en.test.com': {
+            defaultLocale: 'en',
             dev: true,
           },
-          "es.test.com": {
-            defaultLocale: "es",
+          'es.test.com': {
+            defaultLocale: 'es',
             dev: true,
           },
         },
@@ -813,16 +813,16 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const req = new Request(`http://localhost:1234${basePath}/somepage`);
 
-    req.headers.set("Accept-Language", "en-US,en;q=0.5");
+    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `https://en.test.com${basePath}/en/somepage`,
     );
   });
 
-  it("should redirect to the correct browser locale changing the subdomain and trailingSlash", async () => {
+  it('should redirect to the correct browser locale changing the subdomain and trailingSlash', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -831,15 +831,15 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
         trailingSlash: true,
       },
       I18N_CONFIG: {
-        locales: ["en", "es"],
-        defaultLocale: "es",
+        locales: ['en', 'es'],
+        defaultLocale: 'es',
         domains: {
-          "en.test.com": {
-            defaultLocale: "en",
-            protocol: "http",
+          'en.test.com': {
+            defaultLocale: 'en',
+            protocol: 'http',
           },
-          "es.test.com": {
-            defaultLocale: "es",
+          'es.test.com': {
+            defaultLocale: 'es',
           },
         },
       },
@@ -847,16 +847,16 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const req = new Request(`http://es.test.com${basePath}/somepage`);
 
-    req.headers.set("Accept-Language", "en-US,en;q=0.5");
+    req.headers.set('Accept-Language', 'en-US,en;q=0.5');
 
     const response = await testRequest(req);
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `http://en.test.com${basePath}/en/somepage/`,
     );
   });
 
-  it("should redirect with trailingSlash", async () => {
+  it('should redirect with trailingSlash', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -868,12 +868,12 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       new Request(`http://localhost:1234${basePath}/es/somepage`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(
+    expect(response.headers.get('Location')).toBe(
       `http://localhost:1234${basePath}/es/somepage/`,
     );
   });
 
-  it("should redirect with locale and trailingSlash", async () => {
+  it('should redirect with locale and trailingSlash', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
@@ -885,32 +885,32 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       new Request(`http://localhost:1234${basePath}/somepage`),
     );
     expect(response.status).toBe(301);
-    expect(response.headers.get("Location")).toBe(`${basePath}/es/somepage/`);
+    expect(response.headers.get('Location')).toBe(`${basePath}/es/somepage/`);
   });
 
-  it("should return a page with layout and i18n", async () => {
+  it('should return a page with layout and i18n', async () => {
     const response = await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`),
     );
     const html = await response.text();
     expect(response.status).toBe(200);
-    expect(html).toStartWith("<!DOCTYPE html>");
+    expect(html).toStartWith('<!DOCTYPE html>');
     expect(html).toContain('<html lang="es" dir="ltr">');
     expect(html).toContain('<title id="title">CUSTOM LAYOUT</title>');
-    expect(html).toContain("<h1>Some page</h1>");
+    expect(html).toContain('<h1>Some page</h1>');
   });
 
-  it("should be possible to fetch an api route GET", async () => {
+  it('should be possible to fetch an api route GET', async () => {
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/example`),
     );
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ hello: "world" });
+    expect(json).toEqual({ hello: 'world' });
   });
 
-  it("should be possible to fetch an api route GET from root", async () => {
+  it('should be possible to fetch an api route GET from root', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -923,10 +923,10 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ hello: "world" });
+    expect(json).toEqual({ hello: 'world' });
   });
 
-  it("should be possible to fetch an api route POST from root", async () => {
+  it('should be possible to fetch an api route POST from root', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -935,44 +935,44 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/api`, {
-        method: "POST",
-        body: JSON.stringify({ hello: "world" }),
+        method: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
       }),
     );
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ hello: "world" });
+    expect(json).toEqual({ hello: 'world' });
   });
 
-  it("should be possible to fetch an api route GET from root (with i18n)", async () => {
+  it('should be possible to fetch an api route GET from root (with i18n)', async () => {
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api`),
     );
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ hello: "world" });
+    expect(json).toEqual({ hello: 'world' });
   });
 
-  it("should be possible to fetch an api route POST from root (with i18n)", async () => {
+  it('should be possible to fetch an api route POST from root (with i18n)', async () => {
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api`, {
-        method: "POST",
-        body: JSON.stringify({ hello: "world" }),
+        method: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
       }),
     );
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ hello: "world" });
+    expect(json).toEqual({ hello: 'world' });
   });
 
-  it("should not be possible to fetch an api route GET without the correct basePath", async () => {
+  it('should not be possible to fetch an api route GET without the correct basePath', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
-        basePath: "/incorrect",
+        basePath: '/incorrect',
       },
     };
     const response = await testRequest(
@@ -981,25 +981,25 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     expect(response.status).toBe(404);
   });
 
-  it("should be possible to fetch an api route POST with a FormData", async () => {
+  it('should be possible to fetch an api route POST with a FormData', async () => {
     const body = new FormData();
 
-    body.append("name", "Brisa");
-    body.append("email", "test@brisa.com");
+    body.append('name', 'Brisa');
+    body.append('email', 'test@brisa.com');
 
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/example`, {
-        method: "POST",
+        method: 'POST',
         body,
       }),
     );
     const json = await response.json();
 
     expect(response.status).toBe(200);
-    expect(json).toEqual({ name: "Brisa", email: "test@brisa.com" });
+    expect(json).toEqual({ name: 'Brisa', email: 'test@brisa.com' });
   });
 
-  it("should return 404 page if the api route does not exist", async () => {
+  it('should return 404 page if the api route does not exist', async () => {
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/not-found`),
     );
@@ -1009,7 +1009,7 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      "<h1>Page not found 404 es<web-component></web-component></h1>",
+      '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
@@ -1017,11 +1017,11 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
   });
 
   it('should be possible to access to store variables from "x-s" store body', async () => {
-    const xs = [["foo", "bar"]];
+    const xs = [['foo', 'bar']];
     const options = {
-      method: "POST",
+      method: 'POST',
       body: JSON.stringify({
-        "x-s": xs,
+        'x-s': xs,
       }),
     };
     const req = new Request(
@@ -1031,7 +1031,7 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const res = await testRequest(req);
     const html = await res.text();
 
-    expect(req.store.get("foo")).toBe("bar");
+    expect(req.store.get('foo')).toBe('bar');
     expect(html).toContain(
       `<script type="application/json" id="S">[["foo","bar"]]</script>`,
     );
@@ -1039,13 +1039,13 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
   it('should remove the field "x-s" from form-data (Brisa internal field)', async () => {
     const formData = new FormData();
-    formData.append("foo", "bar");
+    formData.append('foo', 'bar');
 
     // Should ignore the "x-s" field
-    formData.append("x-s", '[["foo", "bar"]]');
+    formData.append('x-s', '[["foo", "bar"]]');
 
     const options = {
-      method: "POST",
+      method: 'POST',
       body: formData,
     };
     const req = new Request(
@@ -1055,8 +1055,8 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const res = await testRequest(req);
     const html = await res.text();
 
-    expect(req.store.get("foo")).toBe("bar");
-    expect(res.headers.get("x-reset")).toBeEmpty();
+    expect(req.store.get('foo')).toBe('bar');
+    expect(res.headers.get('x-reset')).toBeEmpty();
     expect(html).toContain(
       `<script type="application/json" id="S">[["foo","bar"]]</script>`,
     );
@@ -1064,10 +1064,10 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
   it('should form-data work with "x-s" store appended to the form-data"', async () => {
     const formData = new FormData();
-    formData.append("x-s", JSON.stringify([["foo", "bar"]]));
+    formData.append('x-s', JSON.stringify([['foo', 'bar']]));
 
     const options = {
-      method: "POST",
+      method: 'POST',
       body: formData,
     };
     const req = new Request(
@@ -1077,19 +1077,19 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const res = await testRequest(req);
     const html = await res.text();
 
-    expect(req.store.get("foo")).toBe("bar");
-    expect(res.headers.get("x-reset")).toBeEmpty();
+    expect(req.store.get('foo')).toBe('bar');
+    expect(res.headers.get('x-reset')).toBeEmpty();
     expect(html).toContain(
       `<script type="application/json" id="S">[["foo","bar"]]</script>`,
     );
   });
 
   it('should decrypt the store variables from "x-s" store that starts with ENCRYPT_PREFIX', async () => {
-    const xs = [["sensitive-data", encrypt("foo")]];
+    const xs = [['sensitive-data', encrypt('foo')]];
     const options = {
-      method: "POST",
+      method: 'POST',
       body: JSON.stringify({
-        "x-s": xs,
+        'x-s': xs,
       }),
     };
     const request = new Request(
@@ -1099,18 +1099,18 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const response = await testRequest(request);
     const html = await response.text();
 
-    expect(request.store.get("sensitive-data")).toEqual("foo");
+    expect(request.store.get('sensitive-data')).toEqual('foo');
     expect(html).toContain(
       `<script type="application/json" id="S">[["sensitive-data","${ENCRYPT_PREFIX}`,
     );
   });
 
   it('should decrypt the store variables from "x-s" body that starts with ENCRYPT_NONTEXT_PREFIX', async () => {
-    const xs = [["sensitive-data", encrypt({ foo: "bar" })]];
+    const xs = [['sensitive-data', encrypt({ foo: 'bar' })]];
     const options = {
-      method: "POST",
+      method: 'POST',
       body: JSON.stringify({
-        "x-s": xs,
+        'x-s': xs,
       }),
     };
     const request = new Request(
@@ -1120,17 +1120,17 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const response = await testRequest(request);
     const html = await response.text();
 
-    expect(request.store.get("sensitive-data")).toEqual({ foo: "bar" });
+    expect(request.store.get('sensitive-data')).toEqual({ foo: 'bar' });
     expect(html).toContain(
       `<script type="application/json" id="S">[["sensitive-data","${ENCRYPT_NONTEXT_PREFIX}`,
     );
   });
 
-  it("should emojis work inside store", async () => {
+  it('should emojis work inside store', async () => {
     const options = {
-      method: "POST",
+      method: 'POST',
       body: JSON.stringify({
-        "x-s": [["sensitive-data", "👍"]],
+        'x-s': [['sensitive-data', '👍']],
       }),
     };
     const request = new Request(
@@ -1140,7 +1140,7 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const response = await testRequest(request);
     const html = await response.text();
 
-    expect(request.store.get("sensitive-data")).toBe("👍");
+    expect(request.store.get('sensitive-data')).toBe('👍');
     expect(html).toContain(
       `<script type="application/json" id="S">[["sensitive-data","👍"]]</script>`,
     );
@@ -1148,14 +1148,14 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
   it('should log and render an error if the decryption fails from "x-s" store body', async () => {
     const options = {
-      method: "POST",
+      method: 'POST',
       body: JSON.stringify({
-        "x-s": [
-          ["sensitive-data", ENCRYPT_NONTEXT_PREFIX + "invalid-encrypted-data"],
+        'x-s': [
+          ['sensitive-data', ENCRYPT_NONTEXT_PREFIX + 'invalid-encrypted-data'],
         ],
       }),
     };
-    const mockLog = spyOn(console, "log");
+    const mockLog = spyOn(console, 'log');
     const request = new Request(
       `http:///localhost:1234${basePath}/es/page-with-web-component`,
       options,
@@ -1170,14 +1170,14 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     expect(mockLog).toHaveBeenCalled();
   });
 
-  it("should clear the context store", async () => {
+  it('should clear the context store', async () => {
     const options = {
-      method: "POST",
+      method: 'POST',
       body: JSON.stringify({
-        "x-s": [
-          ["context:0:1:0", "foo"],
-          ["context:0:1:1", "bar"],
-          ["foo", "bar"],
+        'x-s': [
+          ['context:0:1:0', 'foo'],
+          ['context:0:1:1', 'bar'],
+          ['foo', 'bar'],
         ],
       }),
     };
@@ -1194,14 +1194,14 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
   });
 
-  it("should clear the context store", async () => {
+  it('should clear the context store', async () => {
     const options = {
-      method: "POST",
+      method: 'POST',
       body: JSON.stringify({
-        "x-s": [
-          ["context:0:1:0", "foo"],
-          ["context:0:1:1", "bar"],
-          ["foo", "bar"],
+        'x-s': [
+          ['context:0:1:0', 'foo'],
+          ['context:0:1:1', 'bar'],
+          ['foo', 'bar'],
         ],
       }),
     };
@@ -1218,10 +1218,10 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
   });
 
-  it("should return 404 page if the api route exist but the method does not", async () => {
+  it('should return 404 page if the api route exist but the method does not', async () => {
     const response = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/example`, {
-        method: "PUT",
+        method: 'PUT',
       }),
     );
     const html = await response.text();
@@ -1230,14 +1230,14 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     expect(html).toContain('<title id="title">Page not found</title>');
     expect(html).not.toContain('<title id="title">CUSTOM LAYOUT</title>');
     expect(html).toContain(
-      "<h1>Page not found 404 es<web-component></web-component></h1>",
+      '<h1>Page not found 404 es<web-component></web-component></h1>',
     );
     expect(html).toContain(
       `<script data-cfasync="false" async fetchpriority="high" src="${basePath}/_brisa/pages/_404.tsx"></script>`,
     );
   });
 
-  it("should return an asset in gzip if the browser accept it", async () => {
+  it('should return an asset in gzip if the browser accept it', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1246,12 +1246,12 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
         assetCompression: true,
       },
     };
-    const textDecoder = new TextDecoder("utf-8");
+    const textDecoder = new TextDecoder('utf-8');
     const req = new Request(
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          "accept-encoding": "gzip",
+          'accept-encoding': 'gzip',
         },
       },
     );
@@ -1260,15 +1260,15 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const text = textDecoder.decode(textBuffer);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("content-encoding")).toBe("gzip");
-    expect(response.headers.get("vary")).toBe("Accept-Encoding");
-    expect(response.headers.get("content-type")).toBe(
-      "text/plain;charset=utf-8",
+    expect(response.headers.get('content-encoding')).toBe('gzip');
+    expect(response.headers.get('vary')).toBe('Accept-Encoding');
+    expect(response.headers.get('content-type')).toBe(
+      'text/plain;charset=utf-8',
     );
-    expect(text).toBe("Some text :D");
+    expect(text).toBe('Some text :D');
   });
 
-  it("should not return in DEVELOPMENT an asset in gzip", async () => {
+  it('should not return in DEVELOPMENT an asset in gzip', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
@@ -1281,21 +1281,21 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          "accept-encoding": "gzip",
+          'accept-encoding': 'gzip',
         },
       },
     );
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("content-encoding")).toBe(null);
-    expect(response.headers.get("vary")).toBe(null);
-    expect(response.headers.get("content-type")).toBe(
-      "text/plain;charset=utf-8",
+    expect(response.headers.get('content-encoding')).toBe(null);
+    expect(response.headers.get('vary')).toBe(null);
+    expect(response.headers.get('content-type')).toBe(
+      'text/plain;charset=utf-8',
     );
   });
 
-  it("should not return in PRODUCTION an asset in zip when CONFIG.assetCompression is false", async () => {
+  it('should not return in PRODUCTION an asset in zip when CONFIG.assetCompression is false', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1308,17 +1308,17 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          "accept-encoding": "gzip",
+          'accept-encoding': 'gzip',
         },
       },
     );
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("content-encoding")).toBe(null);
-    expect(response.headers.get("vary")).toBe(null);
-    expect(response.headers.get("content-type")).toBe(
-      "text/plain;charset=utf-8",
+    expect(response.headers.get('content-encoding')).toBe(null);
+    expect(response.headers.get('vary')).toBe(null);
+    expect(response.headers.get('content-type')).toBe(
+      'text/plain;charset=utf-8',
     );
   });
 
@@ -1331,12 +1331,12 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
         assetCompression: true,
       },
     };
-    const textDecoder = new TextDecoder("utf-8");
+    const textDecoder = new TextDecoder('utf-8');
     const req = new Request(
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          "accept-encoding": "br",
+          'accept-encoding': 'br',
         },
       },
     );
@@ -1347,15 +1347,15 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const text = textDecoder.decode(textBuffer);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("content-encoding")).toBe("br");
-    expect(response.headers.get("vary")).toBe("Accept-Encoding");
-    expect(response.headers.get("content-type")).toBe(
-      "text/plain;charset=utf-8",
+    expect(response.headers.get('content-encoding')).toBe('br');
+    expect(response.headers.get('vary')).toBe('Accept-Encoding');
+    expect(response.headers.get('content-type')).toBe(
+      'text/plain;charset=utf-8',
     );
-    expect(text).toBe("Some text :D");
+    expect(text).toBe('Some text :D');
   });
 
-  it("should not return in DEVELOPMENT an asset in brotli", async () => {
+  it('should not return in DEVELOPMENT an asset in brotli', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
@@ -1368,21 +1368,21 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          "accept-encoding": "br",
+          'accept-encoding': 'br',
         },
       },
     );
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("content-encoding")).toBe(null);
-    expect(response.headers.get("vary")).toBe(null);
-    expect(response.headers.get("content-type")).toBe(
-      "text/plain;charset=utf-8",
+    expect(response.headers.get('content-encoding')).toBe(null);
+    expect(response.headers.get('vary')).toBe(null);
+    expect(response.headers.get('content-type')).toBe(
+      'text/plain;charset=utf-8',
     );
   });
 
-  it("should not return in PRODUCTION an asset in brotli when CONFIG.assetCompression is false", async () => {
+  it('should not return in PRODUCTION an asset in brotli when CONFIG.assetCompression is false', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1395,32 +1395,32 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          "accept-encoding": "br",
+          'accept-encoding': 'br',
         },
       },
     );
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("content-encoding")).toBe(null);
-    expect(response.headers.get("vary")).toBe(null);
-    expect(response.headers.get("content-type")).toBe(
-      "text/plain;charset=utf-8",
+    expect(response.headers.get('content-encoding')).toBe(null);
+    expect(response.headers.get('vary')).toBe(null);
+    expect(response.headers.get('content-type')).toBe(
+      'text/plain;charset=utf-8',
     );
   });
 
-  it("should not return an asset with incorrect basePath", async () => {
+  it('should not return an asset with incorrect basePath', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       CONFIG: {
-        basePath: "/incorrect",
+        basePath: '/incorrect',
       },
     };
     const req = new Request(
       `http:///localhost:1234${basePath}/some-dir/some-text.txt`,
       {
         headers: {
-          "accept-encoding": "gzip",
+          'accept-encoding': 'gzip',
         },
       },
     );
@@ -1428,7 +1428,7 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     expect(response.status).toBe(404);
   });
 
-  it("should src/pages/user/[username].tsx dynamic page work", async () => {
+  it('should src/pages/user/[username].tsx dynamic page work', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1438,13 +1438,13 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toBe(
-      "text/html; charset=utf-8",
+    expect(response.headers.get('content-type')).toBe(
+      'text/html; charset=utf-8',
     );
-    expect(response.text()).resolves.toContain("<div>user</div>");
+    expect(response.text()).resolves.toContain('<div>user</div>');
   });
 
-  it("should prefer src/public/user/static.js asset than src/pages/user/[username].tsx page", async () => {
+  it('should prefer src/public/user/static.js asset than src/pages/user/[username].tsx page', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1454,13 +1454,13 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toBe(
-      "application/javascript;charset=utf-8",
+    expect(response.headers.get('content-type')).toBe(
+      'application/javascript;charset=utf-8',
     );
     expect(response.text()).resolves.toContain("console.log('from public')");
   });
 
-  it("should prefer src/public/user/static.js asset than src/pages/user/[username].tsx page (without .js ext)", async () => {
+  it('should prefer src/public/user/static.js asset than src/pages/user/[username].tsx page (without .js ext)', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: true,
@@ -1470,21 +1470,21 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     const response = await testRequest(req);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("content-type")).toBe(
-      "application/javascript;charset=utf-8",
+    expect(response.headers.get('content-type')).toBe(
+      'application/javascript;charset=utf-8',
     );
     expect(response.text()).resolves.toContain("console.log('from public')");
   });
 
-  it("should cache client page code in production", async () => {
+  it('should cache client page code in production', async () => {
     globalThis.mockConstants = {
       ...getConstants(),
       IS_PRODUCTION: true,
       HEADERS: {
-        CACHE_CONTROL: "public, max-age=31536000, immutable",
+        CACHE_CONTROL: 'public, max-age=31536000, immutable',
       },
     };
-    const mockFile = spyOn(Bun, "file").mockImplementation(
+    const mockFile = spyOn(Bun, 'file').mockImplementation(
       () =>
         ({
           text: (pathname: string) => Promise.resolve(pathname),
@@ -1496,13 +1496,13 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     mockFile.mockRestore();
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe(
-      "public, max-age=31536000, immutable",
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=31536000, immutable',
     );
   });
 
-  it("should not cache client page code in development", async () => {
-    const mockFile = spyOn(Bun, "file").mockImplementation(
+  it('should not cache client page code in development', async () => {
+    const mockFile = spyOn(Bun, 'file').mockImplementation(
       () =>
         ({
           text: (pathname: string) => Promise.resolve(pathname),
@@ -1514,26 +1514,26 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     mockFile.mockRestore();
     expect(response.status).toBe(200);
-    expect(response.headers.get("cache-control")).toBe(
-      "no-store, must-revalidate",
+    expect(response.headers.get('cache-control')).toBe(
+      'no-store, must-revalidate',
     );
   });
 
   it('should subscribe to hotload when "open" the websocket connection in development', async () => {
     const serverOptions = await (
-      await import("./serve-options")
+      await import('./serve-options')
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
     const mockSubscribe = mock(() => {});
     const ws = {
-      data: { id: "1234" },
+      data: { id: '1234' },
       subscribe: mockSubscribe,
     } as unknown as ServerWebSocket;
 
     socket.open(ws);
 
-    expect(mockSubscribe).toHaveBeenCalledWith("hot-reload");
+    expect(mockSubscribe).toHaveBeenCalledWith('hot-reload');
   });
 
   it('should NOT subscribe to hotload when "open" the websocket connection in production', async () => {
@@ -1543,13 +1543,13 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     };
 
     const serverOptions = await (
-      await import("./serve-options")
+      await import('./serve-options')
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
     const mockSubscribe = mock(() => {});
     const ws = {
-      data: { id: "1234" },
+      data: { id: '1234' },
       subscribe: mockSubscribe,
     } as unknown as ServerWebSocket;
 
@@ -1560,36 +1560,36 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
   it('should call the "open" method of the websocket module', async () => {
     const serverOptions = await (
-      await import("./serve-options")
+      await import('./serve-options')
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
-    const mockLog = spyOn(console, "log");
+    const mockLog = spyOn(console, 'log');
     const ws = {
-      data: { id: "1234" },
+      data: { id: '1234' },
       subscribe: () => {},
     } as unknown as ServerWebSocket;
 
     socket.open(ws);
 
-    expect(mockLog).toHaveBeenCalledWith("open");
+    expect(mockLog).toHaveBeenCalledWith('open');
   });
 
   it('should unsubscribe to hotload when "close" the websocket connection in development', async () => {
     const serverOptions = await (
-      await import("./serve-options")
+      await import('./serve-options')
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
     const mockUnsubscribe = mock(() => {});
     const ws = {
-      data: { id: "1234" },
+      data: { id: '1234' },
       unsubscribe: mockUnsubscribe,
     } as unknown as ServerWebSocket;
 
     socket.close(ws);
 
-    expect(mockUnsubscribe).toHaveBeenCalledWith("hot-reload");
+    expect(mockUnsubscribe).toHaveBeenCalledWith('hot-reload');
   });
 
   it('should NOT unsubscribe to hotload when "close" the websocket connection in production', async () => {
@@ -1599,13 +1599,13 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     };
 
     const serverOptions = await (
-      await import("./serve-options")
+      await import('./serve-options')
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
     const mockUnsubscribe = mock(() => {});
     const ws = {
-      data: { id: "1234" },
+      data: { id: '1234' },
       unsubscribe: mockUnsubscribe,
     } as unknown as ServerWebSocket;
 
@@ -1616,53 +1616,53 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
   it('should call the "close" method of the websocket module', async () => {
     const serverOptions = await (
-      await import("./serve-options")
+      await import('./serve-options')
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
-    const mockLog = spyOn(console, "log");
+    const mockLog = spyOn(console, 'log');
     const ws = {
-      data: { id: "1234" },
+      data: { id: '1234' },
       unsubscribe: () => {},
     } as unknown as ServerWebSocket;
 
     socket.close(ws);
 
-    expect(mockLog).toHaveBeenCalledWith("close");
+    expect(mockLog).toHaveBeenCalledWith('close');
   });
 
   it('should call the "drain" method of the websocket module', async () => {
     const serverOptions = await (
-      await import("./serve-options")
+      await import('./serve-options')
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
-    const mockLog = spyOn(console, "log");
+    const mockLog = spyOn(console, 'log');
     const ws = {
-      data: { id: "1234" },
+      data: { id: '1234' },
       subscribe: () => {},
     } as unknown as ServerWebSocket;
 
     socket.drain(ws);
 
-    expect(mockLog).toHaveBeenCalledWith("drain");
+    expect(mockLog).toHaveBeenCalledWith('drain');
   });
 
   it('should call the "message" method of the websocket module', async () => {
     const serverOptions = await (
-      await import("./serve-options")
+      await import('./serve-options')
     ).getServeOptions();
 
     const socket = serverOptions!.websocket;
-    const mockLog = spyOn(console, "log");
+    const mockLog = spyOn(console, 'log');
     const ws = {
-      data: { id: "1234" },
+      data: { id: '1234' },
       subscribe: () => {},
     } as unknown as ServerWebSocket;
 
-    socket.message(ws, "hello test");
+    socket.message(ws, 'hello test');
 
-    expect(mockLog).toHaveBeenCalledWith("message", "hello test");
+    expect(mockLog).toHaveBeenCalledWith('message', 'hello test');
   });
 
   it('should have req.initiator with "SERVER_ACTION" when is POST method and has x-action header', async () => {
@@ -1673,15 +1673,15 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       I18N_CONFIG: undefined,
     };
 
-    mock.module("@/utils/response-action", () => ({
+    mock.module('@/utils/response-action', () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "x-action": "a1_1",
+          'x-action': 'a1_1',
         },
       }),
     );
@@ -1694,15 +1694,15 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
   it('should have req.initiator with "SERVER_ACTION" when is POST method and has x-action header and i18n', async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
-    mock.module("@/utils/response-action", () => ({
+    mock.module('@/utils/response-action', () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "x-action": "a1_1",
+          'x-action': 'a1_1',
         },
       }),
     );
@@ -1712,34 +1712,34 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
   });
 
-  it("should the response action receive the formData", async () => {
+  it('should the response action receive the formData', async () => {
     const mockResponseAction = mock(
       (req: RequestContext, content: RequestContent) => {},
     );
     const formData = new FormData();
-    formData.append("foo", "bar");
-    formData.append("x-s", '[["some", "value"]]');
+    formData.append('foo', 'bar');
+    formData.append('x-s', '[["some", "value"]]');
 
-    mock.module("@/utils/response-action", () => ({
+    mock.module('@/utils/response-action', () => ({
       default: (req: RequestContext, content: RequestContent) =>
         mockResponseAction(req, content),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`, {
-        method: "POST",
+        method: 'POST',
         body: formData,
         headers: {
-          "x-action": "a1_1",
+          'x-action': 'a1_1',
         },
       }),
     );
 
     const [req, reqContent] = mockResponseAction.mock.calls[0];
 
-    expect(req.store.get("some")).toBe("value");
+    expect(req.store.get('some')).toBe('value');
     expect(Array.from(reqContent.formData!.entries())).toEqual([
-      ["foo", "bar"],
+      ['foo', 'bar'],
     ]);
   });
 
@@ -1751,25 +1751,25 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: "POST",
-        body: "{}",
+        method: 'POST',
+        body: '{}',
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get("x-initiator")).toBe(Initiator.SPA_NAVIGATION);
+    expect(res.headers.get('x-initiator')).toBe(Initiator.SPA_NAVIGATION);
   });
 
   it('should have req.initiator with "SPA_NAVIGATION" when the Page is POST method without x-action header and i18n', async () => {
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`, {
-        method: "POST",
-        body: "{}",
+        method: 'POST',
+        body: '{}',
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get("x-initiator")).toBe(Initiator.SPA_NAVIGATION);
+    expect(res.headers.get('x-initiator')).toBe(Initiator.SPA_NAVIGATION);
   });
 
   it('should have req.initiator with "INITIAL_REQUEST" when the Page is GET method', async () => {
@@ -1780,23 +1780,23 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: "GET",
+        method: 'GET',
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get("x-initiator")).toBe(Initiator.INITIAL_REQUEST);
+    expect(res.headers.get('x-initiator')).toBe(Initiator.INITIAL_REQUEST);
   });
 
   it('should have req.initiator with "INITIAL_REQUEST" when the Page is GET method and i18n', async () => {
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`, {
-        method: "GET",
+        method: 'GET',
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get("x-initiator")).toBe(Initiator.INITIAL_REQUEST);
+    expect(res.headers.get('x-initiator')).toBe(Initiator.INITIAL_REQUEST);
   });
 
   it('should have req.initiator with "API_REQUEST" when is POST method and is an API endpoint', async () => {
@@ -1806,35 +1806,35 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     };
     const body = new FormData();
 
-    body.append("name", "Brisa");
-    body.append("email", "test@brisa.com");
+    body.append('name', 'Brisa');
+    body.append('email', 'test@brisa.com');
 
     const res = await testRequest(
       new Request(`http:///localhost:1234${basePath}/api/example`, {
-        method: "POST",
+        method: 'POST',
         body,
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get("x-initiator")).toBe(Initiator.API_REQUEST);
+    expect(res.headers.get('x-initiator')).toBe(Initiator.API_REQUEST);
   });
 
   it('should have req.initiator with "API_REQUEST" when is POST method and is an API endpoint and i18n', async () => {
     const body = new FormData();
 
-    body.append("name", "Brisa");
-    body.append("email", "test@brisa.com");
+    body.append('name', 'Brisa');
+    body.append('email', 'test@brisa.com');
 
     const res = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/example`, {
-        method: "POST",
+        method: 'POST',
         body,
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get("x-initiator")).toBe(Initiator.API_REQUEST);
+    expect(res.headers.get('x-initiator')).toBe(Initiator.API_REQUEST);
   });
 
   it('should have req.initiator with "API_REQUEST" when is POST method and is an API endpoint with x-action header', async () => {
@@ -1844,84 +1844,84 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     };
     const body = new FormData();
 
-    body.append("name", "Brisa");
-    body.append("email", "test@brisa.com");
+    body.append('name', 'Brisa');
+    body.append('email', 'test@brisa.com');
 
     const res = await testRequest(
       new Request(`http:///localhost:1234${basePath}/api/example`, {
-        method: "POST",
+        method: 'POST',
         body,
         headers: {
-          "x-action": "a1_1",
+          'x-action': 'a1_1',
         },
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get("x-initiator")).toBe(Initiator.API_REQUEST);
+    expect(res.headers.get('x-initiator')).toBe(Initiator.API_REQUEST);
   });
 
   it('should have req.initiator with "API_REQUEST" when is POST method and is an API endpoint with x-action header and i18n', async () => {
     const body = new FormData();
 
-    body.append("name", "Brisa");
-    body.append("email", "test@brisa.com");
+    body.append('name', 'Brisa');
+    body.append('email', 'test@brisa.com');
 
     const res = await testRequest(
       new Request(`http:///localhost:1234${basePath}/es/api/example`, {
-        method: "POST",
+        method: 'POST',
         body,
         headers: {
-          "x-action": "a1_1",
+          'x-action': 'a1_1',
         },
       }),
     );
 
     // Response x-initiator is the same as the requestContext.initiator (modified in the fixture)
-    expect(res.headers.get("x-initiator")).toBe(Initiator.API_REQUEST);
+    expect(res.headers.get('x-initiator')).toBe(Initiator.API_REQUEST);
   });
 
-  it("should NOT call responseAction method with GET and return 200 with the page", async () => {
+  it('should NOT call responseAction method with GET and return 200 with the page', async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
     };
-    mock.module("@/utils/response-action", () => ({
+    mock.module('@/utils/response-action', () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: "GET",
+        method: 'GET',
         headers: {
-          "x-action": "a1_1",
+          'x-action': 'a1_1',
         },
       }),
     );
 
     expect(mockResponseAction).not.toHaveBeenCalled();
     expect(res.status).toBe(200);
-    expect(await res.text()).toContain("<h1>Some page</h1>");
+    expect(await res.text()).toContain('<h1>Some page</h1>');
   });
 
-  it("should call responseAction method when is an action", async () => {
+  it('should call responseAction method when is an action', async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
     };
-    mock.module("@/utils/response-action", () => ({
+    mock.module('@/utils/response-action', () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "x-action": "a1_1",
+          'x-action': 'a1_1',
         },
       }),
     );
@@ -1930,68 +1930,68 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     expect(mockResponseAction.mock.calls[0][0].i18n.locale).toBeEmpty();
   });
 
-  it("should call responseAction method when is an action and has i18n", async () => {
+  it('should call responseAction method when is an action and has i18n', async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
-    mock.module("@/utils/response-action", () => ({
+    mock.module('@/utils/response-action', () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/es/somepage`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "x-action": "a1_1",
+          'x-action': 'a1_1',
         },
       }),
     );
 
     expect(mockResponseAction).toHaveBeenCalled();
-    expect(mockResponseAction.mock.calls[0][0].i18n.locale).toBe("es");
+    expect(mockResponseAction.mock.calls[0][0].i18n.locale).toBe('es');
   });
 
-  it("should open the editor calling /__brisa_dev_file__ with file, line and column", async () => {
+  it('should open the editor calling /__brisa_dev_file__ with file, line and column', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       IS_DEVELOPMENT: true,
     };
-    const mockOpenInEditor = spyOn(Bun, "openInEditor").mockImplementation(
+    const mockOpenInEditor = spyOn(Bun, 'openInEditor').mockImplementation(
       () => {},
     );
     const response = await testRequest(
       new Request(
         `http://localhost:1234/__brisa_dev_file__?file=${encodeURIComponent(
-          "src/pages/somepage.tsx",
+          'src/pages/somepage.tsx',
         )}&line=1&column=1`,
-        { method: "POST" },
+        { method: 'POST' },
       ),
     );
 
     expect(response.status).toBe(200);
-    expect(mockOpenInEditor).toHaveBeenCalledWith("src/pages/somepage.tsx", {
+    expect(mockOpenInEditor).toHaveBeenCalledWith('src/pages/somepage.tsx', {
       line: 1,
       column: 1,
     });
     mockOpenInEditor.mockRestore();
   });
 
-  it("should not call Bun.openInEditor in Node.js and return 404", async () => {
+  it('should not call Bun.openInEditor in Node.js and return 404', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       IS_DEVELOPMENT: true,
-      JS_RUNTIME: "node",
+      JS_RUNTIME: 'node',
     };
-    const mockOpenInEditor = spyOn(Bun, "openInEditor").mockImplementation(
+    const mockOpenInEditor = spyOn(Bun, 'openInEditor').mockImplementation(
       () => {},
     );
     const response = await testRequest(
       new Request(
         `http://localhost:1234/__brisa_dev_file__?file=${encodeURIComponent(
-          "src/pages/somepage.tsx",
+          'src/pages/somepage.tsx',
         )}&line=1&column=1`,
-        { method: "POST" },
+        { method: 'POST' },
       ),
     );
 
@@ -2000,22 +2000,22 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     mockOpenInEditor.mockRestore();
   });
 
-  it("should not call Bun.openInEditor in Deno and return 404", async () => {
+  it('should not call Bun.openInEditor in Deno and return 404', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       IS_DEVELOPMENT: true,
-      JS_RUNTIME: "deno",
+      JS_RUNTIME: 'deno',
     };
-    const mockOpenInEditor = spyOn(Bun, "openInEditor").mockImplementation(
+    const mockOpenInEditor = spyOn(Bun, 'openInEditor').mockImplementation(
       () => {},
     );
     const response = await testRequest(
       new Request(
         `http://localhost:1234/__brisa_dev_file__?file=${encodeURIComponent(
-          "src/pages/somepage.tsx",
+          'src/pages/somepage.tsx',
         )}&line=1&column=1`,
-        { method: "POST" },
+        { method: 'POST' },
       ),
     );
 
@@ -2024,28 +2024,28 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     mockOpenInEditor.mockRestore();
   });
 
-  it("should open the editor calling /__brisa_dev_file__ with internal brisa file from build with line and column", async () => {
+  it('should open the editor calling /__brisa_dev_file__ with internal brisa file from build with line and column', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       IS_DEVELOPMENT: true,
     };
-    const mockOpenInEditor = spyOn(Bun, "openInEditor").mockImplementation(
+    const mockOpenInEditor = spyOn(Bun, 'openInEditor').mockImplementation(
       () => {},
     );
     const inputFile = encodeURIComponent(
-      "/_brisa/pages/index-595519026220381824.js",
+      '/_brisa/pages/index-595519026220381824.js',
     );
     const expectedFile = path.resolve(
       BUILD_DIR,
-      "pages-client",
-      "index-595519026220381824.js",
+      'pages-client',
+      'index-595519026220381824.js',
     );
     const response = await testRequest(
       new Request(
         `http://localhost:1234/__brisa_dev_file__?file=${inputFile}&line=1&column=1`,
         {
-          method: "POST",
+          method: 'POST',
         },
       ),
     );
@@ -2058,21 +2058,21 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     mockOpenInEditor.mockRestore();
   });
 
-  it("should return 404 trying to open the editor calling /__brisa_dev_file__ with file, line and column with method GET", async () => {
+  it('should return 404 trying to open the editor calling /__brisa_dev_file__ with file, line and column with method GET', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       IS_PRODUCTION: false,
       IS_DEVELOPMENT: true,
     };
-    const mockOpenInEditor = spyOn(Bun, "openInEditor").mockImplementation(
+    const mockOpenInEditor = spyOn(Bun, 'openInEditor').mockImplementation(
       () => {},
     );
     const response = await testRequest(
       new Request(
         `http://localhost:1234/__brisa_dev_file__?file=${encodeURIComponent(
-          "src/pages/somepage.tsx",
+          'src/pages/somepage.tsx',
         )}&line=1&column=1`,
-        { method: "GET" },
+        { method: 'GET' },
       ),
     );
 
@@ -2081,7 +2081,7 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     mockOpenInEditor.mockRestore();
   });
 
-  it("should work declarative shadow DOM on server actions when is form call without RPC", async () => {
+  it('should work declarative shadow DOM on server actions when is form call without RPC', async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
     globalThis.mockConstants = {
@@ -2089,15 +2089,15 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       I18N_CONFIG: undefined,
     };
 
-    mock.module("@/utils/response-action", () => ({
+    mock.module('@/utils/response-action', () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage?_aid=2`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "x-action": "a1_1",
+          'x-action': 'a1_1',
         },
       }),
     );
@@ -2109,7 +2109,7 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     ).toBeFalse();
   });
 
-  it("should return a soft redirect from an action", async () => {
+  it('should return a soft redirect from an action', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
@@ -2119,36 +2119,36 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       new Request(
         `http://localhost:1234${basePath}/somepage?_aid=2&redirect=/`,
         {
-          method: "POST",
+          method: 'POST',
           headers: {
-            "x-action": "a1_1",
+            'x-action': 'a1_1',
           },
         },
       ),
     );
 
     expect(res.status).toBe(200);
-    expect(res.headers.get("x-navigate")).toBe("/");
+    expect(res.headers.get('x-navigate')).toBe('/');
   });
 
-  it("should return a soft redirect from an action with i18n resolving the correct locale", async () => {
+  it('should return a soft redirect from an action with i18n resolving the correct locale', async () => {
     const res = await testRequest(
       new Request(
         `http://localhost:1234${basePath}/en/somepage?_aid=2&redirect=/`,
         {
-          method: "POST",
+          method: 'POST',
           headers: {
-            "x-action": "a1_1",
+            'x-action': 'a1_1',
           },
         },
       ),
     );
 
     expect(res.status).toBe(200);
-    expect(res.headers.get("x-navigate")).toBe("/en");
+    expect(res.headers.get('x-navigate')).toBe('/en');
   });
 
-  it("should return a soft redirect from an SPA navigation", async () => {
+  it('should return a soft redirect from an SPA navigation', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
@@ -2156,26 +2156,26 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
 
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage?redirect=/`, {
-        method: "POST",
+        method: 'POST',
       }),
     );
 
     expect(res.status).toBe(200);
-    expect(res.headers.get("x-navigate")).toBe("/");
+    expect(res.headers.get('x-navigate')).toBe('/');
   });
 
-  it("should return a soft redirect from an SPA Navigation with i18n resolving the correct locale", async () => {
+  it('should return a soft redirect from an SPA Navigation with i18n resolving the correct locale', async () => {
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/en/somepage?redirect=/`, {
-        method: "POST",
+        method: 'POST',
       }),
     );
 
     expect(res.status).toBe(200);
-    expect(res.headers.get("x-navigate")).toBe("/en");
+    expect(res.headers.get('x-navigate')).toBe('/en');
   });
 
-  it("should return a HARD redirect from an API endpoint", async () => {
+  it('should return a HARD redirect from an API endpoint', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
@@ -2186,19 +2186,19 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
 
     expect(res.status).toBe(301);
-    expect(res.headers.get("location")).toBe("/");
+    expect(res.headers.get('location')).toBe('/');
   });
 
-  it("should return a HARD redirect from an API endpoint with i18n resolving the correct locale", async () => {
+  it('should return a HARD redirect from an API endpoint with i18n resolving the correct locale', async () => {
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/en/api/example?redirect=/`),
     );
 
     expect(res.status).toBe(301);
-    expect(res.headers.get("location")).toBe("/en");
+    expect(res.headers.get('location')).toBe('/en');
   });
 
-  it("should return a HARD redirect from an initial render", async () => {
+  it('should return a HARD redirect from an initial render', async () => {
     globalThis.mockConstants = {
       ...globalThis.mockConstants,
       I18N_CONFIG: undefined,
@@ -2209,19 +2209,19 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     );
 
     expect(res.status).toBe(301);
-    expect(res.headers.get("location")).toBe("/");
+    expect(res.headers.get('location')).toBe('/');
   });
 
-  it("should return a HARD redirect from an initial render with i18n resolving the correct locale", async () => {
+  it('should return a HARD redirect from an initial render with i18n resolving the correct locale', async () => {
     const res = await testRequest(
       new Request(`http://localhost:1234${basePath}/en/somepage?redirect=/`),
     );
 
     expect(res.status).toBe(301);
-    expect(res.headers.get("location")).toBe("/en");
+    expect(res.headers.get('location')).toBe('/en');
   });
 
-  it("should avoid declarative shadow DOM on server actions", async () => {
+  it('should avoid declarative shadow DOM on server actions', async () => {
     const mockResponseAction = mock((req: RequestContext) => {});
 
     globalThis.mockConstants = {
@@ -2229,15 +2229,15 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
       I18N_CONFIG: undefined,
     };
 
-    mock.module("@/utils/response-action", () => ({
+    mock.module('@/utils/response-action', () => ({
       default: (req: RequestContext) => mockResponseAction(req),
     }));
 
     await testRequest(
       new Request(`http://localhost:1234${basePath}/somepage`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "x-action": "a1_1",
+          'x-action': 'a1_1',
         },
       }),
     );
@@ -2249,7 +2249,7 @@ describe.each(BASE_PATHS)("CLI: serve %s", (basePath) => {
     ).toBeTrue();
   });
 
-  it("should return idleTimeout as 30 ", async () => {
+  it('should return idleTimeout as 30 ', async () => {
     const serverOptions = await getServeOptions();
     expect(serverOptions!.idleTimeout).toBe(30);
   });

--- a/packages/brisa/src/cli/serve/serve-options.tsx
+++ b/packages/brisa/src/cli/serve/serve-options.tsx
@@ -12,7 +12,6 @@ import getImportableFilepath, {
 } from '@/utils/get-importable-filepath';
 import getRouteMatcher from '@/utils/get-route-matcher';
 import handleI18n from '@/utils/handle-i18n';
-import importFileIfExists from '@/utils/import-file-if-exists';
 import { isNotFoundError } from '@/utils/not-found';
 import redirectTrailingSlash from '@/utils/redirect-trailing-slash';
 import feedbackError from '@/utils/feedback-error';
@@ -25,6 +24,7 @@ import { Initiator } from '@/public-constants';
 import { AVOID_DECLARATIVE_SHADOW_DOM_SYMBOL } from '@/utils/ssr-web-component';
 import getReadableStreamFromPath from '@/utils/get-readable-stream-from-path';
 import getContentTypeFromPath from '@/utils/get-content-type-from-path';
+import { middleware } from 'brisa-project-internals';
 import getInitiator from '@/utils/get-initiator';
 import { handleSPARedirects } from '@/utils/hard-to-soft-redirect';
 import transferStoreService, {
@@ -70,8 +70,6 @@ export async function getServeOptions() {
   const WEBSOCKET_PATH = getImportableFilepath('websocket', BUILD_DIR);
   const wsModule = WEBSOCKET_PATH ? await import(WEBSOCKET_PATH) : null;
   const route404 = pagesRouter.reservedRoutes[PAGE_404];
-  const middlewareModule = await importFileIfExists('middleware', BUILD_DIR);
-  const customMiddleware = middlewareModule?.default;
   const tls = CONFIG?.tls;
   const basePath = CONFIG?.basePath ?? '';
 
@@ -263,10 +261,8 @@ export async function getServeOptions() {
     }
 
     // Middleware
-    if (customMiddleware) {
-      // @ts-ignore TODO: Remove this comment when TypeScript adds Promise.try
-      const middlewareResponse = await Promise.try(() => customMiddleware(req));
-
+    if (middleware) {
+      const middlewareResponse = await Promise.try(() => middleware(req));
       if (middlewareResponse) return middlewareResponse;
     }
 

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import path from 'node:path';
+import { getConstants } from '@/constants';
+import attachBrisaProjectInternalsPlugin from '.';
+
+const BUILD_DIR = path.join(import.meta.dir, '..', '..', '__fixtures__');
+
+describe('attach-brisa-project-internals', () => {
+  beforeEach(() => {
+    globalThis.mockConstants = {
+      ...(getConstants() ?? {}),
+      BUILD_DIR,
+    };
+  });
+
+  it('should export the middleware', () => {
+    const plugin = attachBrisaProjectInternalsPlugin();
+    const onLoad = mock(() => {});
+
+    plugin.setup({ onLoad } as any);
+
+    const [filter, pluginFn] = onLoad.mock.calls[0] as any;
+
+    expect(filter).toEqual({ filter: /brisa-project-internals/ });
+    expect(pluginFn({ loader: 'ts' })).toEqual({
+      contents: `export { default as middleware } from '${BUILD_DIR}/middleware.ts';`,
+      loader: 'ts',
+    });
+  });
+});

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
@@ -1,0 +1,29 @@
+import type { BunPlugin } from 'bun';
+import getImportableFilepath from '@/utils/get-importable-filepath';
+import { getConstants } from '@/constants';
+
+/**
+ * This plugin substitute the dynamic imports of packages/brisa/src/brisa-project-internals.ts to
+ * static imports. Useful to support to compile the app into binary to improve memory in runtime #628
+ *
+ * TODO: Currently is WIP. See TODO's of #628 to finish this.
+ */
+export default function attachBrisaProjectInternalsPlugin() {
+  const { BUILD_DIR } = getConstants();
+  const middlewarePath = getImportableFilepath('middleware', BUILD_DIR);
+  const middlewareExport = middlewarePath
+    ? `export { default as middleware } from '${middlewarePath}';`
+    : 'export const middleware = null;';
+
+  return {
+    name: 'attach-brisa-project-internals',
+    setup(build) {
+      build.onLoad({ filter: /brisa-project-internals/ }, ({ loader }) => {
+        return {
+          contents: middlewareExport,
+          loader,
+        };
+      });
+    },
+  } satisfies BunPlugin;
+}

--- a/packages/brisa/src/utils/compile-serve-internals-into-build/index.ts
+++ b/packages/brisa/src/utils/compile-serve-internals-into-build/index.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import { getConstants } from '@/constants';
 import { logBuildError } from '../log/log-build';
 import getImportableFilepath from '../get-importable-filepath';
+import attachBrisaProjectInternalsPlugin from '@/utils/attach-brisa-project-internals';
 
 const SERVER_OUTPUTS = new Set(['bun', 'node', 'deno']);
 const NO_SERVER_EXPORTS = new Set([
@@ -82,6 +83,7 @@ export default async function compileServeInternalsIntoBuild() {
       entry: '[name].[ext]',
     },
     external: CONFIG.external,
+    plugins: [attachBrisaProjectInternalsPlugin()],
     // Note: for Deno we need "node" as target too
     target: isBun ? 'bun' : 'node',
     banner: [

--- a/packages/brisa/tsconfig.json
+++ b/packages/brisa/tsconfig.json
@@ -5,6 +5,7 @@
     "jsxImportSource": "brisa",
     "baseUrl": "./src",
     "paths": {
+      "brisa-project-internals/*": ["src/brisa-project-internals.ts"],
       "@/*": ["*"]
     }
   },


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/798
Related to https://github.com/brisa-build/brisa/issues/628

This:

- Improve req/sec
- Facilitate compile the app as binary file (future PRs)

We need more work (TODO's on #628), but for now, in this PR, the middleware in production is using the static import! 