### PR TITLE
Removed the ".com" from Brisa's contact email address

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at contact@brisa.build.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at contact@brisa.build. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ This Code of Conduct applies within project spaces and in public spaces when an 
 
 ### Enforcement
 
-Instances of unacceptable behavior may be reported by contacting the team at contact@brisa.build.com. All complaints will be reviewed and investigated with confidentiality. Maintainers not upholding the Code may face consequences.
+Instances of unacceptable behavior may be reported by contacting the team at contact@brisa.build. All complaints will be reviewed and investigated with confidentiality. Maintainers not upholding the Code may face consequences.
 
 ### Attribution
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "author": {
     "name": "Brisa Team",
-    "email": "contact@brisa.build.com"
+    "email": "contact@brisa.build"
   },
   "type": "module",
   "workspaces": [

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -11,7 +11,7 @@
   },
   "author": {
     "name": "Brisa Team",
-    "email": "contact@brisa.build.com"
+    "email": "contact@brisa.build"
   },
   "repository": {
     "type": "git",

--- a/packages/brisa-pandacss/package.json
+++ b/packages/brisa-pandacss/package.json
@@ -8,7 +8,7 @@
   "types": "./index.d.ts",
   "author": {
     "name": "Brisa Team",
-    "email": "contact@brisa.build.com"
+    "email": "contact@brisa.build"
   },
   "repository": {
     "type": "git",

--- a/packages/brisa-tailwindcss/package.json
+++ b/packages/brisa-tailwindcss/package.json
@@ -8,7 +8,7 @@
   "types": "./index.d.ts",
   "author": {
     "name": "Brisa Team",
-    "email": "contact@brisa.build.com"
+    "email": "contact@brisa.build"
   },
   "scripts": {
     "libs-json": "bun run scripts/generate-json-deps.ts"

--- a/packages/brisa/package.json
+++ b/packages/brisa/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "author": {
     "name": "Brisa Team",
-    "email": "contact@brisa.build.com"
+    "email": "contact@brisa.build"
   },
   "type": "module",
   "exports": {

--- a/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
+++ b/packages/brisa/src/utils/client-build-plugin/integration.test.tsx
@@ -3153,14 +3153,14 @@ describe('integration', () => {
 
       testComponent.setAttribute(
         'user',
-        '{ "emails": ["contact@brisa.build.com"] }',
+        '{ "emails": ["contact@brisa.build"] }',
       );
 
       expect(window.mockSignalParent).toHaveBeenCalledTimes(2);
       expect(window.mockSignalChild).toHaveBeenCalledTimes(1);
       expect(window.mockSignalGrandChild).toHaveBeenCalledTimes(1);
       expect(testComponent?.shadowRoot?.innerHTML).toBe(
-        '<div><b>contact@brisa.build.com</b></div>',
+        '<div><b>contact@brisa.build</b></div>',
       );
 
       testComponent.removeAttribute('user');

--- a/packages/create-brisa/package.json
+++ b/packages/create-brisa/package.json
@@ -10,7 +10,7 @@
   },
   "author": {
     "name": "Brisa Team",
-    "email": "contact@brisa.build.com"
+    "email": "contact@brisa.build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It seems like your contact email address should be **contact@brisa.build** (I'm pretty sure it should be this), but some files were using _contact@brisa.build.com_.