### PR TITLE
fix(build): transform i18n import from dynamic to static

### DIFF
--- a/packages/brisa/src/brisa-project-internals.ts
+++ b/packages/brisa/src/brisa-project-internals.ts
@@ -1,7 +1,11 @@
 import importFileIfExists from '@/utils/import-file-if-exists';
-import { getConstants } from '@/constants';
+import { internalConstants } from '@/utils/load-constants';
+import type { I18nConfig } from "brisa";
 
-const { BUILD_DIR } = getConstants();
+// All this is temporal to work in DEV (brisa dev), in the future DEV is going to work
+// in the same way that PROD works (without dynamic imports and these constants would
+// be needed only in build-time, inside attach-brisa-project-internals)
+const { BUILD_DIR, WORKSPACE } = internalConstants();
 
 /**
  * WIP https://github.com/brisa-build/brisa/issues/628
@@ -12,16 +16,17 @@ const { BUILD_DIR } = getConstants();
  * Useful to avoid dynamic imports. Being possible to compile the app into binary to
  * improve memory in runtime.
  */
-const middlewareModule = await importFileIfExists('middleware', BUILD_DIR);
-export const middleware = middlewareModule?.default;
+export const middleware = (await importFileIfExists('middleware', BUILD_DIR))
+  ?.default;
+export const i18n = (await importFileIfExists('i18n', WORKSPACE))
+  ?.default as I18nConfig;
 
 // TODO:
-export const i18n = null;
 export const config = null;
+export const integrations = null;
+export const cssFiles = [];
 export const api = [];
 export const layout = null;
 export const websockets = null;
 export const actions = null;
 export const pages = [];
-export const integrations = null;
-export const cssFiles = [];

--- a/packages/brisa/src/constants.ts
+++ b/packages/brisa/src/constants.ts
@@ -1,8 +1,6 @@
-import type { BrisaConstants, I18nConfig } from './types';
-import {
-  internalConstants,
-  loadProjectConstants,
-} from './utils/load-constants';
+import type { BrisaConstants } from './types';
+import { internalConstants } from '@/utils/load-constants';
+import { loadProjectConstants } from '@/utils/load-constants/load-project-constants';
 
 const internal = internalConstants();
 

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import path from 'node:path';
+import { normalizeHTML } from '@/helpers';
 import { getConstants } from '@/constants';
 import attachBrisaProjectInternalsPlugin from '.';
 
@@ -13,18 +14,21 @@ describe('attach-brisa-project-internals', () => {
     };
   });
 
