### PR TITLE
fix(build): transform all page routes import from dynamic to static

### DIFF
--- a/packages/brisa/src/brisa-project-internals.ts
+++ b/packages/brisa/src/brisa-project-internals.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path';
 import importFileIfExists from '@/utils/import-file-if-exists';
 import { internalConstants } from '@/utils/load-constants';
+import { pathToFileURLWhenNeeded } from '@/utils/get-importable-filepath';
 import type { I18nConfig } from 'brisa';
 
 // All this is temporal to work in DEV (brisa dev), in the future DEV is going to work
@@ -33,9 +34,15 @@ export const integrations = await importFileIfExists(
 
 export const layoutModule = await importFileIfExists('layout', BUILD_DIR);
 
+// All dynamic pages (for dev)
+export const pages = new Proxy({} as Record<string, Promise<any>>, {
+  get(target, filePath: string) {
+    return import(pathToFileURLWhenNeeded(filePath));
+  },
+});
+
 // TODO:
 export const cssFiles = [];
 export const api = [];
 export const websockets = null;
 export const actions = null;
-export const pages = [];

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
@@ -1,11 +1,22 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
-import path from 'node:path';
+import { join } from 'node:path';
 import { normalizeHTML } from '@/helpers';
 import { getConstants } from '@/constants';
 import attachBrisaProjectInternalsPlugin from '.';
 
-const BUILD_DIR = path.join(import.meta.dirname, '..', '..', '__fixtures__');
-const DIR = path.join(import.meta.dirname, 'index.ts');
+const BUILD_DIR = join(import.meta.dirname, '..', '..', '__fixtures__');
+const PAGES_DIR = join(BUILD_DIR, 'pages');
+const DIR = join(import.meta.dirname, 'index.ts');
+
+// Pages
+const p1 = join(PAGES_DIR, 'index.tsx');
+const p2 = join(PAGES_DIR, 'foo.tsx');
+const p3 = join(PAGES_DIR, 'page-with-web-component.tsx');
+const p4 = join(PAGES_DIR, 'somepage.tsx');
+const p5 = join(PAGES_DIR, 'somepage-with-context.tsx');
+const p6 = join(PAGES_DIR, 'user', '[username].tsx');
+const p7 = join(PAGES_DIR, '_404.tsx');
+const p8 = join(PAGES_DIR, '_500.tsx');
 
 describe('attach-brisa-project-internals', () => {
   beforeEach(() => {
@@ -13,6 +24,7 @@ describe('attach-brisa-project-internals', () => {
       ...(getConstants() ?? {}),
       BUILD_DIR,
       ROOT_DIR: BUILD_DIR,
+      PAGES_DIR,
     };
   });
 
@@ -29,6 +41,26 @@ describe('attach-brisa-project-internals', () => {
     expect(filter).toEqual({ filter: new RegExp(DIR) });
     expect(normalizeHTML(pluginContent.contents)).toBe(
       normalizeHTML(`
+      import * as p1 from "${p1}";
+      import * as p2 from "${p2}";
+      import * as p3 from "${p3}";
+      import * as p4 from "${p4}";
+      import * as p5 from "${p5}";
+      import * as p6 from "${p6}";
+      import * as p7 from "${p7}";
+      import * as p8 from "${p8}";
+
+      const allPages = {};
+      allPages["${p1}"] = p1;
+      allPages["${p2}"] = p2;
+      allPages["${p3}"] = p3;
+      allPages["${p4}"] = p4;
+      allPages["${p5}"] = p5;
+      allPages["${p6}"] = p6;
+      allPages["${p7}"] = p7;
+      allPages["${p8}"] = p8;
+      export const pages = allPages;
+
       export { default as middleware } from '${BUILD_DIR}/middleware.ts';
       export { default as i18n } from '${BUILD_DIR}/i18n.ts';
       export { default as config } from '${BUILD_DIR}/brisa.config.ts';

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
@@ -2,6 +2,7 @@ import type { BunPlugin } from 'bun';
 import { resolve } from 'node:path';
 import getImportableFilepath from '@/utils/get-importable-filepath';
 import { getConstants } from '@/constants';
+import { fileSystemRouter } from '@/utils/file-system-router';
 
 /**
  * This plugin substitute the dynamic imports of packages/brisa/src/brisa-project-internals.ts to
@@ -40,6 +41,8 @@ export default function attachBrisaProjectInternalsPlugin() {
     ? `export * as layoutModule from '${layoutPath}';`
     : 'export const layoutModule = null;';
 
+  const pages = getPagesExport();
+
   return {
     name: 'attach-brisa-project-internals',
     setup(build) {
@@ -49,10 +52,28 @@ export default function attachBrisaProjectInternalsPlugin() {
       build.onLoad(
         { filter: new RegExp(import.meta.filename) },
         ({ loader }) => ({
-          contents: `${middlewareExport}${i18nExport}${configExport}${webIntegrationsExport}${layoutExport}`,
+          contents: `${pages.imports}${pages.exports}${middlewareExport}${i18nExport}${configExport}${webIntegrationsExport}${layoutExport}`,
           loader,
         }),
       );
     },
   } satisfies BunPlugin;
+}
+
+function getPagesExport() {
+  const { PAGES_DIR } = getConstants();
+  const { routes } = fileSystemRouter({ dir: PAGES_DIR });
+  let count = 0;
+  let imports = '';
+  let objectCreation = 'const allPages = {};';
+
+  for (const [, filePath] of routes) {
+    imports += `import * as p${++count} from "${filePath}";\n`;
+    objectCreation += `allPages["${filePath}"] = p${count};\n`;
+  }
+
+  return {
+    imports,
+    exports: `${objectCreation}export const pages = allPages;`,
+  };
 }

--- a/packages/brisa/src/utils/compile-serve-internals-into-build/index.test.ts
+++ b/packages/brisa/src/utils/compile-serve-internals-into-build/index.test.ts
@@ -14,9 +14,11 @@ import compileBrisaInternalsToDoBuildPortable from '.';
 const BUILD_DIR = path.join(import.meta.dirname, 'out');
 const BRISA_DIR = path.join(import.meta.dirname, '..', '..', '..');
 const CONFIG_DIR = path.join(import.meta.dirname, 'brisa.config.js');
+const PAGES_DIR = path.join(BUILD_DIR, 'pages');
 const mockConstants = {
   BUILD_DIR,
   BRISA_DIR,
+  PAGES_DIR,
   VERSION: 'x.y.z',
   WORKSPACE: BUILD_DIR,
   LOG_PREFIX: { INFO: 'INFO' } as any,

--- a/packages/brisa/src/utils/file-system-router/index.ts
+++ b/packages/brisa/src/utils/file-system-router/index.ts
@@ -153,10 +153,12 @@ function resolveRoutes({
   fileExtensions = DEFAULT_EXTENSIONS,
 }: FileSystemRouterOptions) {
   const routes: Record<string, string> = {};
-  const files = fs.readdirSync(dir, {
-    withFileTypes: true,
-    recursive: true,
-  });
+  const files = fs.existsSync(dir)
+    ? fs.readdirSync(dir, {
+        withFileTypes: true,
+        recursive: true,
+      })
+    : [];
 
   for (const file of files) {
     if (file.isDirectory() || isTestFile(file.name, true)) continue;

--- a/packages/brisa/src/utils/process-page-route/index.test.tsx
+++ b/packages/brisa/src/utils/process-page-route/index.test.tsx
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { getConstants } from '@/constants';
 import renderToReadableStream from '@/utils/render-to-readable-stream';
 import extendRequestContext from '@/utils/extend-request-context';
-import processPageRoute, { cache } from '.';
+import processPageRoute from '.';
 import { toInline } from '@/helpers';
 import translateCore from '@/utils/translate-core';
 import type { MatchedBrisaRoute, RequestContext } from '@/types';
@@ -33,7 +33,6 @@ const routeHomepage = { filePath: HOMEPAGE } as unknown as MatchedBrisaRoute;
 
 describe('utils', () => {
   beforeEach(() => {
-    cache.clear();
     globalThis.mockConstants = getConstants() ?? {};
   });
 

--- a/packages/brisa/src/utils/process-page-route/index.tsx
+++ b/packages/brisa/src/utils/process-page-route/index.tsx
@@ -2,29 +2,16 @@ import { getConstants } from '@/constants';
 import dangerHTML from '@/utils/danger-html';
 import { LiveReloadScript } from '@/cli/dev-live-reload';
 import LoadLayout from '@/utils/load-layout';
-import type { MatchedBrisaRoute, PageModule } from '@/types';
-import { layoutModule } from 'brisa-project-internals';
-import { pathToFileURLWhenNeeded } from '@/utils/get-importable-filepath';
-
-export const cache = new Map<string, any>();
+import type { MatchedBrisaRoute } from '@/types';
+import { layoutModule, pages } from 'brisa-project-internals';
 
 export default async function processPageRoute(
   route: MatchedBrisaRoute,
   error?: Error,
 ) {
-  const { BUILD_DIR, IS_PRODUCTION } = getConstants();
-
-  // This cache improves the req/sec 575%
-  // https://github.com/brisa-build/brisa/pull/604
-  if (IS_PRODUCTION && cache.has(route.filePath)) {
-    return cache.get(route.filePath);
-  }
-
-  const module = (await import(
-    pathToFileURLWhenNeeded(route.filePath)
-  )) as PageModule;
+  // TODO: Remove async-await after finish #628
+  const module = await pages[route.filePath];
   const PageComponent = module.default;
-
   const Page = () => (
     <>
       {dangerHTML('<!DOCTYPE html>')}
@@ -34,11 +21,7 @@ export default async function processPageRoute(
     </>
   );
 
-  const res = { Page, module, layoutModule } as const;
-
-  cache.set(route.filePath, res);
-
-  return res;
+  return { Page, module, layoutModule } as const;
 }
 
 function PageLayout({


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/810
Related to https://github.com/brisa-build/brisa/issues/628

With this PR, the pages become embedded in the build, without needing the import dynamic. This part had already improved the req/sec by caching it, but now there is no need to cache it because the build/server.js already contains the content of the pages and it is fast.

One step closer to creating a single binary file with everything.