### PR TITLE
fix(build): reduce 71% server.js size

### DIFF
--- a/packages/brisa/src/utils/ast/get-dependencies-list/index.tsx
+++ b/packages/brisa/src/utils/ast/get-dependencies-list/index.tsx
@@ -1,4 +1,3 @@
-import { getConstants } from '@/constants';
 import resolveImportSync from '@/utils/resolve-import-sync';
 import type { ESTree } from 'meriyah';
 import { fileURLToPath, pathToFileURL } from 'node:url';

--- a/packages/brisa/src/utils/client-build/layout-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/layout-build/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 3653;
 const brisaSize = 5738; // TODO: Reduce this size :/
 const webComponents = 1453;
 const unsuspenseSize = 213;
-const rpcSize = 2501; // TODO: Reduce this size
+const rpcSize = 2499; // TODO: Reduce this size
 const lazyRPCSize = 4332; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/replace-ast-imports-to-absolute/index.test.ts
+++ b/packages/brisa/src/utils/replace-ast-imports-to-absolute/index.test.ts
@@ -11,6 +11,22 @@ describe('utils', () => {
   describe('replace-ast-imports-to-absolute', () => {
     it('should not transform "brisa" and "brisa/server" imports', async () => {
       const code = `
+        import {renderPage} from 'brisa/server';
+        import {dangerHTML} from "brisa";
+      `;
+
+      const ast = parseCodeToAST(code);
+      const modifiedAst = await replaceAstImportsToAbsolute(
+        ast,
+        import.meta.url,
+      );
+      const result = normalizeHTML(generateCodeFromAST(modifiedAst));
+      const expected = normalizeHTML(code);
+
+      expect(result).toEqual(expected);
+    });
+    it('should not transform "brisa/macros" imports', async () => {
+      const code = `
         import {__prerender__macro, __resolveImportSync} from 'brisa/macros' with { type: "macro" };
         import dangerHTML from "@/utils/danger-html";
       `;

--- a/packages/brisa/src/utils/replace-ast-imports-to-absolute/index.ts
+++ b/packages/brisa/src/utils/replace-ast-imports-to-absolute/index.ts
@@ -2,7 +2,7 @@ import type { ESTree } from 'meriyah';
 import { logError } from '@/utils/log/log-build';
 import resolveImportSync from '@/utils/resolve-import-sync';
 
-const EXCEPTIONS = new Set(['brisa/macros']);
+const EXCEPTIONS = new Set(['brisa', 'brisa/macros', 'brisa/server']);
 
 /**
  * It is necessary when we create entrypoints on the fly during compilation,

--- a/packages/brisa/src/utils/transpile-actions/index.test.ts
+++ b/packages/brisa/src/utils/transpile-actions/index.test.ts
@@ -17,10 +17,6 @@ function buildActions(code: string) {
   return normalizeHTML(transpileActions(modifiedCode));
 }
 
-const brisaServerFile = path
-  .join(import.meta.dirname, '..', '..', '..', 'server', 'index.js')
-  .replace(/\\/g, '\\\\');
-
 describe('utils', () => {
   afterEach(() => {
     globalThis.mockConstants = undefined;
@@ -2109,7 +2105,7 @@ describe('utils', () => {
 
       const expected = normalizeHTML(`
       import {resolveAction as __resolveAction} from "brisa/server";
-      import {renderComponent} from "${brisaServerFile}";
+      import {renderComponent} from "brisa/server";
 
       function CounterServer({value = 0}) {
         function increment(v) {
@@ -2207,7 +2203,7 @@ describe('utils', () => {
 
       const expected = normalizeHTML(`
       import {resolveAction as __resolveAction} from "brisa/server";
-      import {renderComponent} from "${brisaServerFile}";
+      import {renderComponent} from "brisa/server";
 
       function CounterServer({value = 0}) {
         function inc(v) {
@@ -2320,7 +2316,7 @@ describe('utils', () => {
 
       const expected = normalizeHTML(`
       import {resolveAction as __resolveAction} from "brisa/server";
-      import {renderComponent} from "${brisaServerFile}";
+      import {renderComponent} from "brisa/server";
 
       function CounterServer({value = 0}) {
         const inc = v => {
@@ -2427,7 +2423,7 @@ describe('utils', () => {
 
       const expected = normalizeHTML(`
       import {resolveAction as __resolveAction} from "brisa/server";
-      import {renderComponent} from "${brisaServerFile}";
+      import {renderComponent} from "brisa/server";
 
       function CounterServer({value = 0}) {
         function increment(v) {
@@ -2522,7 +2518,7 @@ describe('utils', () => {
 
       const expected = normalizeHTML(`
       import {resolveAction as __resolveAction} from "brisa/server";
-      import {renderComponent} from "${brisaServerFile}";
+      import {renderComponent} from "brisa/server";
 
       function CounterServer({value = 0}) {
         const increment = v => {


### PR DESCRIPTION
Fixes #861
Related to https://github.com/brisa-build/brisa/issues/628

In this PR, the build file is smaller, uses less memory & faster.

Previously, it was importing wrongly `brisa/server` making it so that there were still dynamic imports when starting the `server.js` when it was unnecessary. After this change, apart from cleaning up these unnecessary dynamic imports, server.js is much smaller, uses less memory & faster.

In a test project:

**before**:

```sh
-rw-r--r--@  1 NNRocaGoAr  staff  900646 May  6 23:50 server.js
```

**now**:

```sh
-rw-r--r--@  1 NNRocaGoAr  staff  256749 May  6 23:48 server.js
```