### PR TITLE
fix(i18n): manage data-run different way

### DIFF
--- a/packages/brisa/src/utils/client-build/layout-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/layout-build/index.test.ts
@@ -23,7 +23,7 @@ const brisaSize = 5738; // TODO: Reduce this size :/
 const webComponents = 1453;
 const unsuspenseSize = 213;
 const rpcSize = 2499; // TODO: Reduce this size
-const lazyRPCSize = 4340; // TODO: Reduce this size
+const lazyRPCSize = 4332; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size
 const initialSize = unsuspenseSize + rpcSize;

--- a/packages/brisa/src/utils/rpc/load-scripts/index.test.ts
+++ b/packages/brisa/src/utils/rpc/load-scripts/index.test.ts
@@ -100,16 +100,17 @@ describe('utils', () => {
       expect(mockLog).toHaveBeenCalledWith('hello');
     });
 
-    it('should not register script with data-run attribute #822', async () => {
-      const src = `data:text/javascript;base64,${btoa(`console.log('first')`)}`;
+    it('should run script with data-run attribute although is registered #822', async () => {
+      const src = `data:text/javascript;base64,${btoa(`console.log('foo')`)}`;
       const withDataRun = true;
       const script = createScript(src, '', 'some-id', withDataRun);
 
       await loadScripts(script);
       registerCurrentScripts();
+      await loadScripts(script);
 
-      expect(scripts.size).toBe(0);
-      expect(mockLog).toHaveBeenCalledWith('first');
+      expect(scripts.size).toBe(1);
+      expect(mockLog).toHaveBeenCalledTimes(2);
     });
 
     it('should execute the scripts in order', async () => {

--- a/packages/brisa/src/utils/rpc/load-scripts/index.ts
+++ b/packages/brisa/src/utils/rpc/load-scripts/index.ts
@@ -4,9 +4,6 @@ let scriptLoaded: Promise<void>;
 
 export function registerCurrentScripts() {
   for (const script of document.scripts) {
-    // Avoid caching scripts with data-run attribute
-    if ('run' in script.dataset) continue;
-
     const hasValidID = script.id && !/R:\d+/.test(script.id);
     if (hasValidID || script.hasAttribute('src')) {
       scripts.add(script.id || script.getAttribute('src'));
@@ -23,7 +20,10 @@ export async function loadScripts(node: Node) {
 
   const src = (node as HTMLScriptElement).getAttribute('src');
 
-  if (scripts.has(src) || scripts.has((node as HTMLScriptElement).id)) {
+  if (
+    (scripts.has(src) || scripts.has((node as HTMLScriptElement).id)) &&
+    !('run' in (node as HTMLScriptElement).dataset)
+  ) {
     return;
   }
 

--- a/packages/brisa/src/utils/rpc/rpc-integration.test.ts
+++ b/packages/brisa/src/utils/rpc/rpc-integration.test.ts
@@ -373,7 +373,7 @@ describe('utils', () => {
           );
         },
       });
-
+      await Bun.sleep(1);
       expect(document.body.innerHTML).toBe(
         `<button data-action-onclick="a1_1"></button>`,
       );
@@ -638,7 +638,7 @@ describe('utils', () => {
 
       // Should remove data-action attribute after register the action after the mutation
       await waitFor(() => {
-        expect(document.body.innerHTML).toBe('<div></div>');
+        expect(document.body.innerHTML).toBe('<div data-action=""></div>');
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/826

@AlbertSabate Initially, in this other commit https://github.com/brisa-build/brisa/commit/cd7d36a2cd66d74f92be47832b1bab4369d8d61e  it was made to always have to load the new i18n keys for each page. But it was **implemented wrong**, so that the one that was always executed was the one of the previous page, since the scripts registered until then were running and that one was not saved as registered. Instead of this, when doing diffing and the new scripts are executed, the ones with the data-run are always executed, so the keys are of the current page and not of the previous one.
