### PR TITLE
fix(tailwind-adapter): add `@tailwindcss/oxide` as external to standalone build

### DIFF
--- a/packages/brisa-tailwindcss/scripts/generate-json-deps.ts
+++ b/packages/brisa-tailwindcss/scripts/generate-json-deps.ts
@@ -12,6 +12,7 @@ fs.writeFileSync(
     dependencies: {
       tailwindcss: TAILWIND_VERSION,
       '@tailwindcss/postcss': TAILWIND_VERSION,
+      '@tailwindcss/oxide': TAILWIND_VERSION,
     },
   }),
 );

--- a/packages/brisa/src/utils/load-constants/index.test.ts
+++ b/packages/brisa/src/utils/load-constants/index.test.ts
@@ -111,7 +111,7 @@ describe('utils -> load-constants', () => {
       expect(result.CONFIG.external).toBeEmpty();
     });
 
-    it('should lightningcss as CONFIG.external', async () => {
+    it('should lightningcss and @tailwindcss/oxide as CONFIG.external', async () => {
       process.env.npm_package_json = undefined;
       const result = await loadProjectConstants({
         IS_PRODUCTION: false,
@@ -120,10 +120,13 @@ describe('utils -> load-constants', () => {
         ROOT_DIR: 'root',
         IS_BUILD_PROCESS: true,
       } as any);
-      expect(result.CONFIG.external).toEqual(['lightningcss']);
+      expect(result.CONFIG.external).toEqual([
+        'lightningcss',
+        '@tailwindcss/oxide',
+      ]);
     });
 
-    it('should return the devDependencies keys with lightningcss if the package.json file exists at the specified path', async () => {
+    it('should return the devDependencies keys with lightningcss + @tailwindcss/oxide if the package.json file exists at the specified path', async () => {
       process.env.npm_package_json = 'package.json';
       const result = await loadProjectConstants({
         IS_PRODUCTION: true,
@@ -135,6 +138,7 @@ describe('utils -> load-constants', () => {
       expect(result.CONFIG.external).toEqual([
         ...Object.keys(mockPackageJson.devDependencies),
         'lightningcss',
+        '@tailwindcss/oxide',
       ]);
     });
   });

--- a/packages/brisa/src/utils/load-constants/load-project-constants.ts
+++ b/packages/brisa/src/utils/load-constants/load-project-constants.ts
@@ -33,7 +33,7 @@ export async function loadProjectConstants({
   };
 
   const defaultExternalDeps = IS_BUILD_PROCESS
-    ? [...getDevDeps(), 'lightningcss']
+    ? [...getDevDeps(), 'lightningcss', '@tailwindcss/oxide']
     : [];
   const CSS_FILES =
     (await importFileIfExists('css-files', BUILD_DIR))?.default ?? [];


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/841