### PR TITLE
feat(build): transform CSS files import from dynamic to static

### DIFF
--- a/packages/brisa/src/__fixtures__/css-files.js
+++ b/packages/brisa/src/__fixtures__/css-files.js
@@ -1,0 +1,1 @@
+export default ['foo.css'];

--- a/packages/brisa/src/brisa-project-internals.ts
+++ b/packages/brisa/src/brisa-project-internals.ts
@@ -50,6 +50,8 @@ export const apiEndpoints = new Proxy({} as Record<string, Promise<any>>, {
 const WEBSOCKET_PATH = getImportableFilepath('websocket', BUILD_DIR);
 export const websocket = WEBSOCKET_PATH ? await import(WEBSOCKET_PATH) : null;
 
+export const cssFiles =
+  (await importFileIfExists('css-files', BUILD_DIR))?.default ?? [];
+
 // TODO:
-export const cssFiles = [];
 export const actions = null;

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
@@ -67,6 +67,7 @@ describe('attach-brisa-project-internals', () => {
       export * as integrations from '${BUILD_DIR}/web-components/_integrations.tsx';
       export * as layoutModule from '${BUILD_DIR}/layout.tsx';
       export * as websocket from '${BUILD_DIR}/websocket.ts';
+      export { default as cssFiles } from '${BUILD_DIR}/css-files.js';
     `),
     );
   });

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
@@ -45,6 +45,11 @@ export default function attachBrisaProjectInternalsPlugin() {
     ? `export * as websocket from '${websocketPath}';`
     : 'export const websocket = null;';
 
+  const cssPath = getImportableFilepath('css-files', BUILD_DIR);
+  const cssExport = cssPath
+    ? `export { default as cssFiles } from '${cssPath}';`
+    : 'export const cssFiles = [];';
+
   const pages = getPagesExport();
   const apiEndpoints = getApiEndpointsExport();
 
@@ -57,7 +62,7 @@ export default function attachBrisaProjectInternalsPlugin() {
       build.onLoad(
         { filter: new RegExp(import.meta.filename) },
         ({ loader }) => ({
-          contents: `${pages.imports}${apiEndpoints.imports}${pages.exports}${apiEndpoints.exports}${middlewareExport}${i18nExport}${configExport}${webIntegrationsExport}${layoutExport}${websocketExport}`,
+          contents: `${pages.imports}${apiEndpoints.imports}${pages.exports}${apiEndpoints.exports}${middlewareExport}${i18nExport}${configExport}${webIntegrationsExport}${layoutExport}${websocketExport}${cssExport}`,
           loader,
         }),
       );

--- a/packages/brisa/src/utils/compile-files/index.test.ts
+++ b/packages/brisa/src/utils/compile-files/index.test.ts
@@ -276,7 +276,7 @@ describe('utils', () => {
     ${info}Ω /i18n                          | 162 B     |
     ${info}Ψ /websocket                     | 207 B     |
     ${info}Θ /web-components/_integrations  | 67 B      |
-    ${info}λ /pages/index                   | 860 B     | ${greenLog('4 kB')}
+    ${info}λ /pages/index                   | 860 B     | ${greenLog('3 kB')}
     ${info}λ /pages/page-with-web-component | 769 B     | ${greenLog('5 kB')}
     ${info}λ /pages/somepage                | 1 kB      | ${greenLog('0 B')}
     ${info}λ /pages/somepage-with-context   | 1 kB      | ${greenLog('0 B')}  

--- a/packages/brisa/src/utils/load-constants/load-project-constants.ts
+++ b/packages/brisa/src/utils/load-constants/load-project-constants.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import importFileIfExists from '../import-file-if-exists';
-import { i18n, config, integrations } from 'brisa-project-internals';
+import { i18n, config, integrations, cssFiles } from 'brisa-project-internals';
 import type { InternalConstants, ProjectConstants } from '@/types';
 import type { BunPlugin } from 'bun';
 
@@ -35,8 +35,6 @@ export async function loadProjectConstants({
   const defaultExternalDeps = IS_BUILD_PROCESS
     ? [...getDevDeps(), 'lightningcss', '@tailwindcss/oxide']
     : [];
-  const CSS_FILES =
-    (await importFileIfExists('css-files', BUILD_DIR))?.default ?? [];
   const WEB_CONTEXT_PLUGINS = integrations?.webContextPlugins ?? [];
   const I18N_CONFIG = i18n?.default;
   const CONFIG = {
@@ -71,7 +69,7 @@ export async function loadProjectConstants({
   globalThis.__BASE_PATH__ = CONFIG.basePath;
 
   return {
-    CSS_FILES,
+    CSS_FILES: cssFiles,
     CONFIG,
     I18N_CONFIG,
     WEB_CONTEXT_PLUGINS,


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/847
Related to https://github.com/brisa-build/brisa/issues/628

We continue scaling to achieve the binary build. One dynamic import less. We were using a dynamic import of an auto-created file (cssFiles) to access the CSS files. 

This is going to change later when we change the way we do the build so that this auto-created file does not even need to exist. But now the ideal is to remove the dynamic import. 💪🏽