### PR TITLE
fix(build): transform brisa.config import from dynamic to static

### DIFF
--- a/packages/brisa/src/brisa-project-internals.ts
+++ b/packages/brisa/src/brisa-project-internals.ts
@@ -1,11 +1,11 @@
 import importFileIfExists from '@/utils/import-file-if-exists';
 import { internalConstants } from '@/utils/load-constants';
-import type { I18nConfig } from "brisa";
+import type { I18nConfig } from 'brisa';
 
 // All this is temporal to work in DEV (brisa dev), in the future DEV is going to work
 // in the same way that PROD works (without dynamic imports and these constants would
 // be needed only in build-time, inside attach-brisa-project-internals)
-const { BUILD_DIR, WORKSPACE } = internalConstants();
+const { BUILD_DIR, WORKSPACE, ROOT_DIR } = internalConstants();
 
 /**
  * WIP https://github.com/brisa-build/brisa/issues/628
@@ -20,9 +20,10 @@ export const middleware = (await importFileIfExists('middleware', BUILD_DIR))
   ?.default;
 export const i18n = (await importFileIfExists('i18n', WORKSPACE))
   ?.default as I18nConfig;
+export const config =
+  (await importFileIfExists('brisa.config', ROOT_DIR))?.default ?? {};
 
 // TODO:
-export const config = null;
 export const integrations = null;
 export const cssFiles = [];
 export const api = [];

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
@@ -11,6 +11,7 @@ describe('attach-brisa-project-internals', () => {
     globalThis.mockConstants = {
       ...(getConstants() ?? {}),
       BUILD_DIR,
+      ROOT_DIR: BUILD_DIR,
     };
   });
 
@@ -28,6 +29,7 @@ describe('attach-brisa-project-internals', () => {
       normalizeHTML(`
       export { default as middleware } from '${BUILD_DIR}/middleware.ts';
       export { default as i18n } from '${BUILD_DIR}/i18n.ts';
+      export { default as config } from '${BUILD_DIR}/brisa.config.ts';
     `),
     );
   });

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
@@ -23,7 +23,7 @@ export default function attachBrisaProjectInternalsPlugin() {
   const configPath = getImportableFilepath('brisa.config', ROOT_DIR);
   const configExport = configPath
     ? `export { default as config } from '${configPath}';`
-    : 'export const config = null;';
+    : 'export const config = {};';
 
   return {
     name: 'attach-brisa-project-internals',

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
@@ -9,7 +9,7 @@ import { getConstants } from '@/constants';
  * TODO: Currently is WIP. See TODO's of #628 to finish this.
  */
 export default function attachBrisaProjectInternalsPlugin() {
-  const { BUILD_DIR } = getConstants();
+  const { BUILD_DIR, ROOT_DIR } = getConstants();
   const middlewarePath = getImportableFilepath('middleware', BUILD_DIR);
   const middlewareExport = middlewarePath
     ? `export { default as middleware } from '${middlewarePath}';`
@@ -20,12 +20,17 @@ export default function attachBrisaProjectInternalsPlugin() {
     ? `export { default as i18n } from '${i18nPath}';`
     : 'export const i18n = null;';
 
+  const configPath = getImportableFilepath('brisa.config', ROOT_DIR);
+  const configExport = configPath
+    ? `export { default as config } from '${configPath}';`
+    : 'export const config = null;';
+
   return {
     name: 'attach-brisa-project-internals',
     setup(build) {
       build.onLoad({ filter: /brisa-project-internals/ }, ({ loader }) => {
         return {
-          contents: `${middlewareExport}${i18nExport}`,
+          contents: `${middlewareExport}${i18nExport}${configExport}`,
           loader,
         };
       });

--- a/packages/brisa/src/utils/load-constants/load-project-constants.ts
+++ b/packages/brisa/src/utils/load-constants/load-project-constants.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import importFileIfExists from '../import-file-if-exists';
-import { i18n } from 'brisa-project-internals';
+import { i18n, config } from 'brisa-project-internals';
 import type { InternalConstants, ProjectConstants } from '@/types';
 import type { BunPlugin } from 'bun';
 
@@ -45,7 +45,7 @@ export async function loadProjectConstants({
   const I18N_CONFIG = i18n;
   const CONFIG = {
     ...defaultConfig,
-    ...((await importFileIfExists('brisa.config', ROOT_DIR))?.default ?? {}),
+    ...config,
   };
   const IS_STATIC_EXPORT = staticExportOutputOption.has(CONFIG?.output);
 


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/801
Related to https://github.com/brisa-build/brisa/issues/628

Now brisa.config is incrusted into the `build/server.js` . No more need of dynamic import for it.