### PR TITLE
fix(build): transform web integrations import from dynamic to static

### DIFF
--- a/packages/brisa/src/brisa-project-internals.ts
+++ b/packages/brisa/src/brisa-project-internals.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'node:path';
 import importFileIfExists from '@/utils/import-file-if-exists';
 import { internalConstants } from '@/utils/load-constants';
 import type { I18nConfig } from 'brisa';
@@ -18,13 +19,19 @@ const { BUILD_DIR, WORKSPACE, ROOT_DIR } = internalConstants();
  */
 export const middleware = (await importFileIfExists('middleware', BUILD_DIR))
   ?.default;
+
 export const i18n = (await importFileIfExists('i18n', WORKSPACE))
   ?.default as I18nConfig;
+
 export const config =
   (await importFileIfExists('brisa.config', ROOT_DIR))?.default ?? {};
 
+export const integrations = await importFileIfExists(
+  '_integrations',
+  resolve(BUILD_DIR, 'web-components'),
+);
+
 // TODO:
-export const integrations = null;
 export const cssFiles = [];
 export const api = [];
 export const layout = null;

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
@@ -30,6 +30,7 @@ describe('attach-brisa-project-internals', () => {
       export { default as middleware } from '${BUILD_DIR}/middleware.ts';
       export { default as i18n } from '${BUILD_DIR}/i18n.ts';
       export { default as config } from '${BUILD_DIR}/brisa.config.ts';
+      export { default as integrations } from '${BUILD_DIR}/web-components/_integrations.tsx';
     `),
     );
   });

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
@@ -1,4 +1,5 @@
 import type { BunPlugin } from 'bun';
+import { resolve } from 'node:path';
 import getImportableFilepath from '@/utils/get-importable-filepath';
 import { getConstants } from '@/constants';
 
@@ -25,12 +26,20 @@ export default function attachBrisaProjectInternalsPlugin() {
     ? `export { default as config } from '${configPath}';`
     : 'export const config = {};';
 
+  const webIntegrationsPath = getImportableFilepath(
+    '_integrations',
+    resolve(BUILD_DIR, 'web-components'),
+  );
+  const webIntegrationsExport = webIntegrationsPath
+    ? `export { default as integrations } from '${webIntegrationsPath}';`
+    : 'export const integrations = null;';
+
   return {
     name: 'attach-brisa-project-internals',
     setup(build) {
       build.onLoad({ filter: /brisa-project-internals/ }, ({ loader }) => {
         return {
-          contents: `${middlewareExport}${i18nExport}${configExport}`,
+          contents: `${middlewareExport}${i18nExport}${configExport}${webIntegrationsExport}`,
           loader,
         };
       });

--- a/packages/brisa/src/utils/load-constants/load-project-constants.ts
+++ b/packages/brisa/src/utils/load-constants/load-project-constants.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import importFileIfExists from '../import-file-if-exists';
-import { i18n, config } from 'brisa-project-internals';
+import { i18n, config, integrations } from 'brisa-project-internals';
 import type { InternalConstants, ProjectConstants } from '@/types';
 import type { BunPlugin } from 'bun';
 
@@ -37,10 +37,6 @@ export async function loadProjectConstants({
     : [];
   const CSS_FILES =
     (await importFileIfExists('css-files', BUILD_DIR))?.default ?? [];
-  const integrations = await importFileIfExists(
-    '_integrations',
-    path.resolve(BUILD_DIR, 'web-components'),
-  );
   const WEB_CONTEXT_PLUGINS = integrations?.webContextPlugins ?? [];
   const I18N_CONFIG = i18n;
   const CONFIG = {


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/804
Related to https://github.com/brisa-build/brisa/issues/628

Now web integrations are embedded into the build to avoid a dynamic import.


For now: middleware, i18n and integrations:

<img width="1280" alt="Screenshot 2025-03-25 at 18 18 50" src="https://github.com/user-attachments/assets/e0b21ab2-f12d-4396-b5ed-f69c68bc6220" />

The next PRs are the ones where the improvement of req/sec will be most noticeable (pages, api endpoints, actions...)
