### PR TITLE
fix: allow build empty page

### DIFF
--- a/packages/brisa/src/__fixtures__/pages/empty.tsx
+++ b/packages/brisa/src/__fixtures__/pages/empty.tsx
@@ -1,0 +1,1 @@
+// Empty page

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
@@ -9,14 +9,17 @@ const PAGES_DIR = join(BUILD_DIR, 'pages');
 const DIR = join(import.meta.dirname, 'index.ts');
 
 // Pages
-const p1 = join(PAGES_DIR, 'index.tsx');
-const p2 = join(PAGES_DIR, 'foo.tsx');
-const p3 = join(PAGES_DIR, 'page-with-web-component.tsx');
-const p4 = join(PAGES_DIR, 'somepage.tsx');
-const p5 = join(PAGES_DIR, 'somepage-with-context.tsx');
-const p6 = join(PAGES_DIR, 'user', '[username].tsx');
-const p7 = join(PAGES_DIR, '_404.tsx');
-const p8 = join(PAGES_DIR, '_500.tsx');
+const pagesPath = [
+  join(PAGES_DIR, 'index.tsx'),
+  join(PAGES_DIR, 'empty.tsx'),
+  join(PAGES_DIR, 'foo.tsx'),
+  join(PAGES_DIR, 'page-with-web-component.tsx'),
+  join(PAGES_DIR, 'somepage.tsx'),
+  join(PAGES_DIR, 'somepage-with-context.tsx'),
+  join(PAGES_DIR, 'user', '[username].tsx'),
+  join(PAGES_DIR, '_404.tsx'),
+  join(PAGES_DIR, '_500.tsx'),
+];
 
 describe('attach-brisa-project-internals', () => {
   beforeEach(() => {
@@ -41,24 +44,10 @@ describe('attach-brisa-project-internals', () => {
     expect(filter).toEqual({ filter: new RegExp(DIR) });
     expect(normalizeHTML(pluginContent.contents)).toBe(
       normalizeHTML(`
-      import * as p1 from "${p1}";
-      import * as p2 from "${p2}";
-      import * as p3 from "${p3}";
-      import * as p4 from "${p4}";
-      import * as p5 from "${p5}";
-      import * as p6 from "${p6}";
-      import * as p7 from "${p7}";
-      import * as p8 from "${p8}";
+      ${pagesPath.map((route, i) => `import * as p${i + 1} from "${route}";`).join('\n')}
 
       const allPages = {};
-      allPages["${p1}"] = p1;
-      allPages["${p2}"] = p2;
-      allPages["${p3}"] = p3;
-      allPages["${p4}"] = p4;
-      allPages["${p5}"] = p5;
-      allPages["${p6}"] = p6;
-      allPages["${p7}"] = p7;
-      allPages["${p8}"] = p8;
+      ${pagesPath.map((route, i) => `allPages["${route}"] = p${i + 1};`).join('\n')}
       export const pages = allPages;
 
       export * as middleware from '${BUILD_DIR}/middleware.ts';

--- a/packages/brisa/src/utils/generate-static-export/index.test.ts
+++ b/packages/brisa/src/utils/generate-static-export/index.test.ts
@@ -87,6 +87,7 @@ describe.each(BASE_PATHS)('utils', (basePath) => {
         expect(generateStaticExport()).resolves.toEqual([
           new Map([
             [formatPath('pages', '_404.tsx'), [formatPath('_404.html')]],
+            [formatPath('pages', 'empty.tsx'), [formatPath('empty.html')]],
             [formatPath('pages', '_500.tsx'), [formatPath('_500.html')]],
             [formatPath('pages', 'foo.tsx'), [formatPath('foo.html')]],
             [
@@ -153,6 +154,10 @@ describe.each(BASE_PATHS)('utils', (basePath) => {
             [
               formatPath('pages', '_404.tsx'),
               [formatPath('en', '_404.html'), formatPath('pt', '_404.html')],
+            ],
+            [
+              formatPath('pages', 'empty.tsx'),
+              [formatPath('en', 'empty.html'), formatPath('pt', 'empty.html')],
             ],
             [
               formatPath('pages', '_500.tsx'),
@@ -224,7 +229,7 @@ describe.each(BASE_PATHS)('utils', (basePath) => {
         </html>
       `);
 
-        testGeneratedContentByIndex(16, expectedSoftRedirectCode);
+        testGeneratedContentByIndex(18, expectedSoftRedirectCode);
       });
 
       it('should generate static export with trailingSlash', () => {
@@ -246,6 +251,10 @@ describe.each(BASE_PATHS)('utils', (basePath) => {
             [
               formatPath('pages', '_404.tsx'),
               [formatPath('_404', 'index.html')],
+            ],
+            [
+              formatPath('pages', 'empty.tsx'),
+              [formatPath('empty', 'index.html')],
             ],
             [
               formatPath('pages', '_500.tsx'),
@@ -335,7 +344,7 @@ describe.each(BASE_PATHS)('utils', (basePath) => {
         await generateStaticExport();
 
         // All are correct logs withouth the warning
-        expect(mockLog).toHaveBeenCalledTimes(9);
+        expect(mockLog).toHaveBeenCalledTimes(10);
         const allLog = mockLog.mock.calls.flat().join();
         expect(allLog).toContain('/index.html prerendered in ');
         expect(allLog).toContain('/foo.html prerendered in ');

--- a/packages/brisa/src/utils/get-entrypoints/index.test.ts
+++ b/packages/brisa/src/utils/get-entrypoints/index.test.ts
@@ -23,6 +23,7 @@ describe('utils', () => {
       const entrypoints = getEntrypoints(pagesDir);
       const expected = [
         path.sep + 'index.tsx',
+        path.sep + 'empty.tsx',
         'foo.tsx',
         'page-with-web-component.tsx',
         'somepage.tsx',

--- a/packages/brisa/src/utils/process-page-route/index.test.tsx
+++ b/packages/brisa/src/utils/process-page-route/index.test.tsx
@@ -11,6 +11,7 @@ import type { MatchedBrisaRoute, RequestContext } from '@/types';
 
 const FIXTURES = path.join(import.meta.dir, '..', '..', '__fixtures__');
 const HOMEPAGE = path.join(FIXTURES, 'pages', 'index.tsx');
+const EMPTY_PAGE = path.join(FIXTURES, 'pages', 'empty.tsx');
 const I18N = path.join(FIXTURES, 'i18n.ts');
 const i18nConfig = (await import.meta.require(I18N)).default;
 
@@ -69,6 +70,42 @@ describe('utils', () => {
               </body>
             </html>
             <template id="U:1"><div data-action>Hello world!</div></template><script id="R:1">u$('1')</script>
+          `),
+      );
+    });
+
+    it('should return a page with only the layout when the page is empty (no default export)', async () => {
+      globalThis.mockConstants = {
+        ...(getConstants() ?? {}),
+        IS_PRODUCTION: true,
+        IS_DEVELOPMENT: false,
+      };
+
+      const { Page } = await processPageRoute({
+        filePath: EMPTY_PAGE,
+      } as unknown as MatchedBrisaRoute);
+
+      // Rendered html
+      const stream = renderToReadableStream(Page(), {
+        request: extendRequestContext({
+          originalRequest: new Request('http://localhost:3000/empty'),
+        }),
+      });
+      const result = await Bun.readableStreamToText(stream);
+
+      expect(result).toBe(
+        toInline(`
+          <!DOCTYPE html>
+            <html>
+              <head>
+                <meta charset="UTF-8"></meta>
+                <meta name="viewport" content="width=device-width, initial-scale=1.0"></meta>
+                <meta name="theme-color" content="#317EFB"></meta>
+                <title>Brisa</title>
+              </head>
+              <body>
+              </body>
+            </html>
           `),
       );
     });

--- a/packages/brisa/src/utils/process-page-route/index.tsx
+++ b/packages/brisa/src/utils/process-page-route/index.tsx
@@ -5,13 +5,15 @@ import LoadLayout from '@/utils/load-layout';
 import type { MatchedBrisaRoute } from '@/types';
 import { layoutModule, pages } from 'brisa-project-internals';
 
+const Empty = () => null;
+
 export default async function processPageRoute(
   route: MatchedBrisaRoute,
   error?: Error,
 ) {
   // TODO: Remove async-await after finish #628
   const module = await pages[route.filePath];
-  const PageComponent = module.default;
+  const PageComponent = module?.default ?? Empty;
   const Page = () => (
     <>
       {dangerHTML('<!DOCTYPE html>')}


### PR DESCRIPTION
Related https://github.com/brisa-build/brisa/issues/628#issuecomment-2769822394

@AlbertSabate, this is not the final solution. But it is necessary because this process will be used in the next releases and in dev, too, and we need to allow empty pages without crashing. This could provide you with more info about this issue.