-  it('should export the middleware', () => {
+  it('should export the middleware & i18n', () => {
     const plugin = attachBrisaProjectInternalsPlugin();
     const onLoad = mock(() => {});
 
     plugin.setup({ onLoad } as any);
 
     const [filter, pluginFn] = onLoad.mock.calls[0] as any;
+    const pluginContent = pluginFn({ loader: 'ts' });
 
     expect(filter).toEqual({ filter: /brisa-project-internals/ });
-    expect(pluginFn({ loader: 'ts' })).toEqual({
-      contents: `export { default as middleware } from '${BUILD_DIR}/middleware.ts';`,
-      loader: 'ts',
-    });
+    expect(normalizeHTML(pluginContent.contents)).toBe(
+      normalizeHTML(`
+      export { default as middleware } from '${BUILD_DIR}/middleware.ts';
+      export { default as i18n } from '${BUILD_DIR}/i18n.ts';
+    `),
+    );
   });
 });

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
@@ -15,12 +15,17 @@ export default function attachBrisaProjectInternalsPlugin() {
     ? `export { default as middleware } from '${middlewarePath}';`
     : 'export const middleware = null;';
 
+  const i18nPath = getImportableFilepath('i18n', BUILD_DIR);
+  const i18nExport = i18nPath
+    ? `export { default as i18n } from '${i18nPath}';`
+    : 'export const i18n = null;';
+
   return {
     name: 'attach-brisa-project-internals',
     setup(build) {
       build.onLoad({ filter: /brisa-project-internals/ }, ({ loader }) => {
         return {
-          contents: middlewareExport,
+          contents: `${middlewareExport}${i18nExport}`,
           loader,
         };
       });

--- a/packages/brisa/src/utils/client-build/layout-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/layout-build/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 3653;
 const brisaSize = 5738; // TODO: Reduce this size :/
 const webComponents = 1118;
 const unsuspenseSize = 213;
-const rpcSize = 2489; // TODO: Reduce this size
+const rpcSize = 2499; // TODO: Reduce this size
 const lazyRPCSize = 4308; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/load-constants/index.test.ts
+++ b/packages/brisa/src/utils/load-constants/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, spyOn, afterEach, mock } from 'bun:test';
 import path from 'node:path';
-import { internalConstants, loadProjectConstants } from '.';
+import { internalConstants } from '.';
+import { loadProjectConstants } from './load-project-constants';
 
 let mockPathJoin: ReturnType<typeof spyOn>;
 

--- a/packages/brisa/src/utils/load-constants/index.ts
+++ b/packages/brisa/src/utils/load-constants/index.ts
@@ -1,7 +1,5 @@
 import path from 'node:path';
-import importFileIfExists from '../import-file-if-exists';
-import type { I18nConfig, InternalConstants, ProjectConstants } from '@/types';
-import type { BunPlugin } from 'bun';
+import type { InternalConstants } from '@/types';
 import {
   blueLog,
   cyanLog,
@@ -15,15 +13,6 @@ import { getRuntime } from '../js-runtime-util';
 const WIN32_SEP_REGEX = /\\/g;
 const PAGE_404 = '/_404';
 const PAGE_500 = '/_500';
-const OS_CAN_LOAD_BALANCE =
-  process.platform !== 'darwin' && process.platform !== 'win32';
-
-const staticExportOutputOption = new Set([
-  'static',
-  'desktop',
-  'android',
-  'ios',
-]);
 
 export function internalConstants(): InternalConstants {
   const currentScript = process.argv[1] ?? '';
@@ -97,82 +86,4 @@ export function internalConstants(): InternalConstants {
         : 'no-store, must-revalidate',
     },
   };
-}
-
-export async function loadProjectConstants({
-  IS_PRODUCTION,
-  BUILD_DIR,
-  WORKSPACE,
-  ROOT_DIR,
-  IS_BUILD_PROCESS,
-}: InternalConstants): Promise<ProjectConstants> {
-  const defaultConfig = {
-    trailingSlash: false,
-    assetPrefix: '',
-    basePath: '',
-    extendPlugins: (plugins: BunPlugin[]) => plugins,
-    output: 'bun',
-    clustering: IS_PRODUCTION && OS_CAN_LOAD_BALANCE,
-    integrations: [],
-    idleTimeout: 30,
-  };
-
-  const defaultExternalDeps = IS_BUILD_PROCESS
-    ? [...getDevDeps(), 'lightningcss']
-    : [];
-  const CSS_FILES =
-    (await importFileIfExists('css-files', BUILD_DIR))?.default ?? [];
-  const integrations = await importFileIfExists(
-    '_integrations',
-    path.resolve(BUILD_DIR, 'web-components'),
-  );
-  const WEB_CONTEXT_PLUGINS = integrations?.webContextPlugins ?? [];
-  const I18N_CONFIG = (await importFileIfExists('i18n', WORKSPACE))
-    ?.default as I18nConfig;
-  const CONFIG = {
-    ...defaultConfig,
-    ...((await importFileIfExists('brisa.config', ROOT_DIR))?.default ?? {}),
-  };
-  const IS_STATIC_EXPORT = staticExportOutputOption.has(CONFIG?.output);
-
-  // Remove trailing slash from pages
-  if (I18N_CONFIG?.pages) {
-    I18N_CONFIG.pages = JSON.parse(
-      JSON.stringify(I18N_CONFIG.pages, (key, value) =>
-        typeof value === 'string' && value.length > 1
-          ? value.replace(/\/$/g, '')
-          : value,
-      ),
-    );
-  }
-
-  const LOCALES_SET = new Set(I18N_CONFIG?.locales || []) as Set<string>;
-
-  if (CONFIG.basePath && !CONFIG.basePath.startsWith(path.sep)) {
-    CONFIG.basePath = path.sep + CONFIG.basePath;
-  }
-
-  // Add external libraries to the list of external libraries
-  if (!CONFIG.external) CONFIG.external = defaultExternalDeps;
-  else CONFIG.external = [...CONFIG.external, ...defaultExternalDeps];
-
-  // This is needed for some helpers like "navigate" to work properly
-  // in the server side. (For the client-side it's solved during the build process)
-  globalThis.__BASE_PATH__ = CONFIG.basePath;
-
-  return {
-    CSS_FILES,
-    CONFIG,
-    I18N_CONFIG,
-    WEB_CONTEXT_PLUGINS,
-    LOCALES_SET,
-    IS_STATIC_EXPORT,
-  };
-}
-
-function getDevDeps() {
-  const packageJSONDir = process.env.npm_package_json;
-  if (!packageJSONDir) return [];
-  const packageJSON = require(packageJSONDir);
-  return Object.keys(packageJSON.devDependencies || {});
 }

--- a/packages/brisa/src/utils/load-constants/load-project-constants.ts
+++ b/packages/brisa/src/utils/load-constants/load-project-constants.ts
@@ -1,0 +1,92 @@
+import path from 'node:path';
+import importFileIfExists from '../import-file-if-exists';
+import { i18n } from 'brisa-project-internals';
+import type { InternalConstants, ProjectConstants } from '@/types';
+import type { BunPlugin } from 'bun';
+
+const OS_CAN_LOAD_BALANCE =
+  process.platform !== 'darwin' && process.platform !== 'win32';
+
+const staticExportOutputOption = new Set([
+  'static',
+  'desktop',
+  'android',
+  'ios',
+]);
+
+export async function loadProjectConstants({
+  IS_PRODUCTION,
+  BUILD_DIR,
+  WORKSPACE,
+  ROOT_DIR,
+  IS_BUILD_PROCESS,
+}: InternalConstants): Promise<ProjectConstants> {
+  const defaultConfig = {
+    trailingSlash: false,
+    assetPrefix: '',
+    basePath: '',
+    extendPlugins: (plugins: BunPlugin[]) => plugins,
+    output: 'bun',
+    clustering: IS_PRODUCTION && OS_CAN_LOAD_BALANCE,
+    integrations: [],
+    idleTimeout: 30,
+  };
+
+  const defaultExternalDeps = IS_BUILD_PROCESS
+    ? [...getDevDeps(), 'lightningcss']
+    : [];
+  const CSS_FILES =
+    (await importFileIfExists('css-files', BUILD_DIR))?.default ?? [];
+  const integrations = await importFileIfExists(
+    '_integrations',
+    path.resolve(BUILD_DIR, 'web-components'),
+  );
+  const WEB_CONTEXT_PLUGINS = integrations?.webContextPlugins ?? [];
+  const I18N_CONFIG = i18n;
+  const CONFIG = {
+    ...defaultConfig,
+    ...((await importFileIfExists('brisa.config', ROOT_DIR))?.default ?? {}),
+  };
+  const IS_STATIC_EXPORT = staticExportOutputOption.has(CONFIG?.output);
+
+  // Remove trailing slash from pages
+  if (I18N_CONFIG?.pages) {
+    I18N_CONFIG.pages = JSON.parse(
+      JSON.stringify(I18N_CONFIG.pages, (key, value) =>
+        typeof value === 'string' && value.length > 1
+          ? value.replace(/\/$/g, '')
+          : value,
+      ),
+    );
+  }
+
+  const LOCALES_SET = new Set(I18N_CONFIG?.locales || []) as Set<string>;
+
+  if (CONFIG.basePath && !CONFIG.basePath.startsWith(path.sep)) {
+    CONFIG.basePath = path.sep + CONFIG.basePath;
+  }
+
+  // Add external libraries to the list of external libraries
+  if (!CONFIG.external) CONFIG.external = defaultExternalDeps;
+  else CONFIG.external = [...CONFIG.external, ...defaultExternalDeps];
+
+  // This is needed for some helpers like "navigate" to work properly
+  // in the server side. (For the client-side it's solved during the build process)
+  globalThis.__BASE_PATH__ = CONFIG.basePath;
+
+  return {
+    CSS_FILES,
+    CONFIG,
+    I18N_CONFIG,
+    WEB_CONTEXT_PLUGINS,
+    LOCALES_SET,
+    IS_STATIC_EXPORT,
+  };
+}
+
+function getDevDeps() {
+  const packageJSONDir = process.env.npm_package_json;
+  if (!packageJSONDir) return [];
+  const packageJSON = require(packageJSONDir);
+  return Object.keys(packageJSON.devDependencies || {});
+}


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/799
Related to https://github.com/brisa-build/brisa/issues/628

Now i18n is incrusted to `server.js` in prod:

<img width="1245" alt="Screenshot 2025-03-23 at 22 15 23" src="https://github.com/user-attachments/assets/6f28efd2-3cb6-4c26-9ba4-8e194d0bfa93" />

