### PR TITLE
feat(github): add Discord for ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Discord server
+    url: https://discord.gg/MsE9RN3FU4
+    about: For lightweight questions.


### PR DESCRIPTION
Add a Discord question submission entry when submitting issues.

similar effects:
![image](https://github.com/user-attachments/assets/1843d9fe-045b-46b1-975b-50281e06aa0a)