### PR TITLE
feat: expose `minify` configuration field into build

### DIFF
--- a/docs/building-your-application/configuring/minify.md
+++ b/docs/building-your-application/configuring/minify.md
@@ -1,0 +1,23 @@
+---
+description: Learn how to configure code minification
+---
+
+# Minify
+
+Brisa automatically optimizes your production builds by minifying JavaScript and CSS bundles. This reduces file sizes by removing whitespace, shortening variable names, and applying other safe optimizations.
+
+
+**brisa.config.ts**:
+
+```ts {4}
+import type { Configuration } from "brisa";
+
+export default {
+  minify: true // or false to disable
+} satisfies Configuration;
+```
+
+## Default Behavior (`minify` config field not specified)
+
+- **Development mode** (`brisa dev`): Minification is automatically disabled for better debugging
+- **Production mode** (`brisa build`): Minification is automatically enabled

--- a/packages/brisa/src/types/index.d.ts
+++ b/packages/brisa/src/types/index.d.ts
@@ -1220,6 +1220,27 @@ export type Configuration = {
   /**
    * Description:
    *
+   * The `minify` config property controls whether the output code should be minified.
+   * When enabled, this removes whitespace, shortens variable names, and performs other
+   * optimizations to reduce the bundle size.
+   *
+   * The default value is `true` in production mode and `false` in development mode.
+   *
+   * Example:
+   *
+   * ```ts
+   * minify: true // enable minification
+   * ```
+   *
+   * Docs:
+   *
+   * - [How to use `minify`](https://brisa.build/building-your-application/configuring/minify)
+   */
+  minify?: boolean;
+
+  /**
+   * Description:
+   *
    * The `extendPlugins` config property is used to add Bun/esbuild plugins
    * to the build process.
    *

--- a/packages/brisa/src/utils/client-build/layout-build/index.test.ts
+++ b/packages/brisa/src/utils/client-build/layout-build/index.test.ts
@@ -22,7 +22,7 @@ const i18nCode = 3653;
 const brisaSize = 5738; // TODO: Reduce this size :/
 const webComponents = 1453;
 const unsuspenseSize = 213;
-const rpcSize = 2499; // TODO: Reduce this size
+const rpcSize = 2490; // TODO: Reduce this size
 const lazyRPCSize = 4332; // TODO: Reduce this size
 // lazyRPC is loaded after user interaction (action, link),
 // so it's not included in the initial size

--- a/packages/brisa/src/utils/compile-files/index.test.ts
+++ b/packages/brisa/src/utils/compile-files/index.test.ts
@@ -540,6 +540,63 @@ describe('utils', () => {
       expect(logOutput).toContain(expected);
     });
 
+    it('should compile an app with minify=false #840', async () => {
+      const SRC_DIR = path.join(FIXTURES, 'with-suspense-in-layout');
+      const BUILD_DIR = path.join(SRC_DIR, 'out');
+      const PAGES_DIR = path.join(BUILD_DIR, 'pages');
+      const ASSETS_DIR = path.join(BUILD_DIR, 'public');
+      const TYPES = path.join(BUILD_DIR, '_brisa', 'types.ts');
+      const pagesClientPath = path.join(BUILD_DIR, 'pages-client');
+      const constants = getConstants();
+      globalThis.mockConstants = {
+        ...constants,
+        PAGES_DIR,
+        BUILD_DIR,
+        IS_PRODUCTION: true,
+        IS_DEVELOPMENT: false,
+        SRC_DIR,
+        ASSETS_DIR,
+        CONFIG: {
+          minify: false,
+        }
+      };
+
+      mockConsoleLog.mockImplementation(() => {});
+
+      const { success, logs } = await compileFiles();
+
+      expect(logs).toBeEmpty();
+      expect(success).toBe(true);
+
+      const files = fs
+        .readdirSync(BUILD_DIR)
+        .toSorted((a, b) => a.localeCompare(b));
+
+      const info = constants.LOG_PREFIX.INFO;
+
+      const logOutput = minifyText(
+        mockConsoleLog.mock.calls
+          .flat()
+          .join('\n')
+          .replace(/chunk-\S*/g, 'chunk-hash'),
+      );
+
+    // Without minify is 720 B and 1 kB instead of 452 B & 717 B (check the previous suspense test)
+      const expected = minifyText(`
+    ${info}
+    ${info}Route           | JS server | JS client (gz)  
+    ${info}----------------------------------------------
+    ${info}λ /pages/index  | 720 B     | ${greenLog('186 B')}  
+    ${info}Δ /layout       | 1 kB     |
+    ${info}
+    ${info}λ Server entry-points
+    ${info}Δ Layout
+    ${info}Φ JS shared by all
+    ${info}
+  `);
+      expect(logOutput).toContain(expected);
+    });
+
     it('should compile an app with a i18n client keys in the layout and not in the page', async () => {
       const SRC_DIR = path.join(FIXTURES, 'with-i18nkeys-in-layout');
       const BUILD_DIR = path.join(SRC_DIR, 'out');

--- a/packages/brisa/src/utils/compile-files/index.ts
+++ b/packages/brisa/src/utils/compile-files/index.ts
@@ -77,7 +77,7 @@ export default async function compileFiles() {
     sourcemap: IS_PRODUCTION ? undefined : 'inline',
     root: SRC_DIR,
     target: isBun ? 'bun' : 'node',
-    minify: IS_PRODUCTION,
+    minify: CONFIG.minify ?? IS_PRODUCTION,
     // splitting: false -> necessary to analyze the server pages
     // for the client build. FIXME: improve this to analyze each
     // server page including the chunks that the page needs.

--- a/packages/www/src/config.ts
+++ b/packages/www/src/config.ts
@@ -210,6 +210,10 @@ export default {
               link: '/building-your-application/configuring/output-adapter',
             },
             {
+              text: 'Minify',
+              link: '/building-your-application/configuring/minify',
+            },
+            {
               text: 'Integrations',
               link: '/building-your-application/configuring/integrations',
             },


### PR DESCRIPTION
Fixes https://github.com/brisa-build/brisa/issues/840

Now this field is exposed to have more control for devs.


# Minify

Brisa automatically optimizes your production builds by minifying JavaScript and CSS bundles. This reduces file sizes by removing whitespace, shortening variable names, and applying other safe optimizations.


**brisa.config.ts**:

```ts {4}
import type { Configuration } from "brisa";

export default {
  minify: true // or false to disable
} satisfies Configuration;
```

## Default Behavior (`minify` config field not specified)

- **Development mode** (`brisa dev`): Minification is automatically disabled for better debugging
- **Production mode** (`brisa build`): Minification is automatically enabled
