### PR TITLE
fix(build): remove old warning when using CSS Modules in WC

### DIFF
--- a/packages/brisa/src/utils/client-build-plugin/process-client-ast/index.test.ts
+++ b/packages/brisa/src/utils/client-build-plugin/process-client-ast/index.test.ts
@@ -28,31 +28,6 @@ describe('utils', () => {
       );
     });
 
-    it('should remove ".css" imports and log a warning', () => {
-      const mockLog = spyOn(console, 'log');
-      const ast = parseCodeToAST(`
-        import './styles.css';
-        export default function Component() {
-          return jsx('div', null, 'Hello World');
-        }
-      `);
-
-      const res = processClientAST(ast);
-
-      const logs = mockLog.mock.calls.toString();
-      mockLog.mockRestore();
-
-      expect(toInline(generateCodeFromAST(res))).toBe(
-        normalizeHTML(`
-        export default function Component() {
-          return jsx('div', null, 'Hello World');
-        }
-      `),
-      );
-      expect(logs).toContain(
-        'Add this global import into the layout or the page.',
-      );
-    });
     it('should detect i18n when is declated and used to consume the locale', () => {
       const ast = parseCodeToAST(`  
         export default function Component({i18n}) {

--- a/packages/brisa/src/utils/client-build-plugin/process-client-ast/index.ts
+++ b/packages/brisa/src/utils/client-build-plugin/process-client-ast/index.ts
@@ -54,27 +54,11 @@ export default function processClientAst(ast: ESTree.Program, path = '') {
     }
 
     // Remove ".css" imports and log a warning
-    // TODO: Remove this restriction when this Bun feature is solved:
     // https://github.com/oven-sh/bun/issues/8280
     if (
       value?.type === 'ImportDeclaration' &&
       value?.source?.value.endsWith('.css')
     ) {
-      logWarning(
-        [
-          'CSS Global imports in web components',
-          '',
-          `Code: import '${value.source.value}';`,
-          `Path: ${path}`,
-          '',
-          'Add this global import into the layout or the page.',
-          'Currently, CSS Global imports only work in Web Components when it does not have the "skipSSR", to avoid problems, it is better not to use it here yet.',
-          '',
-          'If you have any questions or need further assistance,',
-          'feel free to contact us. We are happy to help!',
-        ],
-        'Docs: https://brisa.build/building-your-application/styling/web-components#global-styles-in-web-components',
-      );
       return null;
     }
 

--- a/packages/brisa/src/utils/client-build-plugin/process-client-ast/index.ts
+++ b/packages/brisa/src/utils/client-build-plugin/process-client-ast/index.ts
@@ -53,15 +53,6 @@ export default function processClientAst(ast: ESTree.Program, path = '') {
       return null;
     }
 
-    // Remove ".css" imports and log a warning
-    // https://github.com/oven-sh/bun/issues/8280
-    if (
-      value?.type === 'ImportDeclaration' &&
-      value?.source?.value.endsWith('.css')
-    ) {
-      return null;
-    }
-
     // Clean null values inside arrays
     if (Array.isArray(value)) return value.filter(Boolean);
 

--- a/packages/brisa/src/utils/client-build/layout-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/layout-build/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 3653;
 const brisaSize = 5738; // TODO: Reduce this size :/
 const webComponents = 1453;
 const unsuspenseSize = 213;
-const rpcSize = 2505; // TODO: Reduce this size
+const rpcSize = 2499; // TODO: Reduce this size
 const lazyRPCSize = 4332; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/client-build/pages-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/pages-build/index.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
-import clientPageBuild from '.';
+import clientPageBuild, { getOutputsPerFile } from '.';
 import { getConstants } from '@/constants';
 import getWebComponentsList from '@/utils/get-web-components-list';
 import type { BuildArtifact } from 'bun';
@@ -234,3 +234,13 @@ describe('client-build', () => {
     }
   });
 });
+
+describe('getOutputsPerFile', () => {
+  it('should not return .css files', async () => {
+      expect(getOutputsPerFile([{ path: '/some/example.js' }, { path: '/some/example.css' }] as any)).toEqual({
+        example: {
+          path: "/some/example.js"
+        }
+      } as any);
+  });
+}) 

--- a/packages/brisa/src/utils/client-build/pages-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/pages-build/index.test.ts
@@ -237,10 +237,15 @@ describe('client-build', () => {
 
 describe('getOutputsPerFile', () => {
   it('should not return .css files', async () => {
-      expect(getOutputsPerFile([{ path: '/some/example.js' }, { path: '/some/example.css' }] as any)).toEqual({
-        example: {
-          path: "/some/example.js"
-        }
-      } as any);
+    expect(
+      getOutputsPerFile([
+        { path: '/some/example.js' },
+        { path: '/some/example.css' },
+      ] as any),
+    ).toEqual({
+      example: {
+        path: '/some/example.js',
+      },
+    } as any);
   });
-}) 
+});

--- a/packages/brisa/src/utils/client-build/pages-build/index.ts
+++ b/packages/brisa/src/utils/client-build/pages-build/index.ts
@@ -62,12 +62,12 @@ export default async function clientPageBuild(
 
 export function getOutputsPerFile(outputs: BuildArtifact[]) {
   return outputs
-  .filter((artifact) => !artifact.path.endsWith('.css'))
-  .reduce(
-    (acc, artifact) => {
-      acc[parse(artifact.path).name] = artifact;
-      return acc;
-    },
-    {} as Record<string, BuildArtifact>,
-  );
+    .filter((artifact) => !artifact.path.endsWith('.css'))
+    .reduce(
+      (acc, artifact) => {
+        acc[parse(artifact.path).name] = artifact;
+        return acc;
+      },
+      {} as Record<string, BuildArtifact>,
+    );
 }

--- a/packages/brisa/src/utils/client-build/pages-build/index.ts
+++ b/packages/brisa/src/utils/client-build/pages-build/index.ts
@@ -43,13 +43,7 @@ export default async function clientPageBuild(
     return clientBuildDetails;
   }
 
-  const outputsPerFilename = outputs.reduce(
-    (acc, artifact) => {
-      acc[parse(artifact.path).name] = artifact;
-      return acc;
-    },
-    {} as Record<string, BuildArtifact>,
-  );
+  const outputsPerFilename = getOutputsPerFile(outputs);
 
   await Promise.all(
     clientBuildDetails.map(async (details) => {
@@ -64,4 +58,16 @@ export default async function clientPageBuild(
   );
 
   return clientBuildDetails;
+}
+
+export function getOutputsPerFile(outputs: BuildArtifact[]) {
+  return outputs
+  .filter((artifact) => !artifact.path.endsWith('.css'))
+  .reduce(
+    (acc, artifact) => {
+      acc[parse(artifact.path).name] = artifact;
+      return acc;
+    },
+    {} as Record<string, BuildArtifact>,
+  );
 }


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/877

This PR removes the incorrect warning for CSS Modules (`.module.css`) in web components, also removes the temporary warning + avoid processing i18n into CSS files.