### PR TITLE
fix(build): transform layout module from dynamic import to static

### DIFF
--- a/packages/brisa/src/brisa-project-internals.ts
+++ b/packages/brisa/src/brisa-project-internals.ts
@@ -31,10 +31,11 @@ export const integrations = await importFileIfExists(
   resolve(BUILD_DIR, 'web-components'),
 );
 
+export const layoutModule = await importFileIfExists('layout', BUILD_DIR);
+
 // TODO:
 export const cssFiles = [];
 export const api = [];
-export const layout = null;
 export const websockets = null;
 export const actions = null;
 export const pages = [];

--- a/packages/brisa/src/cli/serve/serve-options.test.tsx
+++ b/packages/brisa/src/cli/serve/serve-options.test.tsx
@@ -25,6 +25,8 @@ import {
 
 // @ts-ignore
 import middleware from '../../__fixtures__/middleware.ts';
+// @ts-ignore
+import * as layoutModule from '../../__fixtures__/layout.tsx';
 
 const BUILD_DIR = path.join(import.meta.dir, '..', '..', '__fixtures__');
 const PAGES_DIR = path.join(BUILD_DIR, 'pages');
@@ -53,7 +55,10 @@ const __CRYPTO_IV__ = process.env.__CRYPTO_IV__;
 
 describe.each(BASE_PATHS)('CLI: serve %s', (basePath) => {
   beforeEach(async () => {
-    mock.module('brisa-project-internals', () => ({ middleware }));
+    mock.module('brisa-project-internals', () => ({
+      middleware,
+      layoutModule,
+    }));
 
     // @ts-ignore - We need to test real server scenarios
     if (typeof window !== 'undefined') window = undefined;

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
@@ -33,6 +33,7 @@ describe('attach-brisa-project-internals', () => {
       export { default as i18n } from '${BUILD_DIR}/i18n.ts';
       export { default as config } from '${BUILD_DIR}/brisa.config.ts';
       export { default as integrations } from '${BUILD_DIR}/web-components/_integrations.tsx';
+      export * as layoutModule from '${BUILD_DIR}/layout.tsx';
     `),
     );
   });

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
@@ -34,6 +34,12 @@ export default function attachBrisaProjectInternalsPlugin() {
     ? `export { default as integrations } from '${webIntegrationsPath}';`
     : 'export const integrations = null;';
 
+  const layoutPath = getImportableFilepath('layout', BUILD_DIR);
+
+  const layoutExport = layoutPath
+    ? `export * as layoutModule from '${layoutPath}';`
+    : 'export const layoutModule = null;';
+
   return {
     name: 'attach-brisa-project-internals',
     setup(build) {
@@ -43,7 +49,7 @@ export default function attachBrisaProjectInternalsPlugin() {
       build.onLoad(
         { filter: new RegExp(import.meta.filename) },
         ({ loader }) => ({
-          contents: `${middlewareExport}${i18nExport}${configExport}${webIntegrationsExport}`,
+          contents: `${middlewareExport}${i18nExport}${configExport}${webIntegrationsExport}${layoutExport}`,
           loader,
         }),
       );

--- a/packages/brisa/src/utils/import-file-if-exists/index.ts
+++ b/packages/brisa/src/utils/import-file-if-exists/index.ts
@@ -7,6 +7,7 @@ export default async function importFileIfExists(
     | 'i18n'
     | 'brisa.config'
     | '_integrations'
+    | 'layout'
     | 'css-files'
     | 'actions',
   dir = path.join(process.cwd(), 'build'),

--- a/packages/brisa/src/utils/process-page-route/index.tsx
+++ b/packages/brisa/src/utils/process-page-route/index.tsx
@@ -3,9 +3,8 @@ import dangerHTML from '@/utils/danger-html';
 import { LiveReloadScript } from '@/cli/dev-live-reload';
 import LoadLayout from '@/utils/load-layout';
 import type { MatchedBrisaRoute, PageModule } from '@/types';
-import getImportableFilepath, {
-  pathToFileURLWhenNeeded,
-} from '@/utils/get-importable-filepath';
+import { layoutModule } from 'brisa-project-internals';
+import { pathToFileURLWhenNeeded } from '@/utils/get-importable-filepath';
 
 export const cache = new Map<string, any>();
 
@@ -24,8 +23,6 @@ export default async function processPageRoute(
   const module = (await import(
     pathToFileURLWhenNeeded(route.filePath)
   )) as PageModule;
-  const layoutPath = getImportableFilepath('layout', BUILD_DIR);
-  const layoutModule = layoutPath ? await import(layoutPath) : undefined;
   const PageComponent = module.default;
 
   const Page = () => (

--- a/packages/brisa/src/utils/response-rendered-page/index.test.ts
+++ b/packages/brisa/src/utils/response-rendered-page/index.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+  mock,
+} from 'bun:test';
 import path from 'node:path';
 
 import type { MatchedBrisaRoute, Translate } from '@/types';
@@ -7,12 +15,21 @@ import responseRenderedPage, { routeToPrerenderedPagePath } from '.';
 import { getConstants } from '@/constants';
 import { Initiator } from '@/public-constants';
 
+// @ts-ignore
+import middleware from '../../__fixtures__/middleware.ts';
+// @ts-ignore
+import * as layoutModule from '../../__fixtures__/layout.tsx';
+
 const BUILD_DIR = path.join(import.meta.dir, '..', '..', '__fixtures__');
 const PAGES_DIR = path.join(BUILD_DIR, 'pages');
 const ASSETS_DIR = path.join(BUILD_DIR, 'public');
 
 describe('utils', () => {
   beforeEach(async () => {
+    mock.module('brisa-project-internals', () => ({
+      middleware,
+      layoutModule,
+    }));
     globalThis.mockConstants = {
       ...(getConstants() ?? {}),
       PAGES_DIR,
@@ -29,6 +46,7 @@ describe('utils', () => {
 
   afterEach(() => {
     globalThis.mockConstants = undefined;
+    jest.restoreAllMocks();
   });
 
   describe('response-rendered-page', () => {


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/808
Related to https://github.com/brisa-build/brisa/issues/628

Now the layout load is not async anymore. 