### PR TITLE
fix(build): remove `brisa/macros` from `server.js`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,14 +10,14 @@
     },
     "packages/adapter-vercel": {
       "name": "brisa-adapter-vercel",
-      "version": "0.2.12-canary.5.1",
+      "version": "0.2.12-canary.5.2",
       "devDependencies": {
         "brisa": "workspace:*",
       },
     },
     "packages/brisa": {
       "name": "brisa",
-      "version": "0.2.12-canary.5.1",
+      "version": "0.2.12-canary.5.2",
       "bin": {
         "brisa": "./index.js",
       },
@@ -40,7 +40,7 @@
     },
     "packages/brisa-pandacss": {
       "name": "brisa-pandacss",
-      "version": "0.2.12-canary.5.1",
+      "version": "0.2.12-canary.5.2",
       "dependencies": {
         "@pandacss/dev": "0.47.0",
         "postcss": "8.4.47",
@@ -48,7 +48,7 @@
     },
     "packages/brisa-tailwindcss": {
       "name": "brisa-tailwindcss",
-      "version": "0.2.12-canary.5.1",
+      "version": "0.2.12-canary.5.2",
       "devDependencies": {
         "@tailwindcss/postcss": "4.1.4",
         "postcss": "8.5.3",
@@ -62,7 +62,7 @@
     },
     "packages/create-brisa": {
       "name": "create-brisa",
-      "version": "0.2.12-canary.5.1",
+      "version": "0.2.12-canary.5.2",
       "bin": {
         "create-brisa": "./create-brisa.cjs",
       },
@@ -72,7 +72,7 @@
     },
     "packages/www": {
       "name": "www",
-      "version": "0.2.12-canary.5.1",
+      "version": "0.2.12-canary.5.2",
       "dependencies": {
         "@swc/wasm-web": "1.11.8",
         "brisa": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -10,14 +10,14 @@
     },
     "packages/adapter-vercel": {
       "name": "brisa-adapter-vercel",
-      "version": "0.2.12-canary.5.2",
+      "version": "0.2.12-canary.6",
       "devDependencies": {
         "brisa": "workspace:*",
       },
     },
     "packages/brisa": {
       "name": "brisa",
-      "version": "0.2.12-canary.5.2",
+      "version": "0.2.12-canary.6",
       "bin": {
         "brisa": "./index.js",
       },
@@ -40,7 +40,7 @@
     },
     "packages/brisa-pandacss": {
       "name": "brisa-pandacss",
-      "version": "0.2.12-canary.5.2",
+      "version": "0.2.12-canary.6",
       "dependencies": {
         "@pandacss/dev": "0.47.0",
         "postcss": "8.4.47",
@@ -48,7 +48,7 @@
     },
     "packages/brisa-tailwindcss": {
       "name": "brisa-tailwindcss",
-      "version": "0.2.12-canary.5.2",
+      "version": "0.2.12-canary.6",
       "devDependencies": {
         "@tailwindcss/postcss": "4.1.4",
         "postcss": "8.5.3",
@@ -62,7 +62,7 @@
     },
     "packages/create-brisa": {
       "name": "create-brisa",
-      "version": "0.2.12-canary.5.2",
+      "version": "0.2.12-canary.6",
       "bin": {
         "create-brisa": "./create-brisa.cjs",
       },
@@ -72,7 +72,7 @@
     },
     "packages/www": {
       "name": "www",
-      "version": "0.2.12-canary.5.2",
+      "version": "0.2.12-canary.6",
       "dependencies": {
         "@swc/wasm-web": "1.11.8",
         "brisa": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -10,14 +10,14 @@
     },
     "packages/adapter-vercel": {
       "name": "brisa-adapter-vercel",
-      "version": "0.2.12-canary.5",
+      "version": "0.2.12-canary.5.1",
       "devDependencies": {
         "brisa": "workspace:*",
       },
     },
     "packages/brisa": {
       "name": "brisa",
-      "version": "0.2.12-canary.5",
+      "version": "0.2.12-canary.5.1",
       "bin": {
         "brisa": "./index.js",
       },
@@ -40,7 +40,7 @@
     },
     "packages/brisa-pandacss": {
       "name": "brisa-pandacss",
-      "version": "0.2.12-canary.5",
+      "version": "0.2.12-canary.5.1",
       "dependencies": {
         "@pandacss/dev": "0.47.0",
         "postcss": "8.4.47",
@@ -48,7 +48,7 @@
     },
     "packages/brisa-tailwindcss": {
       "name": "brisa-tailwindcss",
-      "version": "0.2.12-canary.5",
+      "version": "0.2.12-canary.5.1",
       "devDependencies": {
         "@tailwindcss/postcss": "4.1.4",
         "postcss": "8.5.3",
@@ -62,7 +62,7 @@
     },
     "packages/create-brisa": {
       "name": "create-brisa",
-      "version": "0.2.12-canary.5",
+      "version": "0.2.12-canary.5.1",
       "bin": {
         "create-brisa": "./create-brisa.cjs",
       },
@@ -72,7 +72,7 @@
     },
     "packages/www": {
       "name": "www",
-      "version": "0.2.12-canary.5",
+      "version": "0.2.12-canary.5.1",
       "dependencies": {
         "@swc/wasm-web": "1.11.8",
         "brisa": "workspace:*",

--- a/examples/with-api-routes/package.json
+++ b/examples/with-api-routes/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2"
+    "brisa": "0.2.12-canary.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-api-routes/package.json
+++ b/examples/with-api-routes/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5"
+    "brisa": "0.2.12-canary.5.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-api-routes/package.json
+++ b/examples/with-api-routes/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1"
+    "brisa": "0.2.12-canary.5.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-elysia/package.json
+++ b/examples/with-elysia/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5",
+    "brisa": "0.2.12-canary.5.1",
     "elysia": "latest"
   },
   "devDependencies": {

--- a/examples/with-elysia/package.json
+++ b/examples/with-elysia/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2",
+    "brisa": "0.2.12-canary.6",
     "elysia": "latest"
   },
   "devDependencies": {

--- a/examples/with-elysia/package.json
+++ b/examples/with-elysia/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1",
+    "brisa": "0.2.12-canary.5.2",
     "elysia": "latest"
   },
   "devDependencies": {

--- a/examples/with-external-web-component/package.json
+++ b/examples/with-external-web-component/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1",
+    "brisa": "0.2.12-canary.5.2",
     "counter-wc": "0.1.3",
     "calendar-native-web-component": "0.0.32"
   },

--- a/examples/with-external-web-component/package.json
+++ b/examples/with-external-web-component/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5",
+    "brisa": "0.2.12-canary.5.1",
     "counter-wc": "0.1.3",
     "calendar-native-web-component": "0.0.32"
   },

--- a/examples/with-external-web-component/package.json
+++ b/examples/with-external-web-component/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2",
+    "brisa": "0.2.12-canary.6",
     "counter-wc": "0.1.3",
     "calendar-native-web-component": "0.0.32"
   },

--- a/examples/with-i18n/package.json
+++ b/examples/with-i18n/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2"
+    "brisa": "0.2.12-canary.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-i18n/package.json
+++ b/examples/with-i18n/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5"
+    "brisa": "0.2.12-canary.5.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-i18n/package.json
+++ b/examples/with-i18n/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1"
+    "brisa": "0.2.12-canary.5.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-middleware/package.json
+++ b/examples/with-middleware/package.json
@@ -10,7 +10,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1"
+    "brisa": "0.2.12-canary.5.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-middleware/package.json
+++ b/examples/with-middleware/package.json
@@ -10,7 +10,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5"
+    "brisa": "0.2.12-canary.5.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-middleware/package.json
+++ b/examples/with-middleware/package.json
@@ -10,7 +10,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2"
+    "brisa": "0.2.12-canary.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-pandacss/package.json
+++ b/examples/with-pandacss/package.json
@@ -12,7 +12,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5"
+    "brisa": "0.2.12-canary.5.1"
   },
   "devDependencies": {
     "@pandacss/dev": "0.53.1",

--- a/examples/with-pandacss/package.json
+++ b/examples/with-pandacss/package.json
@@ -12,7 +12,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1"
+    "brisa": "0.2.12-canary.5.2"
   },
   "devDependencies": {
     "@pandacss/dev": "0.53.1",

--- a/examples/with-pandacss/package.json
+++ b/examples/with-pandacss/package.json
@@ -12,7 +12,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2"
+    "brisa": "0.2.12-canary.6"
   },
   "devDependencies": {
     "@pandacss/dev": "0.53.1",

--- a/examples/with-sqlite-with-server-action/package.json
+++ b/examples/with-sqlite-with-server-action/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2"
+    "brisa": "0.2.12-canary.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-sqlite-with-server-action/package.json
+++ b/examples/with-sqlite-with-server-action/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5"
+    "brisa": "0.2.12-canary.5.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-sqlite-with-server-action/package.json
+++ b/examples/with-sqlite-with-server-action/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1"
+    "brisa": "0.2.12-canary.5.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-ssr-modal/package.json
+++ b/examples/with-ssr-modal/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2"
+    "brisa": "0.2.12-canary.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-ssr-modal/package.json
+++ b/examples/with-ssr-modal/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5"
+    "brisa": "0.2.12-canary.5.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-ssr-modal/package.json
+++ b/examples/with-ssr-modal/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1"
+    "brisa": "0.2.12-canary.5.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-streaming-list/package.json
+++ b/examples/with-streaming-list/package.json
@@ -10,7 +10,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1"
+    "brisa": "0.2.12-canary.5.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-streaming-list/package.json
+++ b/examples/with-streaming-list/package.json
@@ -10,7 +10,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5"
+    "brisa": "0.2.12-canary.5.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-streaming-list/package.json
+++ b/examples/with-streaming-list/package.json
@@ -10,7 +10,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2"
+    "brisa": "0.2.12-canary.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-suspense/package.json
+++ b/examples/with-suspense/package.json
@@ -10,7 +10,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1"
+    "brisa": "0.2.12-canary.5.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-suspense/package.json
+++ b/examples/with-suspense/package.json
@@ -10,7 +10,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5"
+    "brisa": "0.2.12-canary.5.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-suspense/package.json
+++ b/examples/with-suspense/package.json
@@ -10,7 +10,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2"
+    "brisa": "0.2.12-canary.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "4.0.0-alpha.33",
-    "brisa": "0.2.12-canary.5",
-    "brisa-tailwindcss": "0.2.12-canary.5",
+    "brisa": "0.2.12-canary.5.1",
+    "brisa-tailwindcss": "0.2.12-canary.5.1",
     "postcss": "8.4.49",
     "tailwindcss": "4.0.0-alpha.33"
   },

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "4.0.0-alpha.33",
-    "brisa": "0.2.12-canary.5.1",
-    "brisa-tailwindcss": "0.2.12-canary.5.1",
+    "brisa": "0.2.12-canary.5.2",
+    "brisa-tailwindcss": "0.2.12-canary.5.2",
     "postcss": "8.4.49",
     "tailwindcss": "4.0.0-alpha.33"
   },

--- a/examples/with-tailwindcss/package.json
+++ b/examples/with-tailwindcss/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "4.0.0-alpha.33",
-    "brisa": "0.2.12-canary.5.2",
-    "brisa-tailwindcss": "0.2.12-canary.5.2",
+    "brisa": "0.2.12-canary.6",
+    "brisa-tailwindcss": "0.2.12-canary.6",
     "postcss": "8.4.49",
     "tailwindcss": "4.0.0-alpha.33"
   },

--- a/examples/with-view-transitions/package.json
+++ b/examples/with-view-transitions/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "4.0.0-alpha.25",
-    "brisa": "0.2.12-canary.5.2",
-    "brisa-tailwindcss": "0.2.12-canary.5.2",
+    "brisa": "0.2.12-canary.6",
+    "brisa-tailwindcss": "0.2.12-canary.6",
     "postcss": "8.4.47",
     "tailwindcss": "4.0.0-alpha.25"
   },

--- a/examples/with-view-transitions/package.json
+++ b/examples/with-view-transitions/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "4.0.0-alpha.25",
-    "brisa": "0.2.12-canary.5.1",
-    "brisa-tailwindcss": "0.2.12-canary.5.1",
+    "brisa": "0.2.12-canary.5.2",
+    "brisa-tailwindcss": "0.2.12-canary.5.2",
     "postcss": "8.4.47",
     "tailwindcss": "4.0.0-alpha.25"
   },

--- a/examples/with-view-transitions/package.json
+++ b/examples/with-view-transitions/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "4.0.0-alpha.25",
-    "brisa": "0.2.12-canary.5",
-    "brisa-tailwindcss": "0.2.12-canary.5",
+    "brisa": "0.2.12-canary.5.1",
+    "brisa-tailwindcss": "0.2.12-canary.5.1",
     "postcss": "8.4.47",
     "tailwindcss": "4.0.0-alpha.25"
   },

--- a/examples/with-websockets/package.json
+++ b/examples/with-websockets/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.2"
+    "brisa": "0.2.12-canary.6"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-websockets/package.json
+++ b/examples/with-websockets/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5"
+    "brisa": "0.2.12-canary.5.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/examples/with-websockets/package.json
+++ b/examples/with-websockets/package.json
@@ -11,7 +11,7 @@
     "start": "brisa start"
   },
   "dependencies": {
-    "brisa": "0.2.12-canary.5.1"
+    "brisa": "0.2.12-canary.5.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-monorepo",
-  "version": "0.2.12-canary.5.2",
+  "version": "0.2.12-canary.6",
   "description": "The next-gen web framework.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-monorepo",
-  "version": "0.2.12-canary.5",
+  "version": "0.2.12-canary.5.1",
   "description": "The next-gen web framework.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-monorepo",
-  "version": "0.2.12-canary.5.1",
+  "version": "0.2.12-canary.5.2",
   "description": "The next-gen web framework.",
   "repository": {
     "type": "git",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-adapter-vercel",
-  "version": "0.2.12-canary.5",
+  "version": "0.2.12-canary.5.1",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-adapter-vercel",
-  "version": "0.2.12-canary.5.2",
+  "version": "0.2.12-canary.6",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-adapter-vercel",
-  "version": "0.2.12-canary.5.1",
+  "version": "0.2.12-canary.5.2",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/brisa-pandacss/package.json
+++ b/packages/brisa-pandacss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-pandacss",
-  "version": "0.2.12-canary.5.2",
+  "version": "0.2.12-canary.6",
   "license": "MIT",
   "type": "module",
   "main": "./index.ts",

--- a/packages/brisa-pandacss/package.json
+++ b/packages/brisa-pandacss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-pandacss",
-  "version": "0.2.12-canary.5.1",
+  "version": "0.2.12-canary.5.2",
   "license": "MIT",
   "type": "module",
   "main": "./index.ts",

--- a/packages/brisa-pandacss/package.json
+++ b/packages/brisa-pandacss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-pandacss",
-  "version": "0.2.12-canary.5",
+  "version": "0.2.12-canary.5.1",
   "license": "MIT",
   "type": "module",
   "main": "./index.ts",

--- a/packages/brisa-tailwindcss/package.json
+++ b/packages/brisa-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-tailwindcss",
-  "version": "0.2.12-canary.5",
+  "version": "0.2.12-canary.5.1",
   "license": "MIT",
   "type": "module",
   "main": "./index.ts",

--- a/packages/brisa-tailwindcss/package.json
+++ b/packages/brisa-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-tailwindcss",
-  "version": "0.2.12-canary.5.2",
+  "version": "0.2.12-canary.6",
   "license": "MIT",
   "type": "module",
   "main": "./index.ts",

--- a/packages/brisa-tailwindcss/package.json
+++ b/packages/brisa-tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa-tailwindcss",
-  "version": "0.2.12-canary.5.1",
+  "version": "0.2.12-canary.5.2",
   "license": "MIT",
   "type": "module",
   "main": "./index.ts",

--- a/packages/brisa/package.json
+++ b/packages/brisa/package.json
@@ -117,7 +117,7 @@
     "build:core-macros": "bun build --minify --target=bun --outdir=macros src/core/macros/index.ts && bun run build:bin",
     "build:core-client": "bun build --minify --outdir=client src/core/client/index.ts && bun run build:core-client-simplified && bun run build:bin",
     "build:core-client-simplified": "bun build --minify --outdir=client-simplified src/core/client/index.ts --define '__TRAILING_SLASH__=false' --define '__WEB_CONTEXT_PLUGINS__=false' --define '__BASE_PATH__=\"\"' --define '__ASSET_PREFIX__=\"\"' --define '__USE_LOCALE__=false' --define '__USE_PAGE_TRANSLATION__=false'",
-    "build:core-server": "bun build --minify --external brisa-project-internals --target=node --outdir=server src/core/server/index.ts src/core/server/node.ts src/core/server/deno.ts && bun run build:bin && cp src/types/server.d.ts server/index.d.ts && cp src/types/server.node.d.ts server/node.d.ts && cp src/types/server.deno.d.ts server/deno.d.ts",
+    "build:core-server": "bun build --minify --target=node --outdir=server src/core/server/index.ts src/core/server/node.ts src/core/server/deno.ts && bun run build:bin && cp src/types/server.d.ts server/index.d.ts && cp src/types/server.node.d.ts server/node.d.ts && cp src/types/server.deno.d.ts server/deno.d.ts",
     "build:core-test": "bun build --minify --target=bun --outdir=test src/core/test/index.ts && bun run build:bin && cp src/types/test.d.ts test/index.d.ts",
     "build:jsx-dev-runtime": "bun build --minify --target=bun --outdir=jsx-dev-runtime src/jsx-runtime/index.ts && cp src/types/index.d.ts jsx-dev-runtime/index.d.ts",
     "build:jsx-runtime": "bun build --minify --target=bun --outdir=jsx-runtime src/jsx-runtime/index.ts && cp src/types/index.d.ts jsx-runtime/index.d.ts",

--- a/packages/brisa/package.json
+++ b/packages/brisa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa",
-  "version": "0.2.12-canary.5.2",
+  "version": "0.2.12-canary.6",
   "description": "Brisa, the next-gen web framework.",
   "repository": {
     "type": "git",

--- a/packages/brisa/package.json
+++ b/packages/brisa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa",
-  "version": "0.2.12-canary.5",
+  "version": "0.2.12-canary.5.1",
   "description": "Brisa, the next-gen web framework.",
   "repository": {
     "type": "git",

--- a/packages/brisa/package.json
+++ b/packages/brisa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brisa",
-  "version": "0.2.12-canary.5.1",
+  "version": "0.2.12-canary.5.2",
   "description": "Brisa, the next-gen web framework.",
   "repository": {
     "type": "git",

--- a/packages/brisa/package.json
+++ b/packages/brisa/package.json
@@ -117,7 +117,7 @@
     "build:core-macros": "bun build --minify --target=bun --outdir=macros src/core/macros/index.ts && bun run build:bin",
     "build:core-client": "bun build --minify --outdir=client src/core/client/index.ts && bun run build:core-client-simplified && bun run build:bin",
     "build:core-client-simplified": "bun build --minify --outdir=client-simplified src/core/client/index.ts --define '__TRAILING_SLASH__=false' --define '__WEB_CONTEXT_PLUGINS__=false' --define '__BASE_PATH__=\"\"' --define '__ASSET_PREFIX__=\"\"' --define '__USE_LOCALE__=false' --define '__USE_PAGE_TRANSLATION__=false'",
-    "build:core-server": "bun build --minify --target=node --outdir=server src/core/server/index.ts src/core/server/node.ts src/core/server/deno.ts && bun run build:bin && cp src/types/server.d.ts server/index.d.ts && cp src/types/server.node.d.ts server/node.d.ts && cp src/types/server.deno.d.ts server/deno.d.ts",
+    "build:core-server": "bun build --minify --external brisa-project-internals --target=node --outdir=server src/core/server/index.ts src/core/server/node.ts src/core/server/deno.ts && bun run build:bin && cp src/types/server.d.ts server/index.d.ts && cp src/types/server.node.d.ts server/node.d.ts && cp src/types/server.deno.d.ts server/deno.d.ts",
     "build:core-test": "bun build --minify --target=bun --outdir=test src/core/test/index.ts && bun run build:bin && cp src/types/test.d.ts test/index.d.ts",
     "build:jsx-dev-runtime": "bun build --minify --target=bun --outdir=jsx-dev-runtime src/jsx-runtime/index.ts && cp src/types/index.d.ts jsx-dev-runtime/index.d.ts",
     "build:jsx-runtime": "bun build --minify --target=bun --outdir=jsx-runtime src/jsx-runtime/index.ts && cp src/types/index.d.ts jsx-runtime/index.d.ts",

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.test.ts
@@ -7,7 +7,6 @@ import attachBrisaProjectInternalsPlugin from '.';
 const BUILD_DIR = join(import.meta.dirname, '..', '..', '__fixtures__');
 const API_DIR = join(BUILD_DIR, 'api');
 const PAGES_DIR = join(BUILD_DIR, 'pages');
-const DIR = join(import.meta.dirname, 'index.ts');
 
 // Pages
 const pagesPath = [
@@ -38,7 +37,10 @@ describe('attach-brisa-project-internals', () => {
     const [filter, pluginFn] = onLoad.mock.calls[0] as any;
     const pluginContent = pluginFn({ loader: 'ts' });
 
-    expect(filter).toEqual({ filter: new RegExp(DIR) });
+    expect(filter).toEqual({
+      filter: /.*/,
+      namespace: 'brisa-project-internals',
+    });
     expect(normalizeHTML(pluginContent.contents)).toBe(
       normalizeHTML(`
       const actions = null;
@@ -86,7 +88,10 @@ describe('attach-brisa-project-internals', () => {
     const [filter, pluginFn] = onLoad.mock.calls[0] as any;
     const pluginContent = pluginFn({ loader: 'ts' });
 
-    expect(filter).toEqual({ filter: new RegExp(DIR) });
+    expect(filter).toEqual({
+      filter: /.*/,
+      namespace: 'brisa-project-internals',
+    });
     expect(normalizeHTML(pluginContent.contents)).toBe(
       normalizeHTML(`
       import * as actions from '${BUILD_DIR}/actions/index.tsx';

--- a/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
+++ b/packages/brisa/src/utils/attach-brisa-project-internals/index.ts
@@ -4,6 +4,7 @@ import getImportableFilepath from '@/utils/get-importable-filepath';
 import { getConstants } from '@/constants';
 import { fileSystemRouter } from '@/utils/file-system-router';
 
+const namespace = 'brisa-project-internals';
 const toImport = (importString: string, from: string | null) =>
   from ? `import ${importString} from '${from}';` : '';
 
@@ -79,16 +80,15 @@ export default function attachBrisaProjectInternalsPlugin() {
       // To fix this, it's necessary to first use build.onResolve with this "trick" before onLoad.
       // This ensures it works in both cases — with a symlink and after generating the Tarball.
       // It's important to keep this structure and not "simplify" it, as simplifying would break Tarball usage.
-      build.onResolve({ filter: /brisa-project-internals/ }, () => ({
-        path: import.meta.filename,
+      build.onResolve({ filter: /brisa-project-internals/ }, ({ path }) => ({
+        path,
+        namespace,
       }));
-      build.onLoad(
-        { filter: new RegExp(import.meta.filename) },
-        ({ loader }) => ({
-          contents,
-          loader,
-        }),
-      );
+
+      build.onLoad({ filter: /.*/, namespace }, ({ loader }) => ({
+        contents,
+        loader,
+      }));
     },
   } satisfies BunPlugin;
 }

--- a/packages/brisa/src/utils/client-build/layout-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/layout-build/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 3653;
 const brisaSize = 5738; // TODO: Reduce this size :/
 const webComponents = 1453;
 const unsuspenseSize = 213;
-const rpcSize = 2499; // TODO: Reduce this size
+const rpcSize = 2501; // TODO: Reduce this size
 const lazyRPCSize = 4332; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/compile-files/index.ts
+++ b/packages/brisa/src/utils/compile-files/index.ts
@@ -15,8 +15,6 @@ import { shouldTransferTranslatedPagePaths } from '@/utils/transfer-translated-p
 import { clientBuild } from '../client-build';
 import { getCSSLoader } from '@/utils/handle-css-files';
 
-const BRISA_DEPS = ['brisa/server'];
-
 export default async function compileFiles() {
   const {
     SRC_DIR,
@@ -61,9 +59,6 @@ export default async function compileFiles() {
     ).toString(),
   };
   const extendPlugins = CONFIG.extendPlugins ?? ((plugins) => plugins);
-  const external = CONFIG.external
-    ? [...CONFIG.external, ...BRISA_DEPS]
-    : BRISA_DEPS;
 
   if (middlewarePath) entrypoints.push(middlewarePath);
   if (layoutPath) entrypoints.push(layoutPath);
@@ -87,7 +82,7 @@ export default async function compileFiles() {
     // for the client build. FIXME: improve this to analyze each
     // server page including the chunks that the page needs.
     splitting: false,
-    external,
+    external: CONFIG.external,
     define,
     loader: getCSSLoader(),
     plugins: extendPlugins(

--- a/packages/brisa/src/utils/compile-serve-internals-into-build/index.ts
+++ b/packages/brisa/src/utils/compile-serve-internals-into-build/index.ts
@@ -72,6 +72,7 @@ export default async function compileServeInternalsIntoBuild() {
     plugins: [attachBrisaProjectInternalsPlugin()],
     // Note: for Deno we need "node" as target too
     target: isBun ? 'bun' : 'node',
+    minify: true,
     banner: [
       'process.env.IS_SERVE_PROCESS ??= true;',
       'process.env.IS_PROD ??= true;',

--- a/packages/brisa/src/utils/compile-serve-internals-into-build/index.ts
+++ b/packages/brisa/src/utils/compile-serve-internals-into-build/index.ts
@@ -57,8 +57,6 @@ export default async function compileServeInternalsIntoBuild() {
   const runtimeName =
     JS_RUNTIME_NAME[CONFIG.output!] ?? JS_RUNTIME_NAME.default;
   const runtimeExec = JS_RUNTIME_CMD[CONFIG.output!] ?? JS_RUNTIME_CMD.default;
-  const serverOutPath = path.join(BUILD_DIR, 'server.js');
-  const indexPath = path.join(BUILD_DIR, 'index.js');
 
   const output = await Bun.build({
     // TODO: adapt to Bun > 1.2 (for now this is to force the old behavior)
@@ -72,6 +70,8 @@ export default async function compileServeInternalsIntoBuild() {
     plugins: [attachBrisaProjectInternalsPlugin()],
     // Note: for Deno we need "node" as target too
     target: isBun ? 'bun' : 'node',
+    // @ts-ignore - Allow files with the same name (it only exist one)
+    naming: 'server.js',
     minify: true,
     banner: [
       'process.env.IS_SERVE_PROCESS ??= true;',
@@ -84,10 +84,6 @@ export default async function compileServeInternalsIntoBuild() {
 
   if (!output.success) {
     logBuildError(`Error compiling the ${runtimeName} server`, output.logs);
-  }
-
-  if (fs.existsSync(indexPath)) {
-    fs.renameSync(indexPath, serverOutPath);
   }
 
   createBrisaModule(runtimeExec);

--- a/packages/brisa/src/utils/compile-serve-internals-into-build/index.ts
+++ b/packages/brisa/src/utils/compile-serve-internals-into-build/index.ts
@@ -63,14 +63,10 @@ export default async function compileServeInternalsIntoBuild() {
     throw: false,
     entrypoints: [servePathname],
     outdir: BUILD_DIR,
-    naming: {
-      entry: '[name].[ext]',
-    },
     external: CONFIG.external,
     plugins: [attachBrisaProjectInternalsPlugin()],
     // Note: for Deno we need "node" as target too
     target: isBun ? 'bun' : 'node',
-    // @ts-ignore - Allow files with the same name (it only exist one)
     naming: 'server.js',
     minify: true,
     banner: [

--- a/packages/brisa/src/utils/compile-standalone-component/index.test.ts
+++ b/packages/brisa/src/utils/compile-standalone-component/index.test.ts
@@ -1,5 +1,0 @@
-import { describe, it, expect } from 'bun:test';
-
-describe('utils/compile-standalone-component', () => {
-  it('should compile a standalone server component', async () => {});
-});

--- a/packages/brisa/src/utils/load-constants/index.test.ts
+++ b/packages/brisa/src/utils/load-constants/index.test.ts
@@ -87,19 +87,7 @@ describe('utils -> load-constants', () => {
   });
 
   describe('loadProjectConstants', () => {
-    it('should NOT use CONFIG.external in serve process', async () => {
-      process.env.npm_package_json = undefined;
-      const result = await loadProjectConstants({
-        IS_PRODUCTION: false,
-        BUILD_DIR: 'build',
-        WORKSPACE: 'workspace',
-        ROOT_DIR: 'root',
-        IS_BUILD_PROCESS: false,
-      } as any);
-      expect(result.CONFIG.external).toBeEmpty();
-    });
-
-    it('should not use devDependencies from the package.json during the serve process', async () => {
+    it('should not use devDependencies from the package.json during the serve process (only Brisa internals)', async () => {
       process.env.npm_package_json = 'package.json';
       const result = await loadProjectConstants({
         IS_PRODUCTION: true,
@@ -108,7 +96,7 @@ describe('utils -> load-constants', () => {
         ROOT_DIR: 'root',
         IS_BUILD_PROCESS: false,
       } as any);
-      expect(result.CONFIG.external).toBeEmpty();
+      expect(result.CONFIG.external).toEqual(['brisa/macros', 'brisa/server']);
     });
 
     it('should lightningcss and @tailwindcss/oxide as CONFIG.external', async () => {
@@ -123,6 +111,8 @@ describe('utils -> load-constants', () => {
       expect(result.CONFIG.external).toEqual([
         'lightningcss',
         '@tailwindcss/oxide',
+        'brisa/macros',
+        'brisa/server',
       ]);
     });
 
@@ -139,6 +129,8 @@ describe('utils -> load-constants', () => {
         ...Object.keys(mockPackageJson.devDependencies),
         'lightningcss',
         '@tailwindcss/oxide',
+        'brisa/macros',
+        'brisa/server',
       ]);
     });
   });

--- a/packages/brisa/src/utils/load-constants/load-project-constants.ts
+++ b/packages/brisa/src/utils/load-constants/load-project-constants.ts
@@ -7,13 +7,6 @@ import type { BunPlugin } from 'bun';
 const OS_CAN_LOAD_BALANCE =
   process.platform !== 'darwin' && process.platform !== 'win32';
 
-const staticExportOutputOption = new Set([
-  'static',
-  'desktop',
-  'android',
-  'ios',
-]);
-
 export async function loadProjectConstants({
   IS_PRODUCTION,
   BUILD_DIR,
@@ -34,16 +27,19 @@ export async function loadProjectConstants({
     idleTimeout: 30,
   };
 
+  const BRISA_DEPS = ['brisa/macros', 'brisa/server'];
   const defaultExternalDeps = IS_BUILD_PROCESS
-    ? [...getDevDeps(), 'lightningcss', '@tailwindcss/oxide']
-    : [];
+    ? [...getDevDeps(), 'lightningcss', '@tailwindcss/oxide', ...BRISA_DEPS]
+    : BRISA_DEPS;
   const WEB_CONTEXT_PLUGINS = integrations?.webContextPlugins ?? [];
   const I18N_CONFIG = i18n?.default;
   const CONFIG = {
     ...defaultConfig,
     ...(config?.default ?? {}),
   };
-  const IS_STATIC_EXPORT = staticExportOutputOption.has(CONFIG?.output);
+  const IS_STATIC_EXPORT = new Set(['static', 'desktop', 'android', 'ios']).has(
+    CONFIG?.output,
+  );
 
   // Remove trailing slash from pages
   if (I18N_CONFIG?.pages) {

--- a/packages/create-brisa/package.json
+++ b/packages/create-brisa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-brisa",
-  "version": "0.2.12-canary.5",
+  "version": "0.2.12-canary.5.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/packages/create-brisa/package.json
+++ b/packages/create-brisa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-brisa",
-  "version": "0.2.12-canary.5.1",
+  "version": "0.2.12-canary.5.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/packages/create-brisa/package.json
+++ b/packages/create-brisa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-brisa",
-  "version": "0.2.12-canary.5.2",
+  "version": "0.2.12-canary.6",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www",
-  "version": "0.2.12-canary.5.1",
+  "version": "0.2.12-canary.5.2",
   "module": "src/pages/index.tsx",
   "type": "module",
   "scripts": {

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www",
-  "version": "0.2.12-canary.5",
+  "version": "0.2.12-canary.5.1",
   "module": "src/pages/index.tsx",
   "type": "module",
   "scripts": {

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www",
-  "version": "0.2.12-canary.5.2",
+  "version": "0.2.12-canary.6",
   "module": "src/pages/index.tsx",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Related to https://github.com/brisa-build/brisa/issues/628

The `brisa/macros` was imported inside the `build/server.js` (it was totally unnecessary). This PR removes it.

**This PR fixes:**  
- ✅ No longer increases the final build size.  
- ✅ Avoids unnecessary dynamic imports (previously caused by `brisa/macros` constants).  
- ✅  Simplify a little bit the build process

**Remaining tasks:**  
- Further cleanup of `server.js` is **still needed**—otherwise:  
  - We can’t safely remove other legacy files from the build.  
  - The build process won’t be fully optimized.  
- Two more redundant files are still being bundled (also triggering dynamic imports).  

**Next steps:**  
- I’ll debug to identify the problematic files (tricky but doable).  
- More PRs will follow to address this incrementally.  

*Note: Despite the pending work, this PR is a solid improvement.*